### PR TITLE
Add support for training with `en` as the target language

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -51,7 +51,7 @@ else
 
   export scol=1
   export tcol=2
-  if [ -d "${pack_dir}/${TRG}-${SRC}" ]; then
+  if [ -f "${pack_dir}/${TRG}-${SRC}.yaml" ]; then
     export scol=2
     export tcol=1
   fi

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -84,7 +84,7 @@ task-defaults:
                 {bicleaner_threshold}
                 {bicleaner_type}
                 {bicleaner_threads}
-                $MOZ_FETCHES_DIR/{src_locale}-{trg_locale}
+                $MOZ_FETCHES_DIR/pack
     dependencies:
         "{provider}": clean-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}
     fetches:
@@ -140,6 +140,8 @@ tasks:
             exclude-locales:
                 - src: en
                   trg: ru
+                - src: ru
+                  trg: en
         attributes:
             cleaning-type: bicleaner-ai
             cache:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -34,37 +34,53 @@ datasets:
               trg: ru
             - src: en
               trg: fr
+            - src: ru
+              trg: en
         devtest:
             - src: en
               trg: ru
             - src: en
               trg: fr
+            - src: ru
+              trg: en
 
     sacrebleu:
         wmt19:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
         wmt20:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
 
     opus:
         ada83/v1:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
         GNOME/v1:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
 
     news-crawl:
         news.2020:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
 
     mtdata:
         Neulab-tedtalks_train-1-eng-rus:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
 
 workers:
     aliases:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -32,16 +32,20 @@ datasets:
         dev:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
             - src: en
               trg: fr
-            - src: ru
+            - src: fr
               trg: en
         devtest:
             - src: en
               trg: ru
+            - src: ru
+              trg: en
             - src: en
               trg: fr
-            - src: ru
+            - src: fr
               trg: en
 
     sacrebleu:
@@ -67,12 +71,20 @@ datasets:
               trg: ru
             - src: ru
               trg: en
+            - src: en
+              trg: fr
+            - src: fr
+              trg: en
 
     news-crawl:
         news.2020:
             - src: en
               trg: ru
             - src: ru
+              trg: en
+            - src: en
+              trg: fr
+            - src: fr
               trg: en
 
     mtdata:

--- a/taskcluster/ci/fetch/bicleaner.yml
+++ b/taskcluster/ci/fetch/bicleaner.yml
@@ -4,495 +4,660 @@
 ---
 bicleaner-ai-en-bg:
     description: bicleaner lite-en-bg pack
+    fetch-alias: bicleaner-ai-bg-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-bg.tgz
         sha256: df40ee261dd8bb24b0bd81c7dfa2e1c4d9b1a123fb82dd93518b884d10346c28
         size: 369188943
         artifact-name: bicleaner-ai-en-bg.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-cs:
     description: bicleaner lite-en-cs pack
+    fetch-alias: bicleaner-ai-cs-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-cs.tgz
         sha256: 7c9f692e341ed6db27bb4fec58fe59968c0f43bfeaa8e7720cd700fc704142b5
         size: 429288829
         artifact-name: bicleaner-ai-en-cs.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-da:
     description: bicleaner lite-en-da pack
+    fetch-alias: bicleaner-ai-da-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-da.tgz
         sha256: 74fecadd06c57932092bb6abf9d066ab77e6bf83bd4d38c1e24bf7369a661991
         size: 367562892
         artifact-name: bicleaner-ai-en-da.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-de:
     description: bicleaner lite-en-de pack
+    fetch-alias: bicleaner-ai-de-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-de.tgz
         sha256: 1a66edfce8493c5cd4238aac77590103bf8c000a2d1b011d62129c1203ce9016
         size: 503693049
         artifact-name: bicleaner-ai-en-de.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-el:
     description: bicleaner lite-en-el pack
+    fetch-alias: bicleaner-ai-el-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-el.tgz
         sha256: 06e52ae97abc4d7cc92789e0285a629ba52af7daf15f4fcae00927f4ed8d56de
         size: 446093598
         artifact-name: bicleaner-ai-en-el.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-es:
     description: bicleaner lite-en-es pack
+    fetch-alias: bicleaner-ai-es-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-es.tgz
         sha256: 35ff078b0c7a08601793a99478bfbe4032f3b56d6a46f0cf4e47aea41257cb95
         size: 535261323
         artifact-name: bicleaner-ai-en-es.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-et:
     description: bicleaner lite-en-et pack
