### PR TITLE
Add split-{corpus,mono} pipeline steps

### DIFF
--- a/pipeline/translate/split-corpus.sh
+++ b/pipeline/translate/split-corpus.sh
@@ -11,6 +11,9 @@ corpus_trg=$2
 output_dir=$3
 length=$4
 
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
+
 mkdir -p "${output_dir}"
-pigz -dc "${corpus_src}" |  split -d -l ${length} - "${output_dir}/file."
-pigz -dc "${corpus_trg}" |  split -d -l ${length} - "${output_dir}/file." --additional-suffix .ref
+${COMPRESSION_CMD} -dc "${corpus_src}" |  split -d -l ${length} - "${output_dir}/file."
+${COMPRESSION_CMD} -dc "${corpus_trg}" |  split -d -l ${length} - "${output_dir}/file." --additional-suffix .ref

--- a/pipeline/translate/split-mono.sh
+++ b/pipeline/translate/split-mono.sh
@@ -13,5 +13,8 @@ mono_path=$1
 output_dir=$2
 length=$3
 
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
+
 mkdir -p "${output_dir}"
-pigz -dc "${mono_path}" | ${BIN}/dedupe | split -d -l ${length} - "${output_dir}/file."
+${COMPRESSION_CMD} -dc "${mono_path}" | ${BIN}/dedupe | split -d -l ${length} - "${output_dir}/file."

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - translations_taskgraph.transforms.from_datasets:mono
     - translations_taskgraph.transforms.find_upstreams:mono
     - translations_taskgraph.transforms.command_context_from_params:transforms
     - taskgraph.transforms.job:transforms
@@ -25,18 +26,21 @@ task-defaults:
             resources:
                 - pipeline/clean/merge-mono.sh
 
-    upstreams-config:
-        locale: "{locale}"
-        upstream-task-attributes:
-            cleaning-type: clean-mono
-        upstream-artifacts:
-            - "{dataset_sanitized}.{locale}.zst"
+    dataset-config:
         substitution-fields:
             - label
             - description
             - name
             - treeherder.symbol
             - worker.env
+            - upstreams-config.locale
+
+    upstreams-config:
+        locale: "{locale}"
+        upstream-task-attributes:
+            cleaning-type: clean-mono
+        upstream-artifacts:
+            - "{dataset_sanitized}.{locale}.zst"
 
     worker-type: b-linux-large
 
@@ -83,6 +87,10 @@ tasks:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-src
 
+        dataset-config:
+            include-categories:
+                - mono-src
+
         treeherder:
             symbol: "src-{src_locale}-{trg_locale}"
             platform: merge-mono/opt
@@ -99,6 +107,10 @@ tasks:
             cache:
                 from-parameters:
                     max_sent: training_config.experiment.mono-max-sentences-trg
+
+        dataset-config:
+            include-categories:
+                - mono-trg
 
         treeherder:
             symbol: "trg-{src_locale}-{trg_locale}"

--- a/taskcluster/ci/split-corpus/kind.yml
+++ b/taskcluster/ci/split-corpus/kind.yml
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:locales_only
+    - translations_taskgraph.transforms.command_context_from_params:transforms
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - merge
+
+tasks:
+    "{src_locale}-{trg_locale}":
+        description: split corpus for {src_locale}-{trg_locale}
+        attributes:
+            dataset-category: train
+            stage: split-corpus
+            cache:
+                type: split-corpus
+                resources:
+                    - pipeline/translate/split-corpus.sh
+                    - taskcluster/scripts/pipeline/split-taskcluster.sh
+                from-parameters:
+                    split_length: training_config.experiment.split-length
+                    split_chunks: training_config.taskcluster.split-chunks
+        dataset-config:
+            substitution-fields:
+                - description
+                - name
+                - treeherder.symbol
+                - fetches
+                - dependencies
+        worker-type: b-linux-large
+        worker:
+            docker-image: {"in-tree": "train"}
+            max-run-time: 3600
+            artifacts:
+                - name: public/build
+                  path: /builds/worker/artifacts
+                  type: directory
+            env:
+                COMPRESSION_CMD: zstdmt
+                ARTIFACT_EXT: zst
+
+        # Don't run unless explicitly scheduled
+        run-on-tasks-for: []
+
+        treeherder:
+            symbol: "{src_locale}-{trg_locale}"
+            platform: split-corpus/opt
+        run:
+            using: run-task
+            command-context:
+                from-parameters:
+                    split_length: training_config.experiment.split-length
+                    split_chunks: training_config.taskcluster.split-chunks
+            command:
+                - bash
+                - -c
+                  # TODO: move number of chunks elsewhere
+                - >-
+                    $VCS_PATH/pipeline/translate/split-taskcluster.sh
+                    corpus
+                    {split_chunks}
+                    /builds/worker/artifacts
+                    {split_length}
+                    fetches/corpus.{src_locale}.zst
+                    fetches/corpus.{trg_locale}.zst
+
+        dependencies:
+            merge-corpus: merge-corpus-{src_locale}-{trg_locale}
+
+        fetches:
+            merge-corpus:
+                - artifact: corpus.{src_locale}.zst
+                  extract: false
+                - artifact: corpus.{trg_locale}.zst
+                  extract: false

