### PR TITLE
Fix unbound CUDA_VISIBLE_DEVICES in bicleaner.sh

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -49,8 +49,8 @@ else
     export tcol=1
   fi
 
-  #Export cuda visible devices if not set
-  if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]; then
+  #Export cuda visible devices if empty or not set
+  if [ -z "${CUDA_VISIBLE_DEVICES:-}" ]; then
     export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=index --format=csv,noheader);
   fi
 


### PR DESCRIPTION
The old condition `if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]` only works when `CUDA_VISIBLE_DEVICES` exists but is empty, `if [ -z "${CUDA_VISIBLE_DEVICES:-}" ]` also covers the case when it is unbound