### PR TITLE
Add merge corpus pipeline step to Taskcluster

### DIFF
--- a/pipeline/clean/merge-corpus.sh
+++ b/pipeline/clean/merge-corpus.sh
@@ -13,22 +13,30 @@ test -v TRG
 test -v BIN
 
 output_prefix=$1
-input_prefixes=( "${@:2}" )
+inputs=( "${@:2}" )
+
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
 
 tmp="${output_prefix}/merge"
 mkdir -p "${tmp}"
 
 echo "### Merging"
-cat "${input_prefixes[@]/%/.${SRC}.gz}" >"${tmp}/corpus.${SRC}.dup.gz"
-cat "${input_prefixes[@]/%/.${TRG}.gz}" >"${tmp}/corpus.${TRG}.dup.gz"
+if [[ "${inputs[0]}" == *.${ARTIFACT_EXT} ]]; then
+  cat `echo ${inputs[@]} | tr ' ' '\n' | grep ${SRC} | tr '\n' ' '` >"${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}"
+  cat `echo ${inputs[@]} | tr ' ' '\n' | grep ${TRG} | tr '\n' ' '` >"${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}"
+else
+  cat "${inputs[@]/%/.${SRC}.${ARTIFACT_EXT}}" >"${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}"
+  cat "${inputs[@]/%/.${TRG}.${ARTIFACT_EXT}}" >"${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}"
+fi
 
 echo "### Deduplication"
-paste <(pigz -dc "${tmp}/corpus.${SRC}.dup.gz") <(pigz -dc "${tmp}/corpus.${TRG}.dup.gz") |
+paste <(${COMPRESSION_CMD} -dc "${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}") <(${COMPRESSION_CMD} -dc "${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}") |
 ${BIN}/dedupe |
-pigz >"${tmp}.${SRC}${TRG}.gz"
+${COMPRESSION_CMD} >"${tmp}.${SRC}${TRG}.${ARTIFACT_EXT}"
 
-pigz -dc "${tmp}.${SRC}${TRG}.gz" | cut -f1 | pigz > "${output_prefix}.${SRC}.gz"
-pigz -dc "${tmp}.${SRC}${TRG}.gz" | cut -f2 | pigz > "${output_prefix}.${TRG}.gz"
+${COMPRESSION_CMD} -dc "${tmp}.${SRC}${TRG}.${ARTIFACT_EXT}" | cut -f1 | ${COMPRESSION_CMD} > "${output_prefix}.${SRC}.${ARTIFACT_EXT}"
+${COMPRESSION_CMD} -dc "${tmp}.${SRC}${TRG}.${ARTIFACT_EXT}" | cut -f2 | ${COMPRESSION_CMD} > "${output_prefix}.${TRG}.${ARTIFACT_EXT}"
 
 rm -rf "${tmp}"
 

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -6,7 +6,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.from_datasets:transforms
+    - translations_taskgraph.transforms.from_datasets:per_dataset
     - translations_taskgraph.transforms.command_context_from_params:transforms
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -104,6 +104,7 @@ tasks:
         treeherder:
             platform: bicleaner/opt
         attributes:
+            cleaning-type: bicleaner
             cache:
                 type: bicleaner
                 resources:
@@ -128,6 +129,7 @@ tasks:
                 - src: en
                   trg: ru
         attributes:
+            cleaning-type: bicleaner-ai
             cache:
                 type: bicleaner-ai
                 resources:

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -36,10 +36,6 @@ task-defaults:
             - worker.env
     worker:
         max-run-time: 3600
-        artifacts:
-            - name: public/build
-              path: artifacts
-              type: directory
         env:
             SRC: "{src_locale}"
             TRG: "{trg_locale}"
@@ -99,9 +95,13 @@ task-defaults:
 tasks:
     "{provider}-{dataset}-{src_locale}-{trg_locale}":
         description: bicleaner for {provider} {dataset} dataset {src_locale}-{trg_locale}
-        worker-type: b-linux
+        worker-type: b-linux-large
         worker:
             docker-image: {"in-tree": "train"}