--- a/taskcluster/ci/split-mono/kind.yml
+++ b/taskcluster/ci/split-mono/kind.yml
@@ -1,0 +1,122 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:mono
+    - translations_taskgraph.transforms.command_context_from_params:transforms
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - merge-mono
+    - toolchain
+
+task-defaults:
+    description: split mono for {locale}
+    attributes:
+        stage: split-mono
+        cache:
+            type: split-mono
+            resources:
+                - pipeline/translate/split-mono.sh
+                - taskcluster/scripts/pipeline/split-taskcluster.sh
+            from-parameters:
+                split_length: training_config.experiment.split-length
+                split_chunks: training_config.taskcluster.split-chunks
+
+    dataset-config:
+        substitution-fields:
+            - description
+            - label
+            - treeherder.symbol
+            - fetches
+            - dependencies
+            - worker.env
+
+    worker-type: b-linux-large
+
+    worker:
+        docker-image: { "in-tree": "train" }
+        max-run-time: 3600
+        artifacts:
+            - name: public/build
+              path: /builds/worker/artifacts
+              type: directory
+        env:
+            LOCALE: "{locale}"
+            COMPRESSION_CMD: zstdmt
+            ARTIFACT_EXT: zst
+
+    # Don't run unless explicitly scheduled
+    run-on-tasks-for: []
+
+    run:
+        using: run-task
+        command-context:
+            from-parameters:
+                split_length: training_config.experiment.split-length
+                split_chunks: training_config.taskcluster.split-chunks
+        command:
+            - bash
+            - -c
+              # TODO: move number of chunks elsewhere
+            - >-
+                export BIN=$MOZ_FETCHES_DIR &&
+                $VCS_PATH/taskcluster/scripts/pipeline/split-taskcluster.sh
+                mono
+                {split_chunks}
+                /builds/worker/artifacts
+                {split_length}
+                $MOZ_FETCHES_DIR/mono.$LOCALE.zst
+
+    fetches:
+        toolchain:
+            - preprocess
+
+tasks:
+    src:
+        label: split-mono-src-{src_locale}-{trg_locale}
+        attributes:
+            dataset-category: mono-src
+
+        dataset-config:
+            include-categories:
+                - mono-src
+
+        treeherder:
+            symbol: "src-{src_locale}-{trg_locale}"
+            platform: split-mono/opt
+
+        dependencies:
+            merge-mono-src: merge-mono-src-{src_locale}-{trg_locale}
+
+        fetches:
+            merge-mono-src:
+                - artifact: mono.{src_locale}.zst
+                  extract: false
+
+    trg:
+        label: split-mono-trg-{src_locale}-{trg_locale}
+        attributes:
+            dataset-category: mono-trg
+
+        dataset-config:
+            include-categories:
+                - mono-trg
+
+        treeherder:
+            symbol: "trg-{src_locale}-{trg_locale}"
+            platform: split-mono/opt
+
+        dependencies:
+            merge-mono-trg: merge-mono-trg-{src_locale}-{trg_locale}
+
+        fetches:
+            merge-mono-trg:
+                - artifact: mono.{trg_locale}.zst
+                  extract: false

