### PR TITLE
bicleaner-ai parallelism fixes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -333,7 +333,7 @@ if use_bicleaner:
         conda: bicleaner_env
         # todo: check what to do about grouping in cluster mode if bicleaner-ai is used
         group: "clean_corpus"
-        threads: gpus_num*2
+        threads: gpus_num * 2 if bicleaner_type == "bicleaner-ai" else workflow.cores
         # todo: check gpu utilizaiton
         resources: gpu=gpus_num if bicleaner_type == "bicleaner-ai" else 0
         input: rules.kenlm.output, multiext(f"{clean}/corpus/{{dataset}}", f".{src}.gz", f".{trg}.gz"),

--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -44,10 +44,32 @@ else
     tcol=1
   fi
 
+  #Export cuda visible devices if not set
+  if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]; then   export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=index --format=csv,noheader); fi
+
   echo "### Classifying"
-  paste <(pigz -dc "${corpus_prefix}.${SRC}.gz") <(pigz -dc "${corpus_prefix}.${TRG}.gz") |
-    ${cmd} --scol ${scol} --tcol ${tcol} --processes "${threads}"  - - "${pack_dir}"/*.yaml |
-    pigz >"${output_prefix}.scored.gz"
+  if [ "${type}" == 'bicleaner-ai' && ${#CUDA_VISIBLE_DEVICES} > 1 ]; then # Use gnu-parallel'd bicleaner-ai if we have more than 1 GPU
+       #Convert CUDA_VISIBLE_DEVICES to an array
+       export CUDA_VISIBLE_ARRAY=($CUDA_VISIBLE_DEVICES)
+       #Turn on tensorflow logging in bicleaner-ai
+       export TF_CPP_MIN_LOG_LEVEL=0
+       #This function expects a bicleaner yaml and a 1-based index into the CUDA_VISIBLE_ARRAY
+       #Example: /mnt/nanna0/nbogoych/data/data/fr-en/fr-en-prod/biclean/pack/metadata.yaml index_in_CUDA_VISIBLE_ARRAY+1
+       biclean() {
+               export CUDA_VISIBLE_ARRAY=($CUDA_VISIBLE_DEVICES)
+               export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_ARRAY[$(($2-1))]}
+               bicleaner-ai-classify --scol 2 --tcol 1 - - $1
+       }
+       export -f biclean
+       # {%} is a 1-indexed job slot number from GNU parallel.  We use that as the 1-indexed offset in CUDA_VISIBLE_ARRAY
+       paste <(pigz -dc "${corpus_prefix}.${SRC}.gz") <(pigz -dc "${corpus_prefix}.${TRG}.gz") |
+       parallel -j ${#CUDA_VISIBLE_ARRAY[@]} --pipe -k --block 10M biclean "${pack_dir}"/*.yaml {#} |
+       pigz >"${output_prefix}.scored.gz"
+  else
+   paste <(pigz -dc "${corpus_prefix}.${SRC}.gz") <(pigz -dc "${corpus_prefix}.${TRG}.gz") |
+     ${cmd} --scol ${scol} --tcol ${tcol} --processes "${threads}"  - - "${pack_dir}"/*.yaml |
+     pigz >"${output_prefix}.scored.gz"
+  fi
 
   echo "### Filtering"
   pigz -dc "${output_prefix}.scored.gz" |

--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -48,7 +48,7 @@ else
   if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]; then   export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=index --format=csv,noheader); fi
 
   echo "### Classifying"
-  if [ "${type}" == 'bicleaner-ai' && ${#CUDA_VISIBLE_DEVICES} > 1 ]; then # Use gnu-parallel'd bicleaner-ai if we have more than 1 GPU
+  if [[ "${type}" == 'bicleaner-ai' && ${#CUDA_VISIBLE_DEVICES} > 1 ]]; then # Use gnu-parallel'd bicleaner-ai if we have more than 1 GPU
        #Convert CUDA_VISIBLE_DEVICES to an array
        export CUDA_VISIBLE_ARRAY=($CUDA_VISIBLE_DEVICES)
        #Turn on tensorflow logging in bicleaner-ai

--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -58,7 +58,7 @@ else
        biclean() {
                export CUDA_VISIBLE_ARRAY=($CUDA_VISIBLE_DEVICES)
                export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_ARRAY[$(($2-1))]}
-               bicleaner-ai-classify --scol 2 --tcol 1 - - $1
+               bicleaner-ai-classify --scol ${scol} --tcol ${tcol} - - $1
        }
        export -f biclean
        # {%} is a 1-indexed job slot number from GNU parallel.  We use that as the 1-indexed offset in CUDA_VISIBLE_ARRAY


### PR DESCRIPTION
How does this look to you @eu9ene 
I kept the CUDA_VISIBLE_DEVICES bit unchanged, but even if it is not exported, we should still be able to get the variable from inside the script. I want to test it before merging though.

EDIT:
Seems both cases are working now.