+            artifacts:
+                - name: public/build
+                  path: /builds/worker/artifacts
+                  type: directory
         treeherder:
             platform: bicleaner/opt
         attributes:
@@ -123,6 +123,11 @@ tasks:
     ai-{provider}-{dataset}-{src_locale}-{trg_locale}:
         description: bicleaner-ai for {provider} {dataset} dataset {src_locale}-{trg_locale}
         worker-type: t-linux-v100-gpu
+        worker:
+            artifacts:
+                - name: public/build
+                  path: artifacts
+                  type: directory
         treeherder:
             platform: bicleaner-ai/opt
         dataset-config:

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -20,6 +20,7 @@ kind-dependencies:
 
 task-defaults:
     attributes:
+        dataset-category: train
         cache:
             resources:
                 - pipeline/bicleaner/bicleaner.sh

--- a/taskcluster/ci/clean/kind.yml
+++ b/taskcluster/ci/clean/kind.yml
@@ -6,7 +6,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.from_datasets:transforms
+    - translations_taskgraph.transforms.from_datasets:per_dataset
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms
     - taskgraph.transforms.cached_tasks:transforms
@@ -19,7 +19,7 @@ task-defaults:
     description: Clean {provider} {dataset} dataset {src_locale}-{trg_locale}
     attributes:
         cache:
-            type: dataset
+            type: clean
             resources:
                 - pipeline/clean/clean-corpus.sh
                 - pipeline/clean/tools/deescape-special-chars.perl

--- a/taskcluster/ci/clean/kind.yml
+++ b/taskcluster/ci/clean/kind.yml
@@ -18,6 +18,7 @@ kind-dependencies:
 task-defaults:
     description: Clean {provider} {dataset} dataset {src_locale}-{trg_locale}
     attributes:
+        cleaning-type: clean
         cache:
             type: clean
             resources:

--- a/taskcluster/ci/clean/kind.yml
+++ b/taskcluster/ci/clean/kind.yml
@@ -19,6 +19,7 @@ task-defaults:
     description: Clean {provider} {dataset} dataset {src_locale}-{trg_locale}
     attributes:
         cleaning-type: clean
+        dataset-category: train
         cache:
             type: clean
             resources:

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -9,7 +9,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.from_datasets:transforms
+    - translations_taskgraph.transforms.from_datasets:per_dataset
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms
     - taskgraph.transforms.cached_tasks:transforms

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -18,6 +18,7 @@ transforms:
 task-defaults:
     worker-type: b-linux
     attributes:
+        dataset-category: train
         cache:
             type: dataset
     dataset-config:

--- a/taskcluster/ci/merge-corpus/kind.yml
+++ b/taskcluster/ci/merge-corpus/kind.yml
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:locales_only
+    - translations_taskgraph.transforms.find_upstreams:by_locales
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    # There are three possible upstream tasks for `merge_corpus`, in order of preference:
+    # 1) `bicleaner-ai` (from the `bicleaner` kind) is used if there is a bicleaner-ai data pack
+    #    for the language pair.
+    # 2) `bicleaner` (also from the `bicleaner` kind) is used if there is a non-ai bicleaner
+    #    data pack available
+    # 3) Otherwise, `clean` is the upstream and `bicleaner` is skipped altogether.
+    - bicleaner
+    - clean
+    - toolchain
+
+tasks:
+    "{src_locale}-{trg_locale}":
+        description: merge corpus for {src_locale}-{trg_locale}
+        attributes:
+            dataset-category: train
+            stage: merge-corpus
+            cache:
+                type: merge-corpus
+                resources:
+                    - pipeline/clean/merge-corpus.sh
+        dataset-config:
+            substitution-fields:
+                - description
+                - name
+                - treeherder.symbol
+                - worker.env
+                - upstreams-config.locale-pair
+        upstreams-config:
+            locale-pair:
+                src: "{src_locale}"
+                trg: "{trg_locale}"
+            upstream-task-attributes:
+                cleaning-type:
+                    by-cleaning-type:
+                        bicleaner-ai: bicleaner-ai
+                        bicleaner: bicleaner
+                        clean: clean
+            upstream-artifacts:
+                - "{dataset_no_slashes}.{src_locale}.zst"
+                - "{dataset_no_slashes}.{trg_locale}.zst"
+        worker-type: b-linux-large
+        worker:
+            docker-image: {"in-tree": "train"}
+            max-run-time: 3600
+            artifacts:
+                - name: public/build
+                  path: /builds/worker/artifacts
+                  type: directory
+            env:
+                SRC: "{src_locale}"
+                TRG: "{trg_locale}"
+                COMPRESSION_CMD: zstdmt
+                ARTIFACT_EXT: zst
+
+        # Don't run unless explicitly scheduled
+        run-on-tasks-for: []
+
+        treeherder:
+            symbol: "{src_locale}-{trg_locale}"
+            platform: merge-corpus/opt
+        run:
+            using: run-task
+            command-context: {}
+            command:
+                - bash
+                - -c
+                # Arguments are:
+                # 1) output directory
+                # 2) input files
+                - >-
+                    export BIN=$MOZ_FETCHES_DIR &&
+                    $VCS_PATH/pipeline/clean/merge-corpus.sh
+                    artifacts
+                    $MOZ_FETCHES_DIR/*.zst
+
+        fetches:
+            toolchain:
+                - preprocess

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -76,7 +76,7 @@ tasks:
             script: build-preprocess.sh
             resources:
                 - taskcluster/scripts/toolchain/build-preprocess.sh
-            toolchain-artifact: public/build/dedupe
+            toolchain-artifact: public/build/dedupe.tar.zst
         fetches:
             fetch:
                 - preprocess
@@ -89,7 +89,7 @@ tasks:
             script: build-extract-lex.sh
             resources:
                 - taskcluster/scripts/toolchain/build-extract-lex.sh
-            toolchain-artifact: public/build/extract_lex
+            toolchain-artifact: public/build/extract_lex.tar.zst
         fetches:
             fetch:
                 - extract-lex

--- a/taskcluster/docker/train/Dockerfile
+++ b/taskcluster/docker/train/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -qq \
                           zstd \
                           bc \
                           libhunspell-1.7-0 \
+                          libboost-program-options1.74.0 \
     && apt-get clean
 
 # Required to download sacrebleu datasets

--- a/taskcluster/scripts/toolchain/build-extract-lex.sh
+++ b/taskcluster/scripts/toolchain/build-extract-lex.sh
@@ -9,4 +9,6 @@ cd $build_dir
 cmake $EXTRACT_LEX_DIR
 make -j$(nproc)
 
-cp $build_dir/extract_lex $UPLOAD_DIR
+cd $build_dir
+chmod +x extract_lex
+tar --zstd -cf $UPLOAD_DIR/extract_lex.tar.zst extract_lex

--- a/taskcluster/scripts/toolchain/build-preprocess.sh
+++ b/taskcluster/scripts/toolchain/build-preprocess.sh
@@ -9,4 +9,6 @@ cd $build_dir
 cmake $PREPROCESS_DIR -DBUILD_TYPE=Release
 make -j$(nproc)
 
-cp $build_dir/bin/dedupe $UPLOAD_DIR
+cd $build_dir/bin
+chmod +x dedupe
+tar --zstd -cf $UPLOAD_DIR/dedupe.tar.zst dedupe

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -8,11 +8,39 @@ from voluptuous import Optional
 def get_defaults(repo_root):
     return {
         "bicleaner_threshold": "0.0",
+        # These will never be used in practice, but specifying them ensures
+        # that we always generate at least one task for each kind, which helps
+        # to avoid bustage that doesn't show up until we run the training action.
+        "datasets": {
+            "train": [
+                "flores_dev",
+                "sacrebleu_wmt19",
+            ],
+            "devtest": [
+                "flores_dev",
+                "sacrebleu_wmt19",
+            ],
+            "test": [
+                "flores_dev",
+                "sacrebleu_wmt19",
+            ],
+            "mono-src": [
+                "flores_dev",
+                "sacrebleu_wmt19",
+            ],
+            "mono-trg": [
+                "flores_dev",
+                "sacrebleu_wmt19",
+            ],
+        },
     }
 
 extend_parameters_schema(
     {
         Optional("bicleaner_threshold"): str,
+        Optional("datasets"): {
+            str: [str],
+        },
     },
     defaults_fn=get_defaults,
 )

--- a/taskcluster/translations_taskgraph/target_tasks.py
+++ b/taskcluster/translations_taskgraph/target_tasks.py
@@ -3,8 +3,29 @@ from taskgraph.target_tasks import _target_task
 
 @_target_task("train-target-tasks")
 def train_target_tasks(full_task_graph, parameters, graph_config):
-    def filter(label):
-        if label in parameters["target_task_names"]:
-            return True
+    stage = parameters["stage"]
+    datasets = parameters["datasets"]
+    src_locale = parameters["src_locale"]
+    trg_locale = parameters["trg_locale"]
+    def filter(task):
+        # These attributes will be present on tasks from all stages
+        for attr in ("stage", "src_locale", "trg_locale"):
+            if task.attributes.get(attr) != parameters[attr]:
+                return False
 
-    return [label for label in full_task_graph.tasks.keys() if filter(label)]
+        # Datasets are only applicable to dataset-specific tasks. If these
+        # attribute isn't present on the task it can be assumed to be included
+        # if the above attributes matched, as it will be a task that is either
+        # agnostic of datasets, or folds in datasets from earlier tasks.
+        # (Pulling in the appropriate datasets for these task must be handled at 
+        # the task generation level, usually by the `find_upstreams` transform.)
+        if "dataset" in task.attributes:
+            dataset_category = task.attributes["dataset-category"]
+            for ds in parameters["datasets"][dataset_category]:
+                provider, dataset = ds.split("_", 1)
+                if task.attributes["provider"] != provider or task.attributes["dataset"] != dataset:
+                    return False
+
+        return True
+
+    return [label for label, task in full_task_graph.tasks.items() if filter(task)]

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -59,7 +59,7 @@ def get_cleaning_type(src, trg, upstreams):
         if type_ in candidates:
             return type_
 
-    raise Exception(f"Unable to find cleaning type for {src_locale}-{trg_locale}!")
+    raise Exception(f"Unable to find cleaning type for {src}-{trg}!")
 
 
 @by_locales.add

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -1,0 +1,136 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This transform sequence sets `dependencies` and `fetches` based on
+# the information provided in the `upstreams-config` data in each job
+# and the given parameters.
+
+# It will through all tasks generated from `kind-dependencies` and
+# set any tasks that match the following conditions as dependencies:
+# - src and trg locale given match the {src,trg}_locale attributes on the upstream task
+# - `upstream-task-attributes` given match their equivalents on the upstream task
+# - `dataset` attribute on the upstream task is one of the datasets provided in `parameters`
+#   for the `dataset-category` given in the job.
+#
+# Additionally, fetches will be added for those tasks for each entry in `upstream-artifacts`.
+#
+# (It is not ideal that this transform hardcodes dataset handling, but because kinds are
+# completely unaware of parameters, there's no other real way to do this.)
+
+import copy
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import Schema, optionally_keyed_by, resolve_keyed_by
+from voluptuous import ALLOW_EXTRA, Required
+
+SCHEMA = Schema(
+    {
+        Required("upstreams-config"): {
+            Required("locale-pair"): {
+                Required("src"): str,
+                Required("trg"): str,
+            },
+            Required("upstream-task-attributes"): {
+                str: optionally_keyed_by("cleaning-type", str),
+            },
+            Required("upstream-artifacts"): [str],
+        },
+    },
+    extra=ALLOW_EXTRA,
+)
+
+by_locales = TransformSequence()
+by_locales.add_validate(SCHEMA)
+
+def get_cleaning_type(src, trg, upstreams):
+    candidates = set()
+
+    for upstream in upstreams:
+        if upstream.kind not in ("bicleaner", "clean"):
+            continue
+
+        if upstream.attributes["src_locale"] != src or upstream.attributes["trg_locale"] != trg:
+            continue
+
+        candidates.add(upstream.attributes["cleaning-type"])
+
+    for type_ in ("bicleaner-ai", "bicleaner", "clean"):
+        if type_ in candidates:
+            return type_
+
+    raise Exception(f"Unable to find cleaning type for {src_locale}-{trg_locale}!")
+
+
+@by_locales.add
+def resolve_keyed_by_fields(config, jobs):
+    for job in jobs:
+        upstreams_config = job["upstreams-config"]
+        src = upstreams_config["locale-pair"]["src"]
+        trg = upstreams_config["locale-pair"]["trg"]
+
+        cleaning_type = get_cleaning_type(src, trg, config.kind_dependencies_tasks.values())
+
+        resolve_keyed_by(
+            upstreams_config,
+            "upstream-task-attributes.cleaning-type",
+            item_name=job["description"],
+            **{"cleaning-type": cleaning_type},
+        )
+
+        yield job
+
+
+@by_locales.add
+def upstreams_for_locales(config, jobs):
+    datasets = config.params.get("datasets", {})
+    for job in jobs:
+        dataset_category = job["attributes"]["dataset-category"]
+        target_datasets = datasets[dataset_category]
+        upstreams_config = job.pop("upstreams-config")
+        src = upstreams_config["locale-pair"]["src"]
+        trg = upstreams_config["locale-pair"]["trg"]
+        artifacts = upstreams_config["upstream-artifacts"]
+        upstream_task_attributes = upstreams_config["upstream-task-attributes"]
+
+        subjob = copy.deepcopy(job)
+        subjob.setdefault("dependencies", {})
+        subjob.setdefault("fetches", {})
+
+        # Now that we've resolved which type of upstream task we want, we need to
+        # find all instances of that task for our locale pair, add them to our
+        # dependencies, and the necessary artifacts to our fetches.
+        for task in config.kind_dependencies_tasks.values():
+            # Filter out any tasks that don't match the desired attributes.
+            if any(task.attributes.get(k) != v for k, v in upstream_task_attributes.items()):
+                continue
+
+            provider = task.attributes["provider"]
+            dataset = task.attributes["dataset"]
+            task_dataset = f"{provider}_{dataset}"
+
+            # Filter out any tasks that don't match a desired dataset
+            if task_dataset not in target_datasets:
+                continue
+
+            # Filter out any tasks that aren't for the correct locale pair.
+            if task.attributes["src_locale"] != src or task.attributes["trg_locale"] != trg:
+                continue
+
+            subs = {
+                "src_locale": src,
+                "trg_locale": trg,
+                "dataset_no_slashes": dataset.replace("/", "."),
+            }
+
+            subjob["dependencies"][task.label] = task.label
+            subjob["fetches"].setdefault(task.label, [])
+            for artifact in artifacts:
+                subjob["fetches"][task.label].append(
+                    {
+                        "artifact": artifact.format(**subs),
+                        "extract": False,
+                    }
+                )
+            
+        yield subjob


### PR DESCRIPTION
This step is the first one that takes many upstream tasks and consumes them all in a single task per locale pair (as opposed to one task per upstream dataset per locale pair). Because of this, much of the changes here are around enhancing the `from_datasets` transform to support this, and an additional transform to help in adding the upstream dependencies + fetches.

There's much more detailed comments in each commit, but at a high level there's a few other things to call out:
- I enhanced the action task schema to bring in closer in line with the existing pipeline configs by using their `datasets` format.
- The `merge-corpus.sh` pipeline script needed slightly more modification than the others -- it was much easier to feed in a glob for all the files, and have it separate into src/trg than to use a prefix (we don't have a single directory to use as a prefix here). If this is too nasty or hacky, I can revisit this.

As with earlier patches, this is not testable in a PR. Instead, I've verified it in the staging repository with both [en-fr](https://firefox-ci-tc.services.mozilla.com/tasks/groups/d7S-gCc1SMaA-vwO4S9eKw) and [en-ru](https://firefox-ci-tc.services.mozilla.com/tasks/groups/FN-L9hhpQ16t6yeZqSrKow).