+    fetch-alias: bicleaner-ai-et-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-et.tgz
         sha256: 7468908c246b761d36e3cc57306f7d342cb694b2b72b597c14c354c07e69cc60
         size: 399644320
         artifact-name: bicleaner-ai-en-et.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-fi:
     description: bicleaner lite-en-fi pack
+    fetch-alias: bicleaner-ai-fi-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-fi.tgz
         sha256: b658cf5c5e3c718a0b8565cdc8d8872c7ff79493e4bd015ed682aff98f9511db
         size: 422105777
         artifact-name: bicleaner-ai-en-fi.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-fr:
     description: bicleaner lite-en-fr pack
+    fetch-alias: bicleaner-ai-fr-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-fr.tgz
         sha256: 1af3675c1525dc35cf4a9a1ce2300aa3c3e5f53a92ef2da5c327596459ff97c2
         size: 509180872
         artifact-name: bicleaner-ai-en-fr.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-ga:
     description: bicleaner lite-en-ga pack
+    fetch-alias: bicleaner-ai-ga-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-ga.tgz
         sha256: aefcd387d75924800d75c96131120040501dad74547f2437f4187da82bc55d0b
         size: 312291448
         artifact-name: bicleaner-ai-en-ga.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-hr:
     description: bicleaner lite-en-hr pack
+    fetch-alias: bicleaner-ai-hr-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-hr.tgz
         sha256: 52302b29399e278070a3fca2c7633f35c67aa7e51459dab339b87e213403fea1
         size: 496642588
         artifact-name: bicleaner-ai-en-hr.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-hu:
     description: bicleaner lite-en-hu pack
+    fetch-alias: bicleaner-ai-hu-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-hu.tgz
         sha256: 9232986b60323384cf95ae08deeea0c009dfc1f5ace85e69187a901a09e0bb87
         size: 472285319
         artifact-name: bicleaner-ai-en-hu.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-is:
     description: bicleaner lite-en-is pack
+    fetch-alias: bicleaner-ai-is-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-is.tgz
         sha256: e7b2871d0d5f377af548762b48db8b7d2442bfca4d44bcbb1fe0246648d1529b
         size: 381104893
         artifact-name: bicleaner-ai-en-is.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-it:
     description: bicleaner lite-en-it pack
+    fetch-alias: bicleaner-ai-it-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-it.tgz
         sha256: 9fdd0f35a05ca15f8e5bc53df26f2cba3f83986b764b6ad4f9d3a98a94c5cb67
         size: 480925447
         artifact-name: bicleaner-ai-en-it.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-lt:
     description: bicleaner lite-en-lt pack
+    fetch-alias: bicleaner-ai-lt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-lt.tgz
         sha256: 83d802b1fa1904fa04f569efdeaf11228cc92af22ed23d2ab946b12ca387c17c
         size: 380216519
         artifact-name: bicleaner-ai-en-lt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-lv:
     description: bicleaner lite-en-lv pack
+    fetch-alias: bicleaner-ai-lv-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-lv.tgz
         sha256: 710ffe6cae4c97808ba267b75295cd2954f9a4753b447fc6b5be4ef2825ac161
         size: 481751211
         artifact-name: bicleaner-ai-en-lv.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-mt:
     description: bicleaner lite-en-mt pack
+    fetch-alias: bicleaner-ai-mt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-mt.tgz
         sha256: 0d08ae53b906810c5b655f4546f8f95c33e365326bfb6322ce3b01993a28112d
         size: 310023942
         artifact-name: bicleaner-ai-en-mt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-nb:
     description: bicleaner lite-en-nb pack
+    fetch-alias: bicleaner-ai-nb-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-nb.tgz
         sha256: 7ca7bd587d220493a7b9c37d6d463bfbf99134387bfa9ad9d1ac8c3302c2d051
         size: 419041286
         artifact-name: bicleaner-ai-en-nb.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-nl:
     description: bicleaner lite-en-nl pack
+    fetch-alias: bicleaner-ai-nl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-nl.tgz
         sha256: 6fd4da690358f4f9c6fc06a97423f4c3371b41dba575b9e88d3187ec25fbe001
         size: 427505540
         artifact-name: bicleaner-ai-en-nl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-nn:
     description: bicleaner lite-en-nn pack
