### PR TITLE
Allow Taskcluster to run on `dev-` branches; add Treeherder symbols for decision and action tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -115,7 +115,7 @@ tasks:
                   routes:
                       $flatten:
                           - checks
-                          - $if: 'tasks_for != "github-pull-request"'
+                          - $if: '!isPullRequest'
                             then:
                               - tc-treeherder.v2.${project}.${head_sha}
                           - $switch:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -71,7 +71,7 @@ tasks:
       in:
           $if: >
               tasks_for in ["action", "cron"]
-              || (tasks_for == "github-push" && head_branch == "refs/heads/main")
+              || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || head_branch[:15] == "refs/heads/dev-"))
               || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           then:
               $let:
@@ -126,9 +126,7 @@ tasks:
                   routes:
                       $flatten:
                           - checks
-                          - $if: 'level == "3"'
-                            then:
-                              - tc-treeherder.v2.${project}.${head_sha}
+                          - tc-treeherder.v2.${project}.${head_sha}
                           - $switch:
                                 'tasks_for == "github-push"':
                                     - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -60,7 +60,7 @@ tasks:
       in:
           $if: >
               tasks_for in ["action", "cron"]
-              || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || head_branch[:15] == "refs/heads/dev-"))
+              || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || (repoUrl == "https://github.com/mozilla-releng/staging-firefox-translations-training" && head_branch[:15] == "refs/heads/dev-")))
               || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           then:
               $let:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,22 +37,11 @@ tasks:
                   'tasks_for == "github-push"': ${event.ref}
                   'tasks_for == "github-release"': '${event.release.target_commitish}'
                   'tasks_for in ["action", "cron"]': '${push.branch}'
-          base_ref:
-              $switch:
-                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
-                  'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-                  'tasks_for == "github-push"': ${event.ref}
-                  'tasks_for in ["cron", "action"]': '${push.branch}'
           head_ref:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
                   'tasks_for == "github-push"': ${event.ref}
                   'tasks_for in ["cron", "action"]': '${push.branch}'
-          base_sha:
-              $switch:
-                  'tasks_for == "github-push"': '${event.before}'
-                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
-                  'tasks_for in ["cron", "action"]': '${push.revision}'
           head_sha:
               $switch:
                   'tasks_for == "github-push"': '${event.after}'
@@ -182,8 +171,6 @@ tasks:
                               # `taskgraph decision` are all on the command line.
                               $merge:
                                   - ${normProjectUpper}_BASE_REPOSITORY: '${baseRepoUrl}'
-                                    ${normProjectUpper}_BASE_REF: '${base_ref}'
-                                    ${normProjectUpper}_BASE_REV: '${base_sha}'
                                     ${normProjectUpper}_HEAD_REPOSITORY: '${repoUrl}'
                                     ${normProjectUpper}_HEAD_REF: '${head_ref}'
                                     ${normProjectUpper}_HEAD_REV: '${head_sha}'
@@ -237,8 +224,6 @@ tasks:
                                         --repository-type=git
                                         --tasks-for='${tasks_for}'
                                         --base-repository='${baseRepoUrl}'
-                                        --base-ref='${base_ref}'
-                                        --base-rev='${base_sha}'
                                         --head-repository='${repoUrl}'
                                         --head-ref='${head_ref}'
                                         --head-rev='${head_sha}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -115,7 +115,9 @@ tasks:
                   routes:
                       $flatten:
                           - checks
-                          - tc-treeherder.v2.${project}.${head_sha}
+                          - $if: 'tasks_for != "github-pull-request"'
+                            then:
+                              - tc-treeherder.v2.${project}.${head_sha}
                           - $switch:
                                 'tasks_for == "github-push"':
                                     - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"


### PR DESCRIPTION
Running on `dev-` branches is primarily to allow parallel development in [the staging repository](https://github.com/mozilla-releng/staging-firefox-translations-training). I also had to stop passing `base_ref/rev` to make this work (looks like [a bug in Taskgraph](https://github.com/taskcluster/taskgraph/issues/242), maybe - we don't pass this for other repositories that build non-main branches either though...).

I'm also enabling Treeherder symbols in the staging repository with this change, which lets us kick off training runs through Treeherder (and generally have better visibility into pushes).