### PR TITLE
Strip HTML from ELRC luxembourg data

### DIFF
--- a/pipeline/clean/fixes/mtdata_ELRC-luxembourg.lu-1.sh
+++ b/pipeline/clean/fixes/mtdata_ELRC-luxembourg.lu-1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+tools/strip-html.sh

--- a/pipeline/clean/tools/strip-html.sh
+++ b/pipeline/clean/tools/strip-html.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+sed -E 's/\s?<(script|style|code|svg|textarea)[^>]*>.+?<\/\1>//ig' |
+sed -E 's/<\/?[^>]+>//g'


### PR DESCRIPTION
The `mtdata_ELRC-luxembourg.lu-1-eng-fra.{en,fr}.gz` files had HTML in them. This is an attempt to strip that.

This patch is still untested. I've run this script manually on the files, not through the Snakemake pipeline. Hence draft.