### PR TITLE
Make patience metric be chrf

### DIFF
--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -40,7 +40,7 @@ echo "### Training ${model_dir}"
   --devices ${GPUS} \
   --sharding local \
   --sync-sgd \
-  --valid-metrics ce-mean-words bleu-detok chrf \
+  --valid-metrics chrf ce-mean-words bleu-detok \
   --valid-sets "${valid_set_prefix}".{"${src}","${trg}"}.gz \
   --valid-translation-output "${model_dir}/devset.out" \
   --quiet-translation \


### PR DESCRIPTION
For high resource languages, ce-mean-words will keep going down for a long time, even if quality isn't improving.  The first-listed metric determines which one is used for early stopping criteria.  This changes the stopping criteria metric to chrf.  