### PR TITLE
Add `merge-mono` pipeline step

### DIFF
--- a/pipeline/clean/merge-mono.sh
+++ b/pipeline/clean/merge-mono.sh
@@ -13,24 +13,15 @@ output=$1
 max_sent=$2
 datasets=( "${@:3}" )
 
-LOCALE="${LOCALE:-}"
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
-ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
 
-if [ -z "${LOCALE}" ]; then
-  dir=$(dirname "${output}")
-  mkdir -p "${dir}"
-  ${COMPRESSION_CMD} -dc "${datasets[@]}" |
-    ${BIN}/dedupe |
-    shuf -n "${max_sent}" |
-    ${COMPRESSION_CMD} >"${output}"
-else
-  datasets=($( printf '%s\n' "${datasets[@]}"| grep ${LOCALE} ))
-  output="${output}/mono.${LOCALE}.${ARTIFACT_EXT}"
-  ${COMPRESSION_CMD} -dc "${datasets[@]}" |
-    ${BIN}/dedupe |
-    shuf -n "${max_sent}" |
-    ${COMPRESSION_CMD} >"${output}"
-fi
+dir=$(dirname "${output}")
+mkdir -p "${dir}"
+
+${COMPRESSION_CMD} -dc "${datasets[@]}" |
+  ${BIN}/dedupe |
+  shuf -n "${max_sent}" |
+  ${COMPRESSION_CMD} >"${output}"
+
 
 echo "###### Done: Merging monolingual datasets"

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -86,6 +86,15 @@ datasets:
               trg: fr
             - src: fr
               trg: en
