### PR TITLE
Prevent duplication of best model metric

### DIFF
--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -28,7 +28,6 @@ mkdir -p "${model_dir}/tmp"
 
 all_model_metrics=(chrf ce-mean-words bleu-detok)
 
-
 echo "### Training ${model_dir}"
 
 # if doesn't fit in RAM, remove --shuffle-in-ram and add --shuffle batches

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -26,6 +26,9 @@ test -v WORKSPACE
 cd "$(dirname "${0}")"
 mkdir -p "${model_dir}/tmp"
 
+all_model_metrics=(chrf ce-mean-words bleu-detok)
+
+
 echo "### Training ${model_dir}"
 
 # if doesn't fit in RAM, remove --shuffle-in-ram and add --shuffle batches
@@ -41,7 +44,7 @@ echo "### Training ${model_dir}"
   --devices ${GPUS} \
   --sharding local \
   --sync-sgd \
-  --valid-metrics "${best_model_metric}" chrf ce-mean-words bleu-detok \
+  --valid-metrics "${best_model_metric}" ${all_model_metrics[@]/$best_model_metric} \
   --valid-sets "${valid_set_prefix}".{"${src}","${trg}"}.gz \
   --valid-translation-output "${model_dir}/devset.out" \
   --quiet-translation \


### PR DESCRIPTION
Model duplicates the eval metrics, and it is making everything slower.

> [2023-01-16 16:24:12] [valid] Ep. 1 : Up. 300 : chrf : 14.717 : new best
> [2023-01-16 16:50:12] [valid] Ep. 1 : Up. 300 : chrf : 14.717 : new best
> [2023-01-16 16:50:27] [valid] Ep. 1 : Up. 300 : ce-mean-words : 2.38221 : new best


(verified to work)