### PR TITLE
clean-corpus: remove `--no-notice` from parallel

### DIFF
--- a/pipeline/alignment/generate-alignment-and-shortlist.sh
+++ b/pipeline/alignment/generate-alignment-and-shortlist.sh
@@ -30,11 +30,11 @@ corpus_trg="${corpus_prefix}.${TRG}.gz"
 echo "### Subword segmentation with SentencePiece"
 test -s "${dir}/corpus.spm.${SRC}.gz" ||
   pigz -dc "${corpus_src}" |
-  parallel --no-notice --pipe -k -j "${threads}" --block 50M "${MARIAN}/spm_encode" --model "${vocab_path}" |
+  parallel --pipe -k -j "${threads}" --block 50M "${MARIAN}/spm_encode" --model "${vocab_path}" |
   pigz >"${dir}/corpus.spm.${SRC}.gz"
 test -s "${dir}/corpus.spm.${TRG}.gz" ||
   pigz -dc "${corpus_trg}" |
-  parallel --no-notice --pipe -k -j "${threads}" --block 50M "${MARIAN}/spm_encode" --model "${vocab_path}" |
+  parallel --pipe -k -j "${threads}" --block 50M "${MARIAN}/spm_encode" --model "${vocab_path}" |
   pigz >"${dir}/corpus.spm.${TRG}.gz"
 
 echo "### Creating merged corpus"

--- a/pipeline/clean/clean-corpus.sh
+++ b/pipeline/clean/clean-corpus.sh
@@ -65,7 +65,7 @@ test -s "${output_prefix}.${SRC}${TRG}.fix.gz" ||
 echo "### Rule-based filtering"
 test -s "${output_prefix}.${SRC}${TRG}.rule-based.gz" ||
   pigz -dc "${output_prefix}.${SRC}${TRG}.fix.gz" |
-  parallel --no-notice --pipe -k -j "${threads}" --block 50M \
+  parallel --pipe -k -j "${threads}" --block 50M \
     "python3 tools/clean_parallel.py -l1 ${SRC} -l2 ${TRG} --debug" \
     2>"${output_prefix}.${SRC}${TRG}.clean.debug.txt" |
   pigz >"${output_prefix}.${SRC}${TRG}.rule-based.gz"
@@ -75,7 +75,7 @@ echo "### Language identification"
 test -s "${output_prefix}.${SRC}${TRG}.langid.gz" ||
   pigz -dc "${output_prefix}.${SRC}${TRG}.rule-based.gz" |
   # memory intensive
-  parallel --no-notice --pipe -k -j "$(echo "${threads}"/4 | bc)" --block 50M \
+  parallel --pipe -k -j "$(echo "${threads}"/4 | bc)" --block 50M \
     "python3 -Wi tools/langid_fasttext.py -f 1 | python3 -Wi tools/langid_fasttext.py -f 1" |
   grep -P "^${SRC}\t${TRG}\t" |
   cut -f3,4 |

--- a/pipeline/clean/clean-corpus.sh
+++ b/pipeline/clean/clean-corpus.sh
@@ -30,7 +30,7 @@ echo "### Basic preprocessing"
 for lng in "${SRC}" "${TRG}"; do
   test -s "${output_prefix}.${lng}.nrm.gz" ||
     pigz -dc "${input_prefix}.${lng}.gz" |
-    parallel --no-notice --pipe -k -j "${threads}" --block 50M \
+    parallel --pipe -k -j "${threads}" --block 50M \
       "perl tools/deescape-special-chars.perl | perl tools/remove-non-printing-char.perl" |
     pigz >"${output_prefix}.${lng}.nrm.gz"
 done

--- a/pipeline/clean/clean-mono.sh
+++ b/pipeline/clean/clean-mono.sh
@@ -26,7 +26,7 @@ mkdir -p "${dir}"
 echo "### Basic preprocessing"
 test -s "${output_prefix}.${lang}.nrm.gz" ||
   pigz -dc "${input_prefix}.${lang}.gz" |
-  parallel --no-notice --pipe -k -j "${threads}" --block 50M \
+  parallel --pipe -k -j "${threads}" --block 50M \
     "perl tools/deescape-special-chars.perl | perl tools/remove-non-printing-char.perl" |
   pigz >"${output_prefix}.${lang}.nrm.gz"
 
@@ -47,7 +47,7 @@ echo "### Language identification"
 test -s "${output_prefix}.${lang}.langid.gz" ||
   pigz -dc "${output_prefix}.${lang}.monofix.gz" |
   # memory intensive
-  parallel --no-notice --pipe -k -j "$(echo "${threads}"/4 | bc)" --block 50M "python tools/langid_fasttext.py" |
+  parallel --pipe -k -j "$(echo "${threads}"/4 | bc)" --block 50M "python tools/langid_fasttext.py" |
   grep -P "^${lang}\t" | cut -f2 |
   pigz >"${output_prefix}.${lang}.langid.gz"
 
@@ -55,7 +55,7 @@ test -s "${output_prefix}.${lang}.langid.gz" ||
 echo "### Rule-based filtering"
 
 pigz -dc "${output_prefix}.${lang}.langid.gz" |
-parallel --no-notice --pipe -k -j "${threads}" --block 50M \
+parallel --pipe -k -j "${threads}" --block 50M \
   "python tools/clean_mono.py -l ${lang} --debug" \
   2>"${output_prefix}.${lang}.clean.debug.txt" |
 pigz >"${output_prefix}.${lang}.gz"


### PR DESCRIPTION
This command line argument makes `parallel` crash without error, see:
https://github.com/mmstick/parallel/issues/39

In addition to removing `--no-notice`, can replace it with `--will-cite` which should act the same way

fixes #98