### PR TITLE
Fix to use with the latest mtdata version

### DIFF
--- a/configs/config.prod.yml
+++ b/configs/config.prod.yml
@@ -41,14 +41,12 @@ experiment:
     default-threshold: 0.5
     dataset-thresholds:
       opus_CCAligned/v1: 0.7
-      opus_WikiMatrix/v1: 0.7
       opus_OpenSubtitles/v2018: 0.8
       opus_bible-uedin/v1: 0.7
-      mtdata_cc_aligned: 0.7
-      mtdata_wiki_titles_v1: 0.7
-      mtdata_WikiMatrix_v1: 0.7
-      mtdata_wiki_titles_v2: 0.7
-      mtdata_wmt13_commoncrawl: 0.7
+      mtdata_Statmt-wiki_titles-1-rus-eng: 0.7
+      mtdata_Facebook-wikimatrix-1-eng-rus: 0.7
+      mtdata_Statmt-wiki_titles-2-rus-eng: 0.7
+      mtdata_Statmt-commoncrawl_wmt13-1-rus-eng: 0.7
       # 0 = skip filtering
       opus_ParaCrawl/v8: 0
 
@@ -101,34 +99,38 @@ datasets:
     - opus_ParaCrawl/v8
     - opus_Books/v1
     - opus_bible-uedin/v1
-    - opus_WikiMatrix/v1
     - opus_QED/v2.0a
     - opus_CCAligned/v1
     - opus_TED2020/v1
     - opus_News-Commentary/v16
     - opus_UNPC/v1.0
-    - mtdata_cc_aligned
-    - mtdata_airbaltic
-    - mtdata_neulab_tedtalksv1_train
-    - mtdata_neulab_tedtalksv1_dev
-    - mtdata_wmt13_commoncrawl
-    - mtdata_czechtourism
-    - mtdata_paracrawl_bonus
-    - mtdata_worldbank
-    - mtdata_wiki_titles_v1
-    - mtdata_WikiMatrix_v1
-    - mtdata_wmt18_news_commentary_v13
-    - mtdata_wiki_titles_v2
-    - mtdata_news_commentary_v14
-    - mtdata_neulab_tedtalksv1_test
-    - mtdata_JW300
+    - mtdata_Statmt-news_commentary-15-eng-rus
+    - mtdata_Neulab-tedtalks_train-1-eng-rus
+    - mtdata_ELRC-wikipedia_health-1-eng-rus
+    - mtdata_ParaCrawl-paracrawl-1_bonus-eng-rus
+    - mtdata_Statmt-news_commentary_wmt18-13-rus-eng
+    - mtdata_Tilde-worldbank-1-eng-rus
+    - mtdata_Statmt-news_commentary-16-eng-rus
+    - mtdata_UN-un_test-1-eng-rus
+    - mtdata_Statmt-wiki_titles-1-rus-eng
+    - mtdata_Statmt-paracrawl-8.wmt21-eng-rus
+    - mtdata_LinguaTools-wikititles-2014-eng-rus
+    - mtdata_Tilde-airbaltic-1-eng-rus
+    - mtdata_Statmt-wiki_titles-2-rus-eng
+    - mtdata_Neulab-tedtalks_dev-1-eng-rus
+    - mtdata_Statmt-news_commentary-14-eng-rus
+    - mtdata_Statmt-commoncrawl_wmt13-1-rus-eng
+    - mtdata_Tilde-czechtourism-1-eng-rus
+    - mtdata_Facebook-wikimatrix-1-eng-rus
+    - mtdata_Neulab-tedtalks_test-1-eng-rus
+    - mtdata_Statmt-wikititles-3-rus-eng
   # datasets to merge for validation while training
   devtest:
     - flores_dev
-    - mtdata_newstest2019_ruen
-    - mtdata_newstest2017_ruen
-    - mtdata_newstest2015_ruen
-    - mtdata_newstest2014_ruen
+    - sacrebleu_wmt19
+    - sacrebleu_wmt17
+    - sacrebleu_wmt15
+    - sacrebleu_wmt14
   # datasets for evaluation
   test:
     - flores_devtest

--- a/configs/config.test.yml
+++ b/configs/config.test.yml
@@ -31,7 +31,7 @@ experiment:
     default-threshold: 0.5
     dataset-thresholds:
       opus_ada83/v1: 0
-      mtdata_neulab_tedtalksv1_train: 0.6
+      mtdata_Neulab-tedtalks_train-1-eng-rus: 0.6
 
 marian-args:
   training-backward:
@@ -55,10 +55,10 @@ datasets:
   train:
     - opus_ada83/v1
     - opus_GNOME/v1
-    - mtdata_neulab_tedtalksv1_train
+    - mtdata_Neulab-tedtalks_train-1-eng-rus
   devtest:
     - flores_dev
-    - mtdata_newstest2019_ruen
+    - sacrebleu_wmt19
   test:
     - flores_devtest
     - sacrebleu_wmt20

--- a/envs/base.yml
+++ b/envs/base.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip=21.2.2
   - pip:
     - sacrebleu==2.0.0
-    - mtdata==0.2.9
+    - mtdata==0.3.2
     - fasttext==0.9.2
     - regex==2019.8.19
     - sacremoses==0.0.43

--- a/envs/corpus.yml
+++ b/envs/corpus.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip=21.2.2
   - pip:
     - sacrebleu==2.0.0
-    - mtdata==0.2.9
+    - mtdata==0.3.2
     - requests==2.26.0

--- a/pipeline/data/importers/corpus/mtdata.sh
+++ b/pipeline/data/importers/corpus/mtdata.sh
@@ -19,10 +19,10 @@ mkdir -p "${tmp}"
 src_iso=$(python -c "from mtdata.iso import iso3_code; print(iso3_code('${src}', fail_error=True))")
 trg_iso=$(python -c "from mtdata.iso import iso3_code; print(iso3_code('${trg}', fail_error=True))")
 
-mtdata get -l "${src}-${trg}" -tr "${dataset}" -o "${tmp}"
+mtdata get -l "${src}-${trg}" -tr "${dataset}" -o "${tmp}" --compress
 
-pigz -c "${tmp}/train-parts/${dataset}-${src_iso}_${trg_iso}.${src_iso}" > "${output_prefix}.${src}.gz"
-pigz -c "${tmp}/train-parts/${dataset}-${src_iso}_${trg_iso}.${trg_iso}" > "${output_prefix}.${trg}.gz"
+mv "${tmp}/train-parts/${dataset}.${src_iso}.gz" "${output_prefix}.${src}.gz"
+mv "${tmp}/train-parts/${dataset}.${trg_iso}.gz" "${output_prefix}.${trg}.gz"
 
 rm -rf "${tmp}"
 

--- a/utils/find-corpus.py
+++ b/utils/find-corpus.py
@@ -38,7 +38,7 @@ elif type == 'mtdata':
     source_tricode = iso3_code(source, fail_error=True)
     target_tricode = iso3_code(target, fail_error=True)
     exclude += ['opus', 'newstest', 'UNv1']
-    entries = get_entries(lang_pair(source_tricode + '-' + target_tricode), None, None, True)
+    entries = sorted(get_entries(lang_pair(source_tricode + '-' + target_tricode), None, None, True), key=lambda entry: entry.did.group)
     names = [f'mtdata_{entry.did.group}-{entry.did.name}-{entry.did.version}-{entry.did.lang_str}' for entry in entries]
 else:
     print(f'Importer type {type} is unsupported. Supported importers: opus, mtdata, sacrebleu')

--- a/utils/find-corpus.py
+++ b/utils/find-corpus.py
@@ -32,11 +32,14 @@ elif type == 'sacrebleu':
     names = [f'sacrebleu_{name}' for name, meta in sacrebleu.DATASETS.items()
              if f'{source}-{target}' in meta or f'{target}-{source}' in meta]
 elif type == 'mtdata':
-    from mtdata.main import LangPair
-    from mtdata.data import get_entries
+    from mtdata.entry import LangPair, lang_pair
+    from mtdata.index import get_entries
+    from mtdata.iso import iso3_code
+    source_tricode = iso3_code(source, fail_error=True)
+    target_tricode = iso3_code(target, fail_error=True)
     exclude += ['opus', 'newstest', 'UNv1']
-    entries = get_entries(LangPair(f'{source}-{target}'), None, None)
-    names = [f'mtdata_{entry.name}' for entry in entries]
+    entries = get_entries(lang_pair(source_tricode + '-' + target_tricode), None, None, True)
+    names = [f'mtdata_{entry.did.group}-{entry.did.name}-{entry.did.version}-{entry.did.lang_str}' for entry in entries]
 else:
     print(f'Importer type {type} is unsupported. Supported importers: opus, mtdata, sacrebleu')
 


### PR DESCRIPTION
The latest mtdata changes corpus names, the funcitonality of the function and rearranges a number of internal functions. I hope this will work now. I also filed a few bug reports @mtdata
This should fix #43 though I have not tested whether the corpus fetcher actually works.