### PR TITLE
Fix unbound LD_LIBRARY_PATH

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -14,7 +14,7 @@ test -v CUDA_DIR
 test -v CUDNN_DIR
 
 # cuda and cudnn libs
-export LD_LIBRARY_PATH=${CUDA_DIR}/lib64:${CUDNN_DIR}:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${CUDA_DIR}/lib64:${CUDNN_DIR}:${LD_LIBRARY_PATH:+LD_LIBRARY_PATH:}
 
 corpus_prefix=$1
 output_prefix=$2


### PR DESCRIPTION
Ran into an unbound variable error (`LD_LIBRARY_PATH`) when applying Bicleaner, this fixes it