### PR TITLE
Jobarray support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CONFIG=configs/config.prod.yml
 CONDA_PATH=$(SHARED_ROOT)/mambaforge
 SNAKEMAKE_OUTPUT_CACHE=$(SHARED_ROOT)/cache
 SLURM_PROFILE=slurm-moz
-# for CSD3 cluster
+# for CSD3 cluster if compiling on CPU
 # MARIAN_CMAKE=-DBUILD_ARCH=core-avx2
 MARIAN_CMAKE=
 TARGET=

--- a/profiles/slurm-csd3/config.cluster.yaml
+++ b/profiles/slurm-csd3/config.cluster.yaml
@@ -4,6 +4,6 @@ multi-gpu-partition: ampere
 cpu-partition: icelake
 cpu-account: t2-cs119-sl4-cpu
 gpu-account: t2-cs119-sl4-gpu
-# todo: change time limits after testing
+# change if using other accounts
 time-limit: "11:00:00"
-training-time-limit: "00:05:00"
+training-time-limit: "11:00:00"

--- a/profiles/slurm-csd3/config.cluster.yaml
+++ b/profiles/slurm-csd3/config.cluster.yaml
@@ -5,3 +5,5 @@ cpu-partition: skylake
 cpu-account: T2-CS119-CPU
 gpu-account: T2-CS119-GPU
 time-limit: "36:00:00"
+# todo: change after testing
+training-time-limit: "00:05:00"

--- a/profiles/slurm-csd3/config.cluster.yaml
+++ b/profiles/slurm-csd3/config.cluster.yaml
@@ -1,9 +1,9 @@
 # CSD3
-single-gpu-partition: pascal
-multi-gpu-partition: pascal
-cpu-partition: skylake
-cpu-account: T2-CS119-CPU
-gpu-account: T2-CS119-GPU
-time-limit: "36:00:00"
-# todo: change after testing
+single-gpu-partition: ampere
+multi-gpu-partition: ampere
+cpu-partition: icelake
+cpu-account: t2-cs119-sl4-cpu
+gpu-account: t2-cs119-sl4-gpu
+# todo: change time limits after testing
+time-limit: "11:00:00"
 training-time-limit: "00:05:00"

--- a/profiles/slurm-csd3/config.yaml
+++ b/profiles/slurm-csd3/config.yaml
@@ -2,7 +2,7 @@ cluster: "submit.py"
 cluster-status: "status.py"
 jobscript: "jobscript.sh"
 jobs: 10
-restart-times: 7
+restart-times: 0
 immediate-submit: false
 verbose: false
 max-jobs-per-second: 1

--- a/profiles/slurm-csd3/jobscript.sh
+++ b/profiles/slurm-csd3/jobscript.sh
@@ -4,3 +4,8 @@
 export SINGULARITYENV_CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES
 
 {exec_job}
+
+# for job arrays
+exit_status=$?
+scancel $SLURM_JOBID
+exit ${exec_exit_status}

--- a/profiles/slurm-csd3/jobscript.sh
+++ b/profiles/slurm-csd3/jobscript.sh
@@ -3,9 +3,34 @@
 
 export SINGULARITYENV_CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES
 
-{exec_job}
+if [ ! -z "$SLURM_ARRAY_JOB_ID" ]; then
+    trap 'kill "$jobpid"' TERM
+    trap 'kill "$jobpid"' INT
+    trap 'kill "$jobpid"' USR1
 
-# for job arrays
-exit_status=$?
-scancel $SLURM_JOBID
-exit ${exec_exit_status}
+    {exec_job} &
+    jobpid=$!
+
+    wait $jobpid
+    wait $jobpid
+    exit_status=$?
+
+    # Now we interpret the exit status.
+    if [ "$exit_status" == 143 ]; then # 143 = 128 + 15 => SIGTERM
+        echo "Not done, continue in the next slot"
+    else
+        if [ "$exit_status" == 0 ]; then
+            echo "Completed"
+        else
+            echo "Failed"
+        fi;
+        # Either we are finished or training failed so we need to
+        # investigate; there's no point in continuing training here.
+        echo "Cancelling job array"
+        scancel --state=PENDING $SLURM_ARRAY_JOB_ID
+    fi
+
+    exit $exit_status
+else
+    {exec_job}
+fi