--- a/taskcluster/scripts/pipeline/split-taskcluster.sh
+++ b/taskcluster/scripts/pipeline/split-taskcluster.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+type=$1
+chunks=$2
+output_dir=$3
+length=$4
+lang_args=( "${@:5}" )
+
+pushd `dirname $0`/../../.. &>/dev/null
+VCS_ROOT=$(pwd)
+popd &>/dev/null
+
+if [ "${type}" = "mono" ]; then
+  ${VCS_ROOT}/pipeline/translate/split-mono.sh "${lang_args[@]}" "${output_dir}" "${length}"
+elif [ "${type}" = "corpus" ]; then
+  ${VCS_ROOT}/pipeline/translate/split-corpus.sh "${lang_args[@]}" "${output_dir}" "${length}"
+else
+  echo "Unknown split type: ${type}"
+  exit 1
+fi
+
+# Taskcluster requires a consistent number of chunks; split the resulting files
+# evenly into the requested number of chunks, creating empty archives if there's
+# not enough files to go around.
+cd "${output_dir}"
+ls file* | sort > all-files.txt
+for i in $(seq 1 ${chunks} | tr '\n' ' '); do
+  files=$(split -n l/${i}/${chunks} all-files.txt | tr '\n' ' ')
+  if [ "${files}" = "" ]; then
+    touch "split-file.${i}"
+  else
+    cat ${files} > "split-file.${i}"
+  fi
+  zstd --rm "split-file.${i}"
+done
+
+rm file* all-files.txt

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -38,7 +38,7 @@ defaults = get_defaults("")["training_config"]
 (any stages this choice depends on will be automatically included).""",
                 "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
-                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards"],
+                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono"],
             },
             "experiment": {
                 "type": "object",
@@ -216,6 +216,17 @@ leave empty to skip augmentation step (high resource languages)
                             # TODO
                             # "enum": []
                         },
+                    },
+                },
+            },
+            "taskcluster": {
+                "type": "object",
+                "default": defaults["taskcluster"],
+                "description": "Taskcluster-specific pipeline configuration, eg: chunking",
+                "properties": {
+                    "split-chunks": {
+                        "type": "number",
+                        "description": "The number of chunks (parallel jobs) to use in `split` steps",
                     },
                 },
             },

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -97,6 +97,10 @@ def get_defaults(_):
                     "news-crawl_news.2020",
                 ],
             },
+            # Taskcluster-specific configuration
+            "taskcluster": {
+                "split-chunks": 10,
+            },
         },
     }
 
@@ -134,6 +138,9 @@ extend_parameters_schema(
             },
             Optional("datasets"): {
                 str: [str],
+            },
+            Optional("taskcluster"): {
+                Optional("split-chunks"): int,
             },
         },
     },

--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -171,7 +171,7 @@ def upstreams_for_mono(config, jobs):
         upstreams_config = job.pop("upstreams-config")
         upstream_task_attributes = upstreams_config["upstream-task-attributes"]
         artifacts = upstreams_config["upstream-artifacts"]
-        substitution_fields = upstreams_config["substitution-fields"]
+        substitution_fields = upstreams_config.get("substitution-fields", [])
 
         for task in config.kind_dependencies_tasks.values():
             # Filter out any tasks that don't match the desired attributes.


### PR DESCRIPTION
The new steps are pretty straightforward, I think. The main notes here are:
- Adjusting the new `merge-mono` steps to use `from_datasets` to ensure we get versions of them for all locales (my bad for not catching this in review...)
- The outputs of these new steps getting compressed into a tarball, so we only have to download one artifact in downstream steps. (This makes it easier to specify `fetches` in those downstream tasks, since the number of files these steps generate won't be known until runtime.)

Runs of these are at https://firefox-ci-tc.services.mozilla.com/tasks/groups/VHrihuG6SXmjr3QkzkyUjg and https://firefox-ci-tc.services.mozilla.com/tasks/groups/HEvP_NzJRPKe7e4K_O05vw