### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ clean-meta:
 
 dag: CONFIG=configs/config.test.yml
 dag:
+	$(CONDA_ACTIVATE) snakemake
 	snakemake \
 	  --dag \
 	  --configfile $(CONFIG) \

--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -49,8 +49,8 @@ else
     export tcol=1
   fi
 
-  #Export cuda visible devices if not set
-  if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]; then
+  #Export cuda visible devices if empty or not set
+  if [ -z "${CUDA_VISIBLE_DEVICES:-}" ]; then
     export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=index --format=csv,noheader);
   fi
 


### PR DESCRIPTION
Two small changes:

1. In `bicleaner.sh`, if unset variables are not allowed, the old condition `if [ ${#CUDA_VISIBLE_DEVICES} == 0 ]` only works when `CUDA_VISIBLE_DEVICES` exists but is empty. `if [ -z "${CUDA_VISIBLE_DEVICES:-}" ]` also covers the case when it is unbound. (I'm not sure where or why `set -o nounset` happens in my case, but the new condition should work in both cases)
2. Environment activation was missing for DAG in `Makefile`