+    fetch-alias: bicleaner-ai-nn-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-nn.tgz
         sha256: b0dd407ffc257f0f485583ba750897dc8abb3e54927b975ee8967381dfa18d1f
         size: 422402790
         artifact-name: bicleaner-ai-en-nn.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-pl:
     description: bicleaner lite-en-pl pack
+    fetch-alias: bicleaner-ai-pl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-pl.tgz
         sha256: 0eb5cd21fb714af81854eb1ed60b18e99a8f59b9bda495df2dc0ff620665c5f1
         size: 546487672
         artifact-name: bicleaner-ai-en-pl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-pt:
     description: bicleaner lite-en-pt pack
+    fetch-alias: bicleaner-ai-pt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-pt.tgz
         sha256: b32ac876a12146957e65960a4e0a3da41630f280d6c3ad1e8306c8c0ed853d51
         size: 502639758
         artifact-name: bicleaner-ai-en-pt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-ro:
     description: bicleaner lite-en-ro pack
+    fetch-alias: bicleaner-ai-ro-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-ro.tgz
         sha256: 4ab30b6eab8a00d4324737b32e56f2050ab14c0426ac8e9e753660b4b853d1b9
         size: 444265818
         artifact-name: bicleaner-ai-en-ro.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-sk:
     description: bicleaner lite-en-sk pack
+    fetch-alias: bicleaner-ai-sk-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-sk.tgz
         sha256: 22756e536ade06f5b4f7cebf4c6ab964c48a1abd1c81d68560a1d11fb2c0f613
         size: 499326003
         artifact-name: bicleaner-ai-en-sk.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-sl:
     description: bicleaner lite-en-sl pack
+    fetch-alias: bicleaner-ai-sl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-sl.tgz
         sha256: 182ef07d8d5548ea14d27edbe65900502d6a1a8970df9aa38ce0e215907131f3
         size: 439849151
         artifact-name: bicleaner-ai-en-sl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-ai-en-sv:
     description: bicleaner lite-en-sv pack
+    fetch-alias: bicleaner-ai-sv-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-ai-data/releases/download/v2.0/lite-en-sv.tgz
         sha256: 62418c0768f55e4787ffdeae310695ca658047aefb2aa4e60ba28e75519bfdb3
         size: 407742801
         artifact-name: bicleaner-ai-en-sv.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-bg:
     description: bicleaner en-bg pack
+    fetch-alias: bicleaner-bg-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-bg.tar.gz
         sha256: a0c2cdd27aeef2c12eb216357cbfb5a1b8920f88c469694e515e8ac61ed29d28
         size: 397053400
         artifact-name: bicleaner-en-bg.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-ca:
     description: bicleaner en-ca pack
+    fetch-alias: bicleaner-ca-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-ca.tar.gz
         sha256: 84890e244bc8fd769a906c3ff4280873d73d83700394808655605c4acc39d5f7
         size: 273582123
         artifact-name: bicleaner-en-ca.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-cs:
     description: bicleaner en-cs pack
+    fetch-alias: bicleaner-cs-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-cs.tar.gz
         sha256: 483520b5cf788aad393a06640e1259293018051445e435186ba66f8d8f0d7c3b
         size: 359498838
         artifact-name: bicleaner-en-cs.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-da:
     description: bicleaner en-da pack
+    fetch-alias: bicleaner-da-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-da.tar.gz
         sha256: 5ea4724af3c00581eede1927fe5467d3fa73ec723a9adebdc083c4f0ae29092e
         size: 333511920
         artifact-name: bicleaner-en-da.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-de:
     description: bicleaner en-de pack
+    fetch-alias: bicleaner-de-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-de.tar.gz
         sha256: c932449563ef0108757382d7d2de2dae2bdd97f78cf9dcee3fcf734a80c5b98d
         size: 523179851
         artifact-name: bicleaner-en-de.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-el:
     description: bicleaner en-el pack
+    fetch-alias: bicleaner-el-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-el.tar.gz
         sha256: c71c53407d8f29f0c0bc78c9c5cd5d9c266ca1414eda27affde86a4d792ca7c8
         size: 415029223
         artifact-name: bicleaner-en-el.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-es:
     description: bicleaner en-es pack
+    fetch-alias: bicleaner-es-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-es.tar.gz
         sha256: 96e5d16d8f30007d203b3c7e362a729f6e5fe60be56abdeccab66b14cc7783c3
         size: 351612333
         artifact-name: bicleaner-en-es.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-et:
     description: bicleaner en-et pack