+        news.2019:
+            - src: en
+              trg: ru
+            - src: ru
+              trg: en
+            - src: en
+              trg: fr
+            - src: fr
+              trg: en
 
     mtdata:
         Neulab-tedtalks_train-1-eng-rus:

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -1,0 +1,118 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:mono
+    - translations_taskgraph.transforms.find_upstreams:mono
+    - translations_taskgraph.transforms.command_context_from_params:transforms
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - clean-mono
+    - toolchain
+
+task-defaults:
+    label: merge-mono-{locale}
+    description: merge mono for {locale}
+    attributes:
+        stage: merge-mono
+        cache:
+            type: merge-mono
+            resources:
+                - pipeline/clean/merge-mono.sh
+
+    dataset-config:
+        substitution-fields:
+            - label
+            - description
+            - name
+            - treeherder.symbol
+            - worker.env
+            - upstreams-config.locale
+
+    upstreams-config:
+        locale: "{locale}"
+        upstream-task-attributes:
+            cleaning-type: clean-mono
+        upstream-artifacts:
+            - "{dataset_sanitized}.{locale}.zst"
+
+    worker-type: b-linux-large
+
+    worker:
+        docker-image: { "in-tree": "train" }
+        max-run-time: 3600
+        artifacts:
+            - name: public/build
+              path: /builds/worker/artifacts
+              type: directory
+        env:
+            LOCALE: "{locale}"
+            COMPRESSION_CMD: zstdmt
+            ARTIFACT_EXT: zst
+
+    # Don't run unless explicitly scheduled
+    run-on-tasks-for: []
+
+    treeherder:
+        symbol: "{locale}"
+        platform: merge-mono/opt
+
+    run:
+        using: run-task
+        command:
+            - bash
+            - -c
+            # Arguments are:
+            # 1) output directory
+            # 2) max_sent (sent to shuf -n to output at most max_sent lines)
+            # 3) input files
+            - >-
+                export BIN=$MOZ_FETCHES_DIR &&
+                $VCS_PATH/pipeline/clean/merge-mono.sh
+                /builds/worker/artifacts
+                {max_sent}
+                $MOZ_FETCHES_DIR/*.zst
+
+    fetches:
+        toolchain:
+            - preprocess
+
+tasks:
+    src:
+        attributes:
+            dataset-category: mono-src
+            cache:
+                from-parameters:
+                    max_sent: training_config.experiment.mono-max-sentences-src
+
+        dataset-config:
+            include-categories:
+                - mono-src
+
+        run:
+            command-context:
+                from-parameters:
+                    max_sent: training_config.experiment.mono-max-sentences-src
+
+    trg:
+        attributes:
+            dataset-category: mono-trg
+            cache:
+                from-parameters:
+                    max_sent: training_config.experiment.mono-max-sentences-trg
+
+        dataset-config:
+            include-categories:
+                - mono-trg
+
+        run:
+            command-context:
+                from-parameters:
+                    max_sent: training_config.experiment.mono-max-sentences-trg

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -5,7 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.from_datasets:mono
+    - translations_taskgraph.transforms.find_upstreams:mono
     - translations_taskgraph.transforms.command_context_from_params:transforms
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms
@@ -17,7 +17,6 @@ kind-dependencies:
     - toolchain
 
 task-defaults:
-    label: merge-mono-{locale}
     description: merge mono for {locale}
     attributes:
         stage: merge-mono
@@ -26,15 +25,18 @@ task-defaults:
             resources:
                 - pipeline/clean/merge-mono.sh
 
-    dataset-config:
+    upstreams-config:
+        locale: "{locale}"
+        upstream-task-attributes:
+            cleaning-type: clean-mono
+        upstream-artifacts:
+            - "{dataset_sanitized}.{locale}.zst"
         substitution-fields:
             - label
             - description
             - name
             - treeherder.symbol
             - worker.env
-            - fetches
-            - dependencies
 
     worker-type: b-linux-large
 
@@ -51,10 +53,6 @@ task-defaults:
 
     # Don't run unless explicitly scheduled
     run-on-tasks-for: []
-
-    treeherder:
-        symbol: "{locale}"
-        platform: merge-mono/opt
 
     run:
         using: run-task
@@ -75,45 +73,38 @@ task-defaults:
     fetches:
         toolchain:
             - preprocess
-        clean-mono:
-            - artifact: "{dataset_sanitized}.{locale}.zst"
-              extract: false
 
 tasks:
     src:
+        label: merge-mono-{provider}-mono-src-{src_locale}-{trg_locale}
         attributes:
             dataset-category: mono-src
             cache:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
-        dataset-config:
-            include-categories:
-                - mono-src
+        treeherder:
+            symbol: "{dataset_short}-src-{src_locale}-{trg_locale}"
+            platform: merge-mono/opt
 
         run:
             command-context:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
-        dependencies:
-            clean-mono: clean-mono-{provider}-{dataset}-mono-src-{locale}
-
     trg:
+        label: merge-mono-{provider}-mono-trg-{src_locale}-{trg_locale}
         attributes:
             dataset-category: mono-trg
             cache:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-trg
 
-        dataset-config:
-            include-categories:
-                - mono-trg
+        treeherder:
+            symbol: "{dataset_short}-trg-{src_locale}-{trg_locale}"
+            platform: merge-mono/opt
 
         run:
             command-context:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-trg
-
-        dependencies:
-            clean-mono: clean-mono-{provider}-{dataset}-mono-trg-{locale}

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -48,7 +48,6 @@ task-defaults:
         env:
             LOCALE: "{locale}"
             COMPRESSION_CMD: zstdmt
-            ARTIFACT_EXT: zst
 
     # Don't run unless explicitly scheduled
     run-on-tasks-for: []
@@ -69,7 +68,7 @@ task-defaults:
             - >-
                 export BIN=$MOZ_FETCHES_DIR &&
                 $VCS_PATH/pipeline/clean/merge-mono.sh
-                /builds/worker/artifacts
+                /builds/worker/artifacts/mono.$LOCALE.zst
                 {max_sent}
                 $MOZ_FETCHES_DIR/*.zst
 

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -6,7 +6,6 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.from_datasets:mono
-    - translations_taskgraph.transforms.find_upstreams:mono
     - translations_taskgraph.transforms.command_context_from_params:transforms
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms
@@ -34,14 +33,8 @@ task-defaults:
             - name
             - treeherder.symbol
             - worker.env
-            - upstreams-config.locale
-
-    upstreams-config:
-        locale: "{locale}"
-        upstream-task-attributes:
-            cleaning-type: clean-mono
-        upstream-artifacts:
-            - "{dataset_sanitized}.{locale}.zst"
+            - fetches
+            - dependencies
 
     worker-type: b-linux-large
 
@@ -83,6 +76,9 @@ task-defaults:
     fetches:
         toolchain:
             - preprocess
+        clean-mono:
+            - artifact: "{dataset_sanitized}.{locale}.zst"
+              extract: false
 
 tasks:
     src:
@@ -101,6 +97,9 @@ tasks:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
+        dependencies:
+            clean-mono: clean-mono-{provider}-{dataset}-mono-src-{locale}
+
     trg:
         attributes:
             dataset-category: mono-trg
@@ -116,3 +115,6 @@ tasks:
             command-context:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-trg
+
+        dependencies:
+            clean-mono: clean-mono-{provider}-{dataset}-mono-trg-{locale}

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -76,7 +76,7 @@ task-defaults:
 
 tasks:
     src:
-        label: merge-mono-{provider}-mono-src-{src_locale}-{trg_locale}
+        label: merge-mono-src-{src_locale}-{trg_locale}
         attributes:
             dataset-category: mono-src
             cache:
@@ -93,7 +93,7 @@ tasks:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
     trg:
-        label: merge-mono-{provider}-mono-trg-{src_locale}-{trg_locale}
+        label: merge-mono-trg-{src_locale}-{trg_locale}
         attributes:
             dataset-category: mono-trg
             cache:

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -84,7 +84,7 @@ tasks:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
         treeherder:
-            symbol: "{dataset_short}-src-{src_locale}-{trg_locale}"
+            symbol: "src-{src_locale}-{trg_locale}"
             platform: merge-mono/opt
 
         run:
@@ -101,7 +101,7 @@ tasks:
                     max_sent: training_config.experiment.mono-max-sentences-trg
 
         treeherder:
-            symbol: "{dataset_short}-trg-{src_locale}-{trg_locale}"
+            symbol: "trg-{src_locale}-{trg_locale}"
             platform: merge-mono/opt
 
         run:

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -38,7 +38,7 @@ defaults = get_defaults("")["training_config"]
 (any stages this choice depends on will be automatically included).""",
                 "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
-                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "train-vocab", "train-backwards", "evaluate-backwards"],
+                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards"],
             },
             "datasets": {
                 "type": "object",
@@ -151,6 +151,14 @@ leave empty to skip augmentation step (high resource languages)
                     "spm-sample-size": {
                         "type": "number",
                         "description": "vocabularly training sample size",
+                    },
+                    "mono-max-sentences-src": {
+                        "type": "number",
+                        "description": "limits per downloaded src dataset",
+                    },
+                    "mono-max-sentences-trg": {
+                        "type": "number",
+                        "description": "limits per downloaded trg dataset",
                     },
                 },
                 "required": [

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -26,6 +26,8 @@ def get_defaults(_):
                 },
                 "best-model": "chrf",
                 "spm-sample-size": 100000,
+                "mono-max-sentences-trg": 200000,
+                "mono-max-sentences-src": 100000,
             },
             "marian-args": {
                 "training-backward": {
@@ -80,6 +82,8 @@ extend_parameters_schema(
                 },
                 Required("best-model"): str,
                 Required("spm-sample-size"): int,
+                Required("mono-max-sentences-trg"): int,
+                Required("mono-max-sentences-src"): int,
             },
             Optional("bicleaner_threshold"): str,
             Optional("train_vocab_sample_size"): str,

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -22,7 +22,10 @@ import copy
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import Schema, optionally_keyed_by, resolve_keyed_by
-from voluptuous import ALLOW_EXTRA, Required
+from voluptuous import ALLOW_EXTRA, Required, Optional
+
+from translations_taskgraph.util.substitution import substitute
+from translations_taskgraph.util.dataset_helpers import shorten_dataset_name
 
 SCHEMA = Schema(
     {
@@ -42,6 +45,24 @@ SCHEMA = Schema(
 
 by_locales = TransformSequence()
 by_locales.add_validate(SCHEMA)
+
+MONO = Schema(
+    {
+        Required("upstreams-config"): {
+            Required("locale"): str,
+            Required("upstream-task-attributes"): {
+                str: optionally_keyed_by("cleaning-type", str),
+            },
+            Required("upstream-artifacts"): [str],
+            Optional("substitution-fields"): [str],
+        },
+    },
+    extra=ALLOW_EXTRA,
+)
+
+mono = TransformSequence()
+mono.add_validate(MONO)
+
 
 def get_cleaning_type(src, trg, upstreams):
     candidates = set()
@@ -134,3 +155,83 @@ def upstreams_for_locales(config, jobs):
                 )
             
         yield subjob
+
+
+@mono.add
+def upstreams_for_mono(config, jobs):
+    training_config = config.params.get("training_config", {})
+    datasets = training_config.get("datasets", {})
+    src = training_config["experiment"]["src"]
+    trg = training_config["experiment"]["trg"]
+    for job in jobs:
+        dataset_category = job["attributes"]["dataset-category"]
+        target_datasets = datasets[dataset_category]
+        job.setdefault("dependencies", {})
+        job.setdefault("fetches", {})
+        upstreams_config = job.pop("upstreams-config")
+        upstream_task_attributes = upstreams_config["upstream-task-attributes"]
+        artifacts = upstreams_config["upstream-artifacts"]
+        substitution_fields = upstreams_config["substitution-fields"]
+
+        for task in config.kind_dependencies_tasks.values():
+            # Filter out any tasks that don't match the desired attributes.
+            if any(task.attributes.get(k) != v for k, v in upstream_task_attributes.items()):
+                continue
+
+            provider = task.attributes["provider"]
+            dataset = task.attributes["dataset"]
+            task_dataset = f"{provider}_{dataset}"
+
+            # Filter out any tasks that don't match a desired dataset
+            if task_dataset not in target_datasets:
+                continue
+
+            if dataset_category == "mono-src":
+                locale = src
+            elif dataset_category == "mono-trg":
+                locale = trg
+            else:
+                raise Exception("Don't use `find_upstreams:mono` without the `mono-src` or `mono-trg` category!")
+
+            # Filter out any tasks that aren't for the correct locale.
+            if task.attributes["locale"] != locale or task.attributes["src_locale"] != src or task.attributes["trg_locale"] != trg:
+                continue
+
+            subs = {
+                "locale": locale,
+                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+            }
+
+            job["dependencies"][task.label] = task.label
+            job["fetches"].setdefault(task.label, [])
+
+            subs = {
+                "provider": provider,
+                "dataset": dataset,
+                "dataset_short": shorten_dataset_name(dataset),
+                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+                "locale": locale,
+                "src_locale": src,
+                "trg_locale": trg,
+            }
+
+            for field in substitution_fields:
+                container, subfield = job, field
+                while "." in subfield:
+                    f, subfield = subfield.split(".", 1)
+                    container = container[f]
+
+                container[subfield] = substitute(container[subfield], **subs)
+
+            for artifact in artifacts:
+                job["fetches"][task.label].append(
+                    {
+                        "artifact": artifact.format(**subs),
+                        "extract": False,
+                    }
+                )
+
+            job["attributes"]["src_locale"] = src
+            job["attributes"]["trg_locale"] = trg
+
+        yield job

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -25,7 +25,7 @@ from taskgraph.util.schema import Schema, optionally_keyed_by, resolve_keyed_by
 from voluptuous import ALLOW_EXTRA, Required, Optional
 
 from translations_taskgraph.util.substitution import substitute
-from translations_taskgraph.util.dataset_helpers import shorten_dataset_name
+from translations_taskgraph.util.dataset_helpers import shorten_dataset_name, sanitize_dataset_name
 
 SCHEMA = Schema(
     {
@@ -141,7 +141,7 @@ def upstreams_for_locales(config, jobs):
             subs = {
                 "src_locale": src,
                 "trg_locale": trg,
-                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+                "dataset_sanitized": sanitize_dataset_name(dataset),
             }
 
             subjob["dependencies"][task.label] = task.label
@@ -197,11 +197,6 @@ def upstreams_for_mono(config, jobs):
             if task.attributes["locale"] != locale or task.attributes["src_locale"] != src or task.attributes["trg_locale"] != trg:
                 continue
 
-            subs = {
-                "locale": locale,
-                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
-            }
-
             job["dependencies"][task.label] = task.label
             job["fetches"].setdefault(task.label, [])
 
@@ -209,7 +204,7 @@ def upstreams_for_mono(config, jobs):
                 "provider": provider,
                 "dataset": dataset,
                 "dataset_short": shorten_dataset_name(dataset),
-                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+                "dataset_sanitized": sanitize_dataset_name(dataset),
                 "locale": locale,
                 "src_locale": src,
                 "trg_locale": trg,

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -43,6 +43,23 @@ SCHEMA = Schema(
 by_locales = TransformSequence()
 by_locales.add_validate(SCHEMA)
 
+mono = TransformSequence()
+mono.add_validate(
+    Schema(
+        {
+            Required("upstreams-config"): {
+                Required("locale"): str,
+                Required("upstream-task-attributes"): {
+                    str: str,
+                },
+                Required("upstream-artifacts"): [str],
+            },
+        },
+        extra=ALLOW_EXTRA,
+    )
+)
+
+
 def get_cleaning_type(src, trg, upstreams):
     candidates = set()
 
@@ -133,4 +150,50 @@ def upstreams_for_locales(config, jobs):
                     }
                 )
             
+        yield subjob
+
+
+@mono.add
+def upstreams_for_mono(config, jobs):
+    datasets = config.params.get("training_config", {}).get("datasets", {})
+    for job in jobs:
+        dataset_category = job["attributes"]["dataset-category"]
+        target_datasets = datasets[dataset_category]
+        upstreams_config = job.pop("upstreams-config")
+        locale = upstreams_config["locale"]
+        artifacts = upstreams_config["upstream-artifacts"]
+        upstream_task_attributes = upstreams_config["upstream-task-attributes"]
+        subjob = copy.deepcopy(job)
+        subjob.setdefault("dependencies", {})
+        subjob.setdefault("fetches", {})
+        for task in config.kind_dependencies_tasks.values():
+            # Filter out any tasks that don't match the desired attributes.
+            if any(
+                task.attributes.get(k) != v for k, v in upstream_task_attributes.items()
+            ):
+                continue
+            # Filter out any tasks that aren't for the correct locale.
+            if (
+                task.attributes["locale"] != locale
+            ):
+                continue
+            provider = task.attributes["provider"]
+            dataset = task.attributes["dataset"]
+            task_dataset = f"{provider}_{dataset}"
+            # Filter out any tasks that don't match a desired dataset.
+            if task_dataset not in target_datasets:
+                continue
+            subs = {
+                "locale": locale,
+                "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+            }
+            subjob["dependencies"][task.label] = task.label
+            subjob["fetches"].setdefault(task.label, [])
+            for artifact in artifacts:
+                subjob["fetches"][task.label].append(
+                    {
+                        "artifact": artifact.format(**subs),
+                        "extract": False,
+                    }
+                )
         yield subjob

--- a/taskcluster/translations_taskgraph/transforms/from_datasets.py
+++ b/taskcluster/translations_taskgraph/transforms/from_datasets.py
@@ -5,7 +5,7 @@ from taskgraph.util.schema import Schema
 from voluptuous import ALLOW_EXTRA, Optional
 
 from translations_taskgraph.util.substitution import substitute
-from translations_taskgraph.util.dataset_helpers import shorten_dataset_name
+from translations_taskgraph.util.dataset_helpers import shorten_dataset_name, sanitize_dataset_name
 
 SCHEMA = Schema(
     {
@@ -131,7 +131,7 @@ def jobs_from_datasets(config, jobs):
                         "provider": provider,
                         "dataset": dataset,
                         "dataset_short": shorten_dataset_name(dataset),
-                        "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+                        "dataset_sanitized": sanitize_dataset_name(dataset),
                         "src_locale": pair["src"],
                         "trg_locale": pair["trg"],
                     }
@@ -207,7 +207,7 @@ def jobs_for_mono_datasets(config, jobs):
                         "provider": provider,
                         "dataset": dataset,
                         "dataset_short": shorten_dataset_name(dataset),
-                        "dataset_sanitized": dataset.replace("/", "_").replace(".", "_"),
+                        "dataset_sanitized": sanitize_dataset_name(dataset),
                         "locale": locale,
                         "src_locale": pair["src"],
                         "trg_locale": pair["trg"],

--- a/taskcluster/translations_taskgraph/transforms/from_datasets.py
+++ b/taskcluster/translations_taskgraph/transforms/from_datasets.py
@@ -5,6 +5,7 @@ from taskgraph.util.schema import Schema
 from voluptuous import ALLOW_EXTRA, Optional
 
 from translations_taskgraph.util.substitution import substitute
+from translations_taskgraph.util.dataset_helpers import shorten_dataset_name
 
 SCHEMA = Schema(
     {
@@ -79,17 +80,6 @@ mono.add_validate(SCHEMA)
 
 locales_only = TransformSequence()
 locales_only.add_validate(SCHEMA)
-
-
-def shorten_dataset_name(dataset):
-    """Shortens various dataset names. Mainly used to make sure we can have
-    useful Treeherder symbols."""
-    # TODO: should the replacements live in ci/config.yml?
-    return (dataset
-        .replace("new-crawl", "nc")
-        .replace("news.2020", "n2020")
-        .replace("Neulab-tedtalks_train-1", "Ntt1")
-    )
 
 
 def get_dataset_categories(provider, dataset, dataset_categories):

--- a/taskcluster/translations_taskgraph/util/dataset_helpers.py
+++ b/taskcluster/translations_taskgraph/util/dataset_helpers.py
@@ -1,0 +1,9 @@
+def shorten_dataset_name(dataset):
+    """Shortens various dataset names. Mainly used to make sure we can have
+    useful Treeherder symbols."""
+    # TODO: should the replacements live in ci/config.yml?
+    return (dataset
+        .replace("new-crawl", "nc")
+        .replace("news.2020", "n2020")
+        .replace("Neulab-tedtalks_train-1", "Ntt1")
+    )

--- a/taskcluster/translations_taskgraph/util/dataset_helpers.py
+++ b/taskcluster/translations_taskgraph/util/dataset_helpers.py
@@ -7,3 +7,7 @@ def shorten_dataset_name(dataset):
         .replace("news.2020", "n2020")
         .replace("Neulab-tedtalks_train-1", "Ntt1")
     )
+
+
+def sanitize_dataset_name(dataset):
+    return dataset.replace("/", "_").replace(".", "_")


### PR DESCRIPTION
Sample run in staging can be found at https://firefox-ci-tc.services.mozilla.com/tasks/groups/Bt9yeBnmQLiKdSMa5uADhQ

I added a new `mono` transform sequence to the `find_upstreams` transforms. Not sure if I should just fuse them into one transform (I think that is possible? I could check for `locale` v. `locale-pair` in the `upstream-config` and make `locale-pair` and `locale` optional in the schema.) I kind of like that, but it's a lil bit more coupling between mono vs. not mono.

