### PR TITLE
Add toolchain build for browsermt-marian

### DIFF
--- a/taskcluster/ci/fetch/toolchains.yml
+++ b/taskcluster/ci/fetch/toolchains.yml
@@ -11,6 +11,15 @@ marian:
         path-prefix: marian-source
         include-dot-git: true
 
+browsermt-marian:
+    description: Browsermt Marian
+    fetch:
+        type: git
+        repo: https://github.com/browsermt/marian-dev
+        revision: 08b1544636fe13eaf1fbacb17c6fb050abfb8d42
+        path-prefix: marian-source
+        include-dot-git: true
+
 fast-align:
     description: fast_align
     fetch:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -37,7 +37,6 @@ tasks:
             fetch:
                 - cuda
 
-    # TODO: probably need to make sure that these are all built statically?
     marian:
         description: Marian
         treeherder:
@@ -52,6 +51,26 @@ tasks:
         fetches:
             fetch:
                 - marian
+            toolchain:
+                - cuda-toolkit
+
+    browsermt-marian:
+        description: Browsermt Marian
+        treeherder:
+            symbol: TL(Browsermt-Marian)
+        worker-type: b-linux-large
+        run:
+            script: build-marian.sh
+            arguments:
+                - browsermt.patch
+            resources:
+                - taskcluster/scripts/toolchain/build-marian.sh
+                - taskcluster/scripts/toolchain/browsermt.patch
+                - pipeline/setup/compile-marian.sh
+            toolchain-artifact: public/build/browsermt-marian.tar.zst
+        fetches:
+            fetch:
+                - browsermt-marian
             toolchain:
                 - cuda-toolkit
 