--- a/profiles/slurm-csd3/jobscript.sh
+++ b/profiles/slurm-csd3/jobscript.sh
@@ -18,6 +18,7 @@ if [ ! -z "$SLURM_ARRAY_JOB_ID" ]; then
     # Now we interpret the exit status.
     if [ "$exit_status" == 143 ]; then # 143 = 128 + 15 => SIGTERM
         echo "Not done, continue in the next slot"
+        exit 0
     else
         if [ "$exit_status" == 0 ]; then
             echo "Completed"
@@ -28,9 +29,8 @@ if [ ! -z "$SLURM_ARRAY_JOB_ID" ]; then
         # investigate; there's no point in continuing training here.
         echo "Cancelling job array"
         scancel --state=PENDING $SLURM_ARRAY_JOB_ID
+        exit $exit_status
     fi
-
-    exit $exit_status
 else
     {exec_job}
 fi

--- a/profiles/slurm-csd3/status.py
+++ b/profiles/slurm-csd3/status.py
@@ -23,9 +23,14 @@ for i in range(STATUS_ATTEMPTS):
         if jobid in res:
             status = res[jobid]
         # job array
+        # example:
+        # 2379_1|COMPLETED|0:0
+        # 2379_1.batch|COMPLETED|0:0
+        # 2379_2|RUNNING|0:0
+        # 2379_2.batch|RUNNING|0:0
+        # 2379_[3-7%1]|PENDING|0:0
         else:
-            all_steps = sorted([(k, v) for k, v in res.items() if not k.endswith('batch') and '[' not in k],
-                               key=lambda x: x[0])
+            all_steps = sorted([(k, v) for k, v in res.items() if not k.endswith('batch')], key=lambda x: x[0])
             statuses = {v for _, v in all_steps}
             if "COMPLETED" in statuses:
                 status = "COMPLETED"

--- a/profiles/slurm-csd3/submit.py
+++ b/profiles/slurm-csd3/submit.py
@@ -54,7 +54,12 @@ if "resources" in job_properties:
 options += ['-p', partition]
 options += ['-A', account]
 options += ['--nodes=1']
-options += ['-t', str(cluster_config['time-limit'])]
+
+if name.startswith('train') or name.startswith('finetune'):
+    options += ['--array', '1-20%1']
+    options += ['-t', str(cluster_config['training-time-limit'])]
+else:
+    options += ['-t', str(cluster_config['time-limit'])]
 
 if "threads" in job_properties:
     options += ["--cpus-per-task", str(job_properties["threads"])]

--- a/utils/find-corpus.py
+++ b/utils/find-corpus.py
@@ -53,4 +53,4 @@ for name in names:
     if not filter:
         cleaned.add(name)
 
-print('\n'.join([f'\t\t- {name}' for name in cleaned]))
+print('\n'.join(sorted([f'\t\t- {name}' for name in cleaned])))


### PR DESCRIPTION
Added using Slurm job arrays to overcome issues of training job timeouts on HPC.

I ran a test on my cluster with an artificially small time limit for training (10 min) and the whole pipeline has completed successfully.

Also, I'm testing it on CSD3 and it looks working and already trained backward model (also with a small time limit for training). 
How smakemake Slurm command looks like:
```
[Thu May  5 05:15:01 2022]
Job 48: Training teacher on all data
Reason: Missing output files: /home/cs-pavl1/rds/evgeny/models/fr-en/test/teacher-base1/final.model.npz.best-chrf.npz

Running command: ['sbatch', '--parsable', '--job-name', 'train_teacher', '--gres=gpu:2', '-p', 'ampere', '-A', 't2-cs119-sl4-gpu', '--nodes=1', '--array', '1-20%1', '-t', '00:05:00', '--cpus-per-task', '4', '/home/cs-pavl1/rds/evgeny/bergamot-training/.snakemake/tmp.w6lu7xa5/snakejob.train_teacher.48.sh']
```

It's how I run it:
```
cd /home/cs-pavl1/rds/evgeny
git clone https://github.com/eu9ene/bergamot-training.git
git checkout jobarray

Makefile
+SHARED_ROOT=/home/cs-pavl1/rds/evgeny
+CUDA_DIR=/usr/local/software/cuda/11.2
+CUDNN_DIR=/usr/local/Cluster-Apps/cudnn/8.1_cuda-11.2/lib64
+GPUS=2
# GPU memory is 80GB on Ampere, so can be increased here
 WORKSPACE=12000
+CLUSTER_CORES=16
+CONFIG=configs/config.test.yml


module load singularity
module load cudnn/8.1_cuda-11.2

make git-modules
make conda
make snakemake
make pull
make run-slurm-container
```