+    fetch-alias: bicleaner-et-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-et.tar.gz
         sha256: 0c8c4acc4856d34f5a9d887a5d4eb6572217e757f32f7b6cdc4c2862ec34f443
         size: 434084344
         artifact-name: bicleaner-en-et.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-fi:
     description: bicleaner en-fi pack
+    fetch-alias: bicleaner-fi-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-fi.tar.gz
         sha256: feb8390ec911a888678b86751d6eaeb56b1a916bbea5a0bbdc0ef76428398017
         size: 503190781
         artifact-name: bicleaner-en-fi.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-fr:
     description: bicleaner en-fr pack
+    fetch-alias: bicleaner-fr-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-fr.tar.gz
         sha256: e32134c6e3563a2e2b86e03bc082dea29f99f16f06a1127ed8cda1d4be6ec284
         size: 301237052
         artifact-name: bicleaner-en-fr.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-ga:
     description: bicleaner en-ga pack
+    fetch-alias: bicleaner-ga-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-ga.tar.gz
         sha256: 69f812bcbc1dcc44c16a4386545b33a41fb3e7ed76a3fc2fa7f63433d5088898
         size: 429467347
         artifact-name: bicleaner-en-ga.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-hr:
     description: bicleaner en-hr pack
+    fetch-alias: bicleaner-hr-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-hr.tar.gz
         sha256: e866ab391aecb3f14e9c984f59dc69ab2884a66c2a0cc1c651e734728e499856
         size: 396828015
         artifact-name: bicleaner-en-hr.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-hu:
     description: bicleaner en-hu pack
+    fetch-alias: bicleaner-hu-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-hu.tar.gz
         sha256: 366807757aa5381609b0bfc39ef26741ef8c1e957047c3330958b76e9b392237
         size: 415085287
         artifact-name: bicleaner-en-hu.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-is:
     description: bicleaner en-is pack
+    fetch-alias: bicleaner-is-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-is.tar.gz
         sha256: c3efb8676198fddab36052d7f606c010ce3c7c659e924f5bfac3753023167f55
         size: 420381350
         artifact-name: bicleaner-en-is.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-it:
     description: bicleaner en-it pack
+    fetch-alias: bicleaner-it-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-it.tar.gz
         sha256: 2aeb588cd0b931a468aa043ac8285fd89c8aa52cdd6a04d878ce873d1d472fb6
         size: 282449727
         artifact-name: bicleaner-en-it.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-lt:
     description: bicleaner en-lt pack
+    fetch-alias: bicleaner-lt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-lt.tar.gz
         sha256: 01c64b93362a8140811c66c3ca1be0a35c2deb8404bd63df3cb55ffefeb5858b
         size: 433983794
         artifact-name: bicleaner-en-lt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-lv:
     description: bicleaner en-lv pack
+    fetch-alias: bicleaner-lv-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-lv.tar.gz
         sha256: f92663d90bb12faaa1f8d9fc01c6546d09bacb9036442d112d5af6e57cec0bfd
         size: 395646027
         artifact-name: bicleaner-en-lv.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-mt:
     description: bicleaner en-mt pack
+    fetch-alias: bicleaner-mt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-mt.tar.gz
         sha256: f1f477cc76049a63ebb751ec01bafbe35cd2a7e3f1fa95d516001239fdfde3d2
         size: 446888765
         artifact-name: bicleaner-en-mt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-nb:
     description: bicleaner en-nb pack
+    fetch-alias: bicleaner-nb-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-nb.tar.gz
         sha256: 8289271d1b92cb78ccee0f90af648fd0e2b1e034bf7ce3555dee3cb9bb7b8561
         size: 477583939
         artifact-name: bicleaner-en-nb.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-nl:
     description: bicleaner en-nl pack
+    fetch-alias: bicleaner-nl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-nl.tar.gz
         sha256: 3f0885999c9bd4f9a9d1e4d79cc8e1cf5532cf88e46758e1a36ba3be84b8a5ca
         size: 555802202
         artifact-name: bicleaner-en-nl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-nn:
     description: bicleaner en-nn pack
+    fetch-alias: bicleaner-nn-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-nn.tar.gz
         sha256: 8c1ab49c94d9ed9fb093917dd7a80d8bedd047a18f88dbf8a7e81507fad0d73b
         size: 324817842
         artifact-name: bicleaner-en-nn.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-pl:
     description: bicleaner en-pl pack
