### PR TITLE
CI: add automatic test workflow on every push

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -13,8 +13,8 @@ jobs:
 
       - name: Edit Makefile
         run: |
-          sed -i 's/NUM_GPUS=8/NUM_GPUS=0/' Makefile
-          sed -i 's/SHARED_ROOT.*/SHARED_ROOT=\/tmp/' Makefile
+          sed -i 's/^NUM_GPUS=8/NUM_GPUS=0/' Makefile
+          sed -i 's/^SHARED_ROOT.*/SHARED_ROOT=\/tmp/' Makefile
 
       - name: Install necessary dependencies
         run: |

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -1,0 +1,29 @@
+name: Test Run
+
+on: push
+
+
+jobs:
+  test-run:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout repository files
+        uses: actions/checkout@v2
+
+      - name: Edit Makefile
+        run: |
+          sed -i 's/NUM_GPUS=8/NUM_GPUS=0/' Makefile
+          sed -i 's/SHARED_ROOT.*/SHARED_ROOT=\/tmp/' Makefile
+
+      - name: Install necessary dependencies
+        run: |
+          make conda
+          make snakemake
+          make git-modules
+
+      - name: Dry run
+        run: make dry-run
+
+      - name: Test run
+        run: make test

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -24,6 +24,3 @@ jobs:
 
       - name: Dry run
         run: make dry-run
-
-      - name: Test run
-        run: make test

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -1,6 +1,6 @@
 name: Test Run
 
-on: push
+on: [push, pull_request]
 
 
 jobs:


### PR DESCRIPTION
I have been having a problem running the `make test` command locally on my machine, so I created continuous integration for the repository, at least until that step.

This PR adds a workflow to run on the designated OS (`ubuntu-18.04`), with no GPUs.

You can see the output of such workflow here:
https://github.com/AmitMY/firefox-translations-training/runs/6109206105

And see, for example, that it fails to run the `make test` command.