### PR TITLE
Adjust action input to match existing pipeline config format

### DIFF
--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -24,8 +24,10 @@ task-defaults:
         cache:
             resources:
                 - pipeline/bicleaner/bicleaner.sh
-            parameters:
-                - bicleaner_threshold
+            from-parameters:
+                bicleaner_threshold:
+                    - training_config.experiment.bicleaner.dataset-thresholds.{provider}_{dataset_sanitized}
+                    - training_config.experiment.bicleaner.default-threshold
     dataset-config:
         substitution-fields:
             - description
@@ -34,6 +36,8 @@ task-defaults:
             - fetches
             - treeherder.symbol
             - worker.env
+            - attributes.cache.from-parameters.bicleaner_threshold
+            - run.command-context.from-parameters.bicleaner_threshold
     worker:
         max-run-time: 3600
         env:
@@ -55,7 +59,9 @@ task-defaults:
         using: run-task
         command-context:
             from-parameters:
-                - bicleaner_threshold
+                bicleaner_threshold:
+                    - training_config.experiment.bicleaner.dataset-thresholds.{provider}_{dataset_sanitized}
+                    - training_config.experiment.bicleaner.default-threshold
         command:
             - bash
             - -c
@@ -73,23 +79,23 @@ task-defaults:
                 pip install -r {bicleaner_reqs} &&
                 export PATH=$PATH:~/.local/bin &&
                 $VCS_PATH/pipeline/bicleaner/bicleaner.sh
-                $MOZ_FETCHES_DIR/{dataset_no_slashes}
-                artifacts/{dataset_no_slashes}
+                $MOZ_FETCHES_DIR/{dataset_sanitized}
+                artifacts/{dataset_sanitized}
                 {bicleaner_threshold}
                 {bicleaner_type}
                 {bicleaner_threads}
                 $MOZ_FETCHES_DIR/{src_locale}-{trg_locale}
     dependencies:
-        "{provider}": clean-{provider}-{dataset_no_slashes}-{src_locale}-{trg_locale}
+        "{provider}": clean-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}
     fetches:
         toolchain:
             - hunspell
             - kenlm
             - cuda-toolkit
         "{provider}":
-            - artifact: "{dataset_no_slashes}.{src_locale}.zst"
+            - artifact: "{dataset_sanitized}.{src_locale}.zst"
               extract: false
-            - artifact: "{dataset_no_slashes}.{trg_locale}.zst"
+            - artifact: "{dataset_sanitized}.{trg_locale}.zst"
               extract: false
 
 tasks:

--- a/taskcluster/ci/clean/kind.yml
+++ b/taskcluster/ci/clean/kind.yml
@@ -63,14 +63,14 @@ task-defaults:
         command:
             - bash
             - -c
-            - $VCS_PATH/pipeline/clean/clean-corpus.sh $MOZ_FETCHES_DIR/{dataset_no_slashes} /builds/worker/artifacts/{dataset_no_slashes} auto {dataset}
+            - $VCS_PATH/pipeline/clean/clean-corpus.sh $MOZ_FETCHES_DIR/{dataset_sanitized} /builds/worker/artifacts/{dataset_sanitized} auto {dataset}
     dependencies:
-        "{provider}": dataset-{provider}-{dataset_no_slashes}-{src_locale}-{trg_locale}
+        "{provider}": dataset-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}
     fetches:
         "{provider}":
-            - artifact: "{dataset_no_slashes}.{src_locale}.zst"
+            - artifact: "{dataset_sanitized}.{src_locale}.zst"
               extract: false
-            - artifact: "{dataset_no_slashes}.{trg_locale}.zst"
+            - artifact: "{dataset_sanitized}.{trg_locale}.zst"
               extract: false
 
 tasks:
@@ -84,7 +84,7 @@ tasks:
             include-datasets:
                 sacrebleu: {}
 
-    opus-{dataset_no_slashes}-{src_locale}-{trg_locale}:
+    opus-{dataset_sanitized}-{src_locale}-{trg_locale}:
         dataset-config:
             include-datasets:
                 opus: {}