+    fetch-alias: bicleaner-pl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-pl.tar.gz
         sha256: e2bc5d07cba8a5b59eb0f5583b0c4f1c9f4ead096bcd0186a6f22fdd631c8172
         size: 380483224
         artifact-name: bicleaner-en-pl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-pt:
     description: bicleaner en-pt pack
+    fetch-alias: bicleaner-pt-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-pt.tar.gz
         sha256: 5d48b074f955bbfa582c6c47bbadc90178b04a392b58af27178389677f1c135e
         size: 431671623
         artifact-name: bicleaner-en-pt.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-ro:
     description: bicleaner en-ro pack
+    fetch-alias: bicleaner-ro-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-ro.tar.gz
         sha256: 25048eaf627c3f950e44898d7892b11b06321ee9c4bfe16dab1e1400f1336abc
         size: 393528818
         artifact-name: bicleaner-en-ro.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-ru:
     description: bicleaner en-ru pack
+    fetch-alias: bicleaner-ru-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-ru.tar.gz
         sha256: ad445d317665bf81a895dca2c10c4466e76f9d7fbfb32d9a08770ddef34ea42e
         size: 508534409
         artifact-name: bicleaner-en-ru.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-sk:
     description: bicleaner en-sk pack
+    fetch-alias: bicleaner-sk-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-sk.tar.gz
         sha256: e0b5cab1198b73ed67d8c72bd9622a6a0362427221d321aa2631c98e04de4e34
         size: 336424929
         artifact-name: bicleaner-en-sk.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-sl:
     description: bicleaner en-sl pack
+    fetch-alias: bicleaner-sl-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-sl.tar.gz
         sha256: 9a365867cc2f10b0f58d18ee14834f1b42525fddf23402ce3ac54bfcf8bd9a5b
         size: 400519843
         artifact-name: bicleaner-en-sl.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-sv:
     description: bicleaner en-sv pack
+    fetch-alias: bicleaner-sv-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-sv.tar.gz
         sha256: 773d0f2e32f8399c465966a32647a45289bbd85a53c7c4fafbac189ac3c028b6
         size: 401161427
         artifact-name: bicleaner-en-sv.tar.zst
+        add-prefix: pack/
+        strip-components: 1
 
 bicleaner-en-uk:
     description: bicleaner en-uk pack
+    fetch-alias: bicleaner-uk-en
     fetch:
         type: static-url
         url: https://github.com/bitextor/bicleaner-data/releases/download/v1.6/en-uk.tar.gz
         sha256: ab7ef285c3ec5ab0878aa45e5a6b20b60c41dd9c25e695bcb9dca022e6cf2541
         size: 336387092
         artifact-name: bicleaner-en-uk.tar.zst
+        add-prefix: pack/
+        strip-components: 1

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -15,8 +15,8 @@ def get_defaults(_):
         "training_config": {
             "target-stage": "train-vocab",
             "experiment": {
-                "src": "en",
-                "trg": "ru",
+                "src": "ru",
+                "trg": "en",
                 "bicleaner": {
                     "default-threshold": 0.5,
                     "dataset-thresholds": {


### PR DESCRIPTION
The main wrinkle with this (at least with what we've implemented of the pipeline so far), is that any bicleaner packs that include English use it as the `src` language, but we still need to consume them when English is the target. Fetch aliases allow us to refer to the same cached downloads with `en` in either spot.

@eu9ene - this also adjusts reverse locale detection in the bicleaner script, which you probably ought to sanity check. This seems like it ought to work, but I'm unable to test it.

Some example runs in Taskcluster with this applied:
* [ru-en](https://firefox-ci-tc.services.mozilla.com/tasks/groups/WJnqzfNRTT-pMDnfnlmOAQ)
* [en-ru](https://firefox-ci-tc.services.mozilla.com/tasks/groups/E6E1uKBiQFudm_P2MzPpVQ)
* [fr-en](https://firefox-ci-tc.services.mozilla.com/tasks/groups/GAYo75liR4mkOntTKu_KYw)
* [en-fr](https://firefox-ci-tc.services.mozilla.com/tasks/groups/RmlAjjB6RlaF3GhDQD4WLg)

(`train-vocab` is failing on the two `fr` runs, but this is due not having enough datasets added for French to hit the desired `spm-sample-size`.)