--- a/taskcluster/scripts/toolchain/browsermt.patch
+++ b/taskcluster/scripts/toolchain/browsermt.patch
@@ -1,0 +1,49 @@
+diff -Naur browsermt-marian-dev.bak/CMakeLists.txt browsermt-marian-dev/CMakeLists.txt
+--- browsermt-marian-dev.bak/CMakeLists.txt	2023-06-01 20:13:41.351269359 -0400
++++ browsermt-marian-dev/CMakeLists.txt	2023-06-02 07:07:18.757839602 -0400
+@@ -377,20 +377,20 @@
+   # We want to compile as many targets as possible but different CUDA versions support different targets.
+   # Let's instead enable options based on what cuda version we have.
+   if((CUDA_VERSION VERSION_EQUAL "9.0" OR CUDA_VERSION VERSION_GREATER "9.0") AND CUDA_VERSION VERSION_LESS "11.0")
+-    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" ON)
++    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" OFF)
+     option(COMPILE_CUDA_SM50 "Compile GPU version with SM50 support" ON)
+     option(COMPILE_CUDA_SM60 "Compile GPU version with SM60 support" ON)
+     option(COMPILE_CUDA_SM70 "Compile GPU version with SM70 support" ON)
+   endif()
+   if((CUDA_VERSION VERSION_EQUAL "10.0" OR CUDA_VERSION VERSION_GREATER "10.0") AND CUDA_VERSION VERSION_LESS "11.0")
+-    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" ON)
++    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" OFF)
+     option(COMPILE_CUDA_SM50 "Compile GPU version with SM50 support" ON)
+     option(COMPILE_CUDA_SM60 "Compile GPU version with SM60 support" ON)
+     option(COMPILE_CUDA_SM70 "Compile GPU version with SM70 support" ON)
+     option(COMPILE_CUDA_SM75 "Compile GPU version with SM75 support" ON)
+   endif()
+   if(CUDA_VERSION VERSION_EQUAL "11.0" OR CUDA_VERSION VERSION_GREATER "11.0")
+-    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" ON)
++    option(COMPILE_CUDA_SM35 "Compile GPU version with SM35 support" OFF)
+     option(COMPILE_CUDA_SM50 "Compile GPU version with SM50 support" ON)
+     option(COMPILE_CUDA_SM60 "Compile GPU version with SM60 support" ON)
+     option(COMPILE_CUDA_SM70 "Compile GPU version with SM70 support" ON)
+diff -Naur browsermt-marian-dev.bak/src/3rd_party/fbgemm/src/RefImplementations.cc browsermt-marian-dev/src/3rd_party/fbgemm/src/RefImplementations.cc
+--- browsermt-marian-dev.bak/src/3rd_party/fbgemm/src/RefImplementations.cc	2023-06-01 20:14:27.376440856 -0400
++++ browsermt-marian-dev/src/3rd_party/fbgemm/src/RefImplementations.cc	2023-06-01 20:01:21.124240843 -0400
+@@ -12,6 +12,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <cstring>
++#include <limits>
+ 
+ using namespace std;
+ 
+diff -Naur browsermt-marian-dev.bak/src/tensors/gpu/add_all.inc browsermt-marian-dev/src/tensors/gpu/add_all.inc
+--- browsermt-marian-dev.bak/src/tensors/gpu/add_all.inc	2023-06-01 19:58:41.817439641 -0400
++++ browsermt-marian-dev/src/tensors/gpu/add_all.inc	2023-06-02 10:29:18.811776577 -0400
+@@ -23,6 +23,7 @@
+ template void AggregateAll<float, float, BinaryFunctor<elem::Mult, BinaryFunctor<elem::Leq, Assignee<2>, Assignee<3>>, Assignee<1>>, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, BinaryFunctor<elem::Mult, BinaryFunctor<elem::Leq, Assignee<2>, Assignee<3>>, Assignee<1>>, float, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor, marian::Tensor, marian::Tensor);
+ template void AggregateAll<float, float, BinaryFunctor<elem::Mult, Assignee<1>, UnaryFunctor<elem::Sigmoid, BinaryFunctor<elem::Minus, Assignee<2>, Assignee<3>>>>, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, BinaryFunctor<elem::Mult, Assignee<1>, UnaryFunctor<elem::Sigmoid, BinaryFunctor<elem::Minus, Assignee<2>, Assignee<3>>>>, float, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor, marian::Tensor, marian::Tensor);
+ template void AggregateAll<float, float, BinaryFunctor<elem::Div, Assignee<1>, Assignee<2>>, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, BinaryFunctor<elem::Div, Assignee<1>, Assignee<2>>, float, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor, marian::Tensor);
++template void AggregateAll<float, float, Assignee<1>, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, Assignee<1>, float, BinaryFunctor<elem::Plus, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor);
+ template void AggregateAll<float, float, Assignee<1>, BinaryFunctor<elem::Min, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, Assignee<1>, float, BinaryFunctor<elem::Min, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor);
+ template void AggregateAll<float, float, Assignee<1>, BinaryFunctor<elem::Max, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, Assignee<1>, float, BinaryFunctor<elem::Max, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor);
+ template void AggregateAll<float, float, Assignee<1>, BinaryFunctor<elem::Mult, Assignee<1>, Assignee<2>>>(std::shared_ptr<Allocator>, Assignee<1>, float, BinaryFunctor<elem::Mult, Assignee<1>, Assignee<2>>, float, marian::Tensor, marian::Tensor);

--- a/taskcluster/scripts/toolchain/build-marian.sh
+++ b/taskcluster/scripts/toolchain/build-marian.sh
@@ -2,8 +2,18 @@
 set -e
 set -x
 
+pushd `dirname $0` &>/dev/null
+MY_DIR=$(pwd)
+popd &>/dev/null
+
+patch=${1:-none}
+
 export MARIAN_DIR=$MOZ_FETCHES_DIR/marian-source
 export CUDA_DIR=$MOZ_FETCHES_DIR/cuda-toolkit
+
+if [ "$patch" != "none" ]; then
+  patch -d ${MARIAN_DIR} -p1 < ${MY_DIR}/${patch}
+fi
 
 # TODO: consider not calling out to this since it's such a simple script...
 bash $VCS_PATH/pipeline/setup/compile-marian.sh "${MARIAN_DIR}/build" "$(nproc)"


### PR DESCRIPTION
This is a simple fork of the upstream marian project, so we can use the same build script for it. It looks like this was forked from an older version that we're using for upstream marian though, and I had to apply a few fixes to have it build properly - mostly around using a newer CUDA library.

It won't be used until we get further into the pipeline - but we may as well get the build sorted out now.

https://firefox-ci-tc.services.mozilla.com/tasks/groups/Kjv4Y0p2RrqFtGkSmeQ0dg shows this building successfully in staging.