@@ -108,7 +108,7 @@ tasks:
                     - pipeline/clean/fixes/mtdata_OPUS_UNPC_v1_0.en.sh
                     - pipeline/clean/fixes/mtdata_OPUS_UNPC_v1_0.fr.sh
 
-    news-crawl-{dataset}-{src_locale}-{trg_locale}:
+    news-crawl-{dataset_sanitized}-{src_locale}-{trg_locale}:
         dataset-config:
             include-datasets:
                 news-crawl: {}

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -82,7 +82,7 @@ tasks:
     opus:
         description: Fetch opus dataset
         # No slashes version of dataset used here because slashes break caches
-        label: dataset-opus-{dataset_no_slashes}-{src_locale}-{trg_locale}
+        label: dataset-opus-{dataset_sanitized}-{src_locale}-{trg_locale}
         dataset-config:
             include-datasets:
                 opus: {}
@@ -94,7 +94,7 @@ tasks:
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/corpus/opus.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset_no_slashes} {dataset}
+                - $VCS_PATH/pipeline/data/importers/corpus/opus.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset_sanitized} {dataset}
 
     mtdata:
         description: Fetch mtdata dataset
@@ -114,7 +114,7 @@ tasks:
 
     news-crawl:
         description: Fetch news-crawl dataset
-        label: dataset-news-crawl-{dataset}-{src_locale}-{trg_locale}
+        label: dataset-news-crawl-{dataset_sanitized}-{src_locale}-{trg_locale}
         dataset-config:
             include-datasets:
                 news-crawl: {}

--- a/taskcluster/ci/merge-corpus/kind.yml
+++ b/taskcluster/ci/merge-corpus/kind.yml
@@ -52,8 +52,8 @@ tasks:
                         bicleaner: bicleaner
                         clean: clean
             upstream-artifacts:
-                - "{dataset_no_slashes}.{src_locale}.zst"
-                - "{dataset_no_slashes}.{trg_locale}.zst"
+                - "{dataset_sanitized}.{src_locale}.zst"
+                - "{dataset_sanitized}.{trg_locale}.zst"
         worker-type: b-linux-large
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/train-vocab/kind.yml
+++ b/taskcluster/ci/train-vocab/kind.yml
@@ -28,8 +28,8 @@ tasks:
                 type: train-vocab
                 resources:
                     - pipeline/train/spm-vocab.sh
-                parameters:
-                    - train_vocab_sample_size
+                from-parameters:
+                    spm_sample_size: training_config.experiment.spm-sample-size
         dataset-config:
             substitution-fields:
                 - description
@@ -58,7 +58,7 @@ tasks:
             using: run-task
             command-context:
                 from-parameters:
-                    - train_vocab_sample_size
+                    spm_sample_size: training_config.experiment.spm-sample-size
             command:
                 - bash
                 - -c
@@ -74,7 +74,7 @@ tasks:
                     fetches/corpus.{src_locale}.zst
                     fetches/corpus.{trg_locale}.zst
                     artifacts/vocab.spm
-                    {train_vocab_sample_size}
+                    {spm_sample_size}
                     auto
 
         dependencies:

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -6,6 +6,8 @@ from taskgraph.actions.registry import register_callback_action
 from taskgraph.decision import taskgraph_decision
 from taskgraph.parameters import Parameters
 
+from translations_taskgraph.parameters import get_defaults
+
 TRAIN_ON_PROJECTS = (
     "https://github.com/mozilla/firefox-translations-training",
     "https://github.com/mozilla-releng/staging-firefox-translations-training",
@@ -16,10 +18,7 @@ def can_train(parameters):
     return parameters["head_repository"] in TRAIN_ON_PROJECTS
 
 
-# Stages that only have locales in their task names (not providers/datasets).
-# Typically these are stages that "fan in" and a consume a number of upstream
-# tasks that are per-dataset.
-LOCALE_ONLY_STAGES = ["merge-corpus"]
+defaults = get_defaults("")["training_config"]
 
 @register_callback_action(
     name="train",
@@ -30,29 +29,25 @@ LOCALE_ONLY_STAGES = ["merge-corpus"]
     order=500,
     context=[],
     available=can_train,
-    # TODO: investigate re-using the exact schema of the existing configs
-    # for this both to ease the transition to taskcluster, and because they
-    # have already been well thought out
     schema=lambda graph_config: {
         "type": "object",
         "properties": {
-            "stage": {
+            "target-stage": {
                 "type": "string",
                 "description": """The stage of the pipeline to run until
 (any stages this choice depends on will be automatically included).""",
-                "default": "",
+                "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
                 "enum": ["clean", "bicleaner", "bicleaner-ai", "merge-corpus", "train-vocab"],
             },
             "datasets": {
                 "type": "object",
+                "default": defaults["datasets"],
                 "description": "The datasets to train with",
-                "default": {},
                 "properties": {
                     "train": {
                         "type": "array",
                         "description": "Parallel training corpus",
-                        "default": [],
                         "items": {
                             "type": "string",
                             # TODO
@@ -62,7 +57,6 @@ LOCALE_ONLY_STAGES = ["merge-corpus"]
                     "devtest": {
                         "type": "array",
                         "description": "datasets to merge for validation while training",
-                        "default": [],
                         "items": {
                             "type": "string",
                             # TODO
@@ -72,7 +66,6 @@ LOCALE_ONLY_STAGES = ["merge-corpus"]
                     "test": {
                         "type": "array",
                         "description": "datasets for evaluation",
-                        "default": [],
                         "items": {
                             "type": "string",
                             # TODO
@@ -85,7 +78,6 @@ LOCALE_ONLY_STAGES = ["merge-corpus"]
 monolingual datasets (ex. paracrawl-mono_paracrawl8, commoncrawl_wmt16, news-crawl_news.2020)
 to be translated by the teacher model
 """,
-                        "default": [],
                         "items": {
                             "type": "string",
                             # TODO
@@ -98,7 +90,6 @@ to be translated by the teacher model
 to be translated by the backward model to augment teacher corpus with back-translations
 leave empty to skip augmentation step (high resource languages)
 """,
-                        "default": [],
                         "items": {
                             "type": "string",
                             # TODO
@@ -107,35 +98,55 @@ leave empty to skip augmentation step (high resource languages)
                     },
                 },
             },
-            # TODO: should these be replaced with a single pair?
-            "src_locale": {
-                "type": "string",
-                "description": "The src locale to train",
-                "default": "",
-            },
-            "trg_locale": {
-                "type": "string",
-                "description": "The trg locale to train",
-                "default": "",
-            },
-            # TODO: lots of reworking here. the default should be by dataset
-            # we may want to re-use the existing pipeline configs, too
-            "bicleaner_threshold": {
-                "type": "string",
-                "description": "bicleaner threshold",
-                "default": "1.0",
-            },
-            "train_vocab_sample_size": {
-                "type": "string",
-                "description": "vocabularly training sample size",
-                "default": "10000",
+            "experiment": {
+                "type": "object",
+                "default": defaults["experiment"],
+                "properties": {
+                    "src": {
+                        "type": "string",
+                        "description": "The src locale to train",
+                    },
+                    "trg": {
+                        "type": "string",
+                        "description": "The trg locale to train",
+                    },
+                    "bicleaner": {
+                        "properties": {
+                            "default-threshold": {
+                                "type": "number",
+                                "description": "bicleaner threshold",
+                            },
+                            "dataset-thresholds": {
+                                "type": "object",
+                                "properties": {
+                                    "opus_ada83/v1": {
+                                        "type": "number",
+                                    },
+                                    "mtdata_Neulab-tedtalks_train-1-eng-rus": {
+                                        "type": "number",
+                                    },
+                                },
+                                "additionalProperties": {
+                                    "type": "number",
+                                }
+                            },
+                        },
+                    },
+                    "spm-sample-size": {
+                        "type": "number",
+                        "description": "vocabularly training sample size",
+                    },
+                },
+                "required": [
+                    "src",
+                    "trg",
+                ],
             },
         },
         "required": [
-            "stage",
+            "target-stage",
             "datasets",
-            "src_locale",
-            "trg_locale",
+            "experiment",
         ],
     },
 )
@@ -152,12 +163,7 @@ def train_action(parameters, graph_config, input, task_group_id, task_id):
     parameters["target_tasks_method"] = "train-target-tasks"
     parameters["optimize_target_tasks"] = True
     parameters["tasks_for"] = "action"
-    parameters["stage"] = input["stage"]
-    parameters["datasets"] = input["datasets"]
-    parameters["src_locale"] = input["src_locale"]
-    parameters["trg_locale"] = input["trg_locale"]
-    parameters["bicleaner_threshold"] = input["bicleaner_threshold"]
-    parameters["train_vocab_sample_size"] = input["train_vocab_sample_size"]
+    parameters["training_config"] = input
 
     parameters = Parameters(**parameters)
     taskgraph_decision({"root": graph_config.root_dir}, parameters=parameters)

--- a/taskcluster/translations_taskgraph/target_tasks.py
+++ b/taskcluster/translations_taskgraph/target_tasks.py
@@ -3,15 +3,21 @@ from taskgraph.target_tasks import _target_task
 
 @_target_task("train-target-tasks")
 def train_target_tasks(full_task_graph, parameters, graph_config):
-    stage = parameters["stage"]
-    datasets = parameters["datasets"]
-    src_locale = parameters["src_locale"]
-    trg_locale = parameters["trg_locale"]
+    training_config = parameters["training_config"]
+    stage = training_config["target-stage"]
+    src = training_config["experiment"]["src"]
+    trg = training_config["experiment"]["trg"]
+    datasets = parameters["training_config"]["datasets"]
     def filter(task):
         # These attributes will be present on tasks from all stages
-        for attr in ("stage", "src_locale", "trg_locale"):
-            if task.attributes.get(attr) != parameters[attr]:
-                return False
+        if task.attributes.get("stage") != stage:
+            return False
+
+        if task.attributes.get("src_locale") != src:
+            return False
+
+        if task.attributes.get("trg_locale") != trg:
+            return False
 
         # Datasets are only applicable to dataset-specific tasks. If these
         # attribute isn't present on the task it can be assumed to be included
@@ -21,7 +27,7 @@ def train_target_tasks(full_task_graph, parameters, graph_config):
         # the task generation level, usually by the `find_upstreams` transform.)
         if "dataset" in task.attributes:
             dataset_category = task.attributes["dataset-category"]
-            for ds in parameters["datasets"][dataset_category]:
+            for ds in datasets[dataset_category]:
                 provider, dataset = ds.split("_", 1)
                 if task.attributes["provider"] != provider or task.attributes["dataset"] != dataset:
                     return False

--- a/taskcluster/translations_taskgraph/transforms/cache.py
+++ b/taskcluster/translations_taskgraph/transforms/cache.py
@@ -1,7 +1,27 @@
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.hash import hash_path
+from taskgraph.util.schema import Schema
+from voluptuous import ALLOW_EXTRA, Any, Optional, Required
+
+from translations_taskgraph.util.dict_helpers import deep_get
+
+SCHEMA = Schema(
+    {
+        Required("attributes"): {
+            Required("cache"): {
+                Required("type"): str,
+                Optional("resources"): [str],
+                Optional("from-parameters"): {
+                    str: Any([str], str),
+                },
+            },
+        },
+    },
+    extra=ALLOW_EXTRA,
+)
 
 transforms = TransformSequence()
+transforms.add_validate(SCHEMA)
 
 @transforms.add
 def add_cache(config, jobs):
@@ -9,7 +29,7 @@ def add_cache(config, jobs):
         cache = job["attributes"]["cache"]
         cache_type = cache["type"]
         cache_resources = cache["resources"]
-        cache_parameters = cache.get("parameters", {})
+        cache_parameters = cache.get("from-parameters", {})
         digest_data = []
 
         if cache_resources:
@@ -17,9 +37,16 @@ def add_cache(config, jobs):
                 digest_data.append(hash_path(r))
 
         if cache_parameters:
-            for p in cache_parameters:
-                # TODO: this should somehow find the default value for each paramater...
-                digest_data.append(config.params.get(p, ""))
+            for param, path in cache_parameters.items():
+                if isinstance(path, str):
+                    value = deep_get(config.params, path)
+                    digest_data.append(f"{param}:{value}")
+                else:
+                    for choice in path:
+                        value = deep_get(config.params, choice)
+                        if value is not None:
+                            digest_data.append(f"{param}:{value}")
+                            break
 
         job["cache"] = {
             "type": cache_type,

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -83,7 +83,7 @@ def resolve_keyed_by_fields(config, jobs):
 
 @by_locales.add
 def upstreams_for_locales(config, jobs):
-    datasets = config.params.get("datasets", {})
+    datasets = config.params.get("training_config", {}).get("datasets", {})
     for job in jobs:
         dataset_category = job["attributes"]["dataset-category"]
         target_datasets = datasets[dataset_category]
@@ -120,7 +120,7 @@ def upstreams_for_locales(config, jobs):
             subs = {
                 "src_locale": src,
                 "trg_locale": trg,
-                "dataset_no_slashes": dataset.replace("/", "."),
+                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
             }
 
             subjob["dependencies"][task.label] = task.label

--- a/taskcluster/translations_taskgraph/transforms/from_datasets.py
+++ b/taskcluster/translations_taskgraph/transforms/from_datasets.py
@@ -137,14 +137,14 @@ def jobs_from_datasets(config, jobs):
                         "provider": provider,
                         "dataset": dataset,
                         "dataset_short": shorten_dataset_name(dataset),
-                        "dataset_no_slashes": dataset.replace("/", "."),
+                        "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
                         "src_locale": pair["src"],
                         "trg_locale": pair["trg"],
                     }
                     for field in substitution_fields:
                         container, subfield = subjob, field
                         while "." in subfield:
-                            f, subfield = field.split(".", 1)
+                            f, subfield = subfield.split(".", 1)
                             container = container[f]
 
                         container[subfield] = substitute(container[subfield], **subs)

--- a/taskcluster/translations_taskgraph/util/dict_helpers.py
+++ b/taskcluster/translations_taskgraph/util/dict_helpers.py
@@ -1,0 +1,10 @@
+def deep_get(dict_, field):
+    container, subfield = dict_, field
+    while "." in subfield:
+        f, subfield = subfield.split(".", 1)
+        if f not in container:
+            return None
+
+        container = container[f]
+
+    return container.get(subfield)


### PR DESCRIPTION
Examples of this can be found in the `configs` directory of this repository. Mostly this is just shuffling existing fields around, but there's also some changes types (eg: bicleaner_threshold becomes a number).

A few other notes:
* `target-stage` is present here but not in the existing configs. This allows for stopping the pipeline at specific stages (instead of running the whole thing). My suggestion is to use the deepest part of the pipeline as the default (for now that's `train-vocab`), although maybe we'll find that being more conservative is more desirable - we can always change it later.
* `dataset_no_slashes` becomes `dataset_sanitized`. This is because some datasets contain `.` - which we need to use in some places as a separator for fields in a deeply nested dict.
* Support for lists when interpolating things from parameters. This allows us to look for a dataset specific version of something, and still fallback to the general default (both of which come from parameters via action input).
* Sync up defaults for all parameters with `config.test.yml`, with the exception of src/trg. I discovered that `bicleaner` doesn't yet work with `en` as the `trg` locale. I'll fix this up in a future PR. These new defaults make it much easier to run the `train` action, especially for testing (usually you can just take the defaults.
* Add a schema for the `cache` transform, which I forgot to do when I created it.

Here's a graph that was created off of this PR in staging: https://firefox-ci-tc.services.mozilla.com/tasks/groups/f7KrQjqmSmGKZTfCOy_M1Q