### PR TITLE
Implement the remaining `mono-trg` parts of the pipeline in Taskcluster

### DIFF
--- a/pipeline/translate/collect.sh
+++ b/pipeline/translate/collect.sh
@@ -12,12 +12,14 @@ output_path=$2
 mono_path=$3
 
 
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+
 echo "### Collecting translations"
-cat "${dir}"/*.out | pigz >"${output_path}"
+cat "${dir}"/*.out | ${COMPRESSION_CMD} >"${output_path}"
 
 echo "### Comparing number of sentences in source and artificial target files"
-src_len=$(pigz -dc "${mono_path}" | wc -l)
-trg_len=$(pigz -dc "${output_path}" | wc -l)
+src_len=$(${COMPRESSION_CMD} -dc "${mono_path}" | wc -l)
+trg_len=$(${COMPRESSION_CMD} -dc "${output_path}" | wc -l)
 if [ "${src_len}" != "${trg_len}" ]; then
   echo "### Error: length of ${mono_path} ${src_len} is different from ${output_path} ${trg_len}"
   exit 1

--- a/pipeline/translate/merge-corpus.sh
+++ b/pipeline/translate/merge-corpus.sh
@@ -27,23 +27,26 @@ trg2=$4
 res_src=$5
 res_trg=$6
 
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
+
 tmp_dir="$(dirname "${res_src}")/tmp"
 mkdir -p "${tmp_dir}"
 
-cat <(pigz -dc "${src1}") <(pigz -dc "${src2}") | pigz >"${tmp_dir}/original.src.gz"
-cat <(pigz -dc "${trg1}") <(pigz -dc "${trg2}") | pigz >"${tmp_dir}/original.trg.gz"
+cat <(${COMPRESSION_CMD} -dc "${src1}") <(${COMPRESSION_CMD} -dc "${src2}") | ${COMPRESSION_CMD} >"${tmp_dir}/original.src.${ARTIFACT_EXT}"
+cat <(${COMPRESSION_CMD} -dc "${trg1}") <(${COMPRESSION_CMD} -dc "${trg2}") | ${COMPRESSION_CMD} >"${tmp_dir}/original.trg.${ARTIFACT_EXT}"
 
 echo "#### Deduplicating"
-paste <(pigz -dc "${tmp_dir}/original.src.gz") <(pigz -dc "${tmp_dir}/original.trg.gz") |
+paste <(${COMPRESSION_CMD} -dc "${tmp_dir}/original.src.${ARTIFACT_EXT}") <(${COMPRESSION_CMD} -dc "${tmp_dir}/original.trg.${ARTIFACT_EXT}") |
   shuf --random-source=<(get_seeded_random 42) |
   ${BIN}/dedupe |
-  pigz > "${tmp_dir}/all.gz"
+  ${COMPRESSION_CMD} > "${tmp_dir}/all.${ARTIFACT_EXT}"
 
-pigz -dc "${tmp_dir}/all.gz" | cut -f1 | pigz > "${res_src}"
-pigz -dc "${tmp_dir}/all.gz" | cut -f2 | pigz > "${res_trg}"
+${COMPRESSION_CMD} -dc "${tmp_dir}/all.${ARTIFACT_EXT}" | cut -f1 | ${COMPRESSION_CMD} > "${res_src}"
+${COMPRESSION_CMD} -dc "${tmp_dir}/all.${ARTIFACT_EXT}" | cut -f2 | ${COMPRESSION_CMD} > "${res_trg}"
 
-src_len=$(pigz -dc "${res_src}" | wc -l)
-trg_len=$(pigz -dc "${res_trg}" | wc -l)
+src_len=$(${COMPRESSION_CMD} -dc "${res_src}" | wc -l)
+trg_len=$(${COMPRESSION_CMD} -dc "${res_trg}" | wc -l)
 if [ "${src_len}" != "${trg_len}" ]; then
   echo "Error: length of ${res_src} ${src_len} is different from ${res_trg} ${trg_len}"
   exit 1

--- a/taskcluster/ci/collect/kind.yml
+++ b/taskcluster/ci/collect/kind.yml
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:locales_only
+    - translations_taskgraph.transforms.chunking:unchunk
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - merge-mono
+    - translate-mono
+
+task-defaults:
+    attributes:
+        cache:
+            resources:
+                - pipeline/translate/collect.sh
+    dataset-config:
+        substitution-fields:
+            - description
+            - name
+            - treeherder.symbol
+            - chunk-config.per-upstream-fields
+            - run.command
+            - dependencies
+            - fetches
+    worker-type: b-linux-large
+    worker:
+        docker-image: {"in-tree": "train"}
+        max-run-time: 3600
+        artifacts:
+            - name: public/build
+              path: /builds/worker/artifacts
+              type: directory
+        env:
+            COMPRESSION_CMD: zstdmt
+
+    # Don't run unless explicitly scheduled
+    run-on-tasks-for: []
+
+    treeherder:
+        symbol: "{src_locale}-{trg_locale}"
+    run:
+        using: run-task
+        command:
+            - bash
+            - -c
+            - >-
+                zstd -d --rm $MOZ_FETCHES_DIR/split-file* &&
+                $VCS_PATH/pipeline/translate/collect.sh
+                fetches
+                artifacts/mono.{src_locale}.zst
+                $MOZ_FETCHES_DIR/mono.{trg_locale}.zst
+
+tasks:
+    mono-trg-{src_locale}-{trg_locale}:
+        description: collect mono trg {src_locale}-{trg_locale}
+        attributes:
+            dataset-category: mono-trg
+            stage: collect-mono-trg
+            cache:
+                type: collect-mono-trg
+
+        chunk-config:
+            total-chunks:
+                from-parameters: training_config.taskcluster.split-chunks
+            per-upstream-fields:
+                dependencies:
+                    translate-mono-trg-{this_chunk}: translate-mono-trg-{src_locale}-{trg_locale}-{this_chunk}/{total_chunks}
+                fetches:
+                    translate-mono-trg-{this_chunk}:
+                        - artifact: split-file.{this_chunk}.out.zst
+
+        # Don't run unless explicitly scheduled
+        run-on-tasks-for: []
+
+        treeherder:
+            platform: collect-mono-trg/opt
+
+        dependencies:
+            merge-mono-trg: merge-mono-trg-{src_locale}-{trg_locale}
+
+        fetches:
+            merge-mono-trg:
+                - artifact: mono.{trg_locale}.zst

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -121,6 +121,11 @@ workers:
             implementation: generic-worker
             os: linux
             worker-type: '{alias}'
+        t-linux-v100-gpu-4:
+            provisioner: '{trust-domain}-{level}'
+            implementation: generic-worker
+            os: linux
+            worker-type: '{alias}'
         images:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker

--- a/taskcluster/ci/merge-translated/kind.yml
+++ b/taskcluster/ci/merge-translated/kind.yml
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.from_datasets:locales_only
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - merge-mono
+    - merge
+    - collect
+    - toolchain
+
+task-defaults:
+    attributes:
+        cache:
+            resources:
+                - pipeline/translate/merge-corpus.sh
+    dataset-config:
+        substitution-fields:
+            - label
+            - description
+            - name
+            - treeherder.symbol
+            - worker.env
+            - dependencies
+            - fetches
+            - run.command
+    worker-type: b-linux-large
+    worker:
+        docker-image: {"in-tree": "train"}
+        max-run-time: 3600
+        artifacts:
+            - name: public/build
+              path: /builds/worker/artifacts
+              type: directory
+        env:
+            SRC: "{src_locale}"
+            TRG: "{trg_locale}"
+            COMPRESSION_CMD: zstdmt
+            ARTIFACT_EXT: zst
+
+    # Don't run unless explicitly scheduled
+    run-on-tasks-for: []
+
+    treeherder:
+        symbol: "{src_locale}-{trg_locale}"
+
+    run:
+        using: run-task
+        command:
+            - bash
+            - -c
+            - >-
+                export BIN=$MOZ_FETCHES_DIR &&
+                $VCS_PATH/pipeline/translate/merge-corpus.sh
+                $MOZ_FETCHES_DIR/corpus.{src_locale}.zst
+                $MOZ_FETCHES_DIR/mono.{src_locale}.zst
+                $MOZ_FETCHES_DIR/corpus.{trg_locale}.zst
+                $MOZ_FETCHES_DIR/mono.{trg_locale}.zst
+                /builds/worker/artifacts/corpus.{src_locale}.zst
+                /builds/worker/artifacts/corpus.{trg_locale}.zst
+    fetches:
+        toolchain:
+            - preprocess
+
+tasks:
+    merge-augmented:
+        label: merge-augmented-{src_locale}-{trg_locale}
+        description: merge augmented for {src_locale}-{trg_locale}
+        attributes:
+            dataset-category: devtest
+            stage: merge-augmented
+            cache:
+                type: merge-augmented
+
+        treeherder:
+            platform: merge-augmented/opt
+
+        dependencies:
+            merge-corpus: merge-corpus-{src_locale}-{trg_locale}
+            merge-mono-trg: merge-mono-trg-{src_locale}-{trg_locale}
+            collect-mono-trg: collect-mono-trg-{src_locale}-{trg_locale}
+
+        fetches:
+            merge-corpus:
+                - artifact: corpus.{src_locale}.zst
+                - artifact: corpus.{trg_locale}.zst
+            merge-mono-trg:
+                - artifact: mono.{trg_locale}.zst
+            collect-mono-trg:
+                - artifact: mono.{src_locale}.zst

--- a/taskcluster/ci/translate-mono/kind.yml
+++ b/taskcluster/ci/translate-mono/kind.yml
@@ -1,0 +1,122 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.task_substitution_from_params:transforms
+    - translations_taskgraph.transforms.from_datasets:mono
+    - translations_taskgraph.transforms.chunking:chunk
+    - taskgraph.transforms.job:transforms
+    - translations_taskgraph.transforms.cache:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - split-mono
+    - train
+    - train-vocab
+    - toolchain
+
+task-defaults:
+    description: translate mono for {locale}
+    attributes:
+        cache:
+            resources:
+                - pipeline/translate/translate.sh
+                - taskcluster/scripts/pipeline/translate-taskcluster.sh
+            from-parameters:
+                split_chunks: training_config.taskcluster.split-chunks
+
+    dataset-config:
+        substitution-fields:
+            - description
+            - label
+            - treeherder.symbol
+            - fetches.train-backwards
+            - dependencies
+            - worker.env
+
+    task-substitution:
+        from-parameters:
+            best_model: training_config.experiment.best-model
+        substitution-fields:
+            - fetches.train-backwards
+
+    worker-type: t-linux-v100-gpu-4
+
+    worker:
+        max-run-time: 3600
+        artifacts:
+            - name: public/build
+              path: artifacts
+              type: directory
+        env:
+            GPUS: "0 1 2 3"
+            WORKSPACE: "8000"
+            CUDA_DIR: fetches/cuda-toolkit
+            CUDNN_DIR: fetches/cuda-toolkit
+
+    # Don't run unless explicitly scheduled
+    run-on-tasks-for: []
+
+    run:
+        using: run-task
+        command:
+            - bash
+            - -xc
+            - >-
+                export MARIAN=$MOZ_FETCHES_DIR &&
+                $VCS_PATH/taskcluster/scripts/pipeline/translate-taskcluster.sh
+                $MOZ_FETCHES_DIR/split-file.{this_chunk}.zst
+                artifacts
+                $MOZ_FETCHES_DIR/vocab.spm
+                $MOZ_FETCHES_DIR/*.npz
+
+    fetches:
+        toolchain:
+            - marian
+            - cuda-toolkit
+
+tasks:
+    trg:
+        label: translate-mono-trg-{src_locale}-{trg_locale}-{this_chunk}/{total_chunks}
+        attributes:
+            stage: translate-mono-trg
+            dataset-category: mono-trg
+            cache:
+                type: translate-mono-trg
+
+        chunk-config:
+            total-chunks:
+                from-parameters: training_config.taskcluster.split-chunks
+            substitution-fields:
+                - label
+                - treeherder.symbol
+                - fetches.split-mono-trg
+                - run.command
+
+        dataset-config:
+            include-categories:
+                - mono-trg
+
+        treeherder:
+            symbol: "trg-{src_locale}-{trg_locale}-{this_chunk}/{total_chunks}"
+            platform: translate-mono/opt
+
+        dependencies:
+            split-mono-trg: split-mono-trg-{src_locale}-{trg_locale}
+            train-backwards: train-backwards-{src_locale}-{trg_locale}
+            train-vocab: train-vocab-{src_locale}-{trg_locale}
+
+        fetches:
+            split-mono-trg:
+                - artifact: split-file.{this_chunk}.zst
+                  extract: true
+            train-backwards:
+                - artifact: final.model.npz.best-{best_model}.npz
+                  extract: false
+            train-vocab:
+                - artifact: vocab.spm
+                  extract: false

--- a/taskcluster/scripts/pipeline/translate-taskcluster.sh
+++ b/taskcluster/scripts/pipeline/translate-taskcluster.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+input=$1
+output_dir=$2
+other_args=( "${@:3}" )
+
+pushd `dirname $0`/../../.. &>/dev/null
+VCS_ROOT=$(pwd)
+popd &>/dev/null
+
+mkdir -p "${output_dir}"
+
+zstd -d --rm "${input}"
+input="${input%.zst}"
+# In Taskcluster, we always parallelize this step N ways. In rare cases, there
+# may not be enough input files to feed all of these jobs. If we received an
+# empty input file we have nothing to do other than copying the empty file
+# to the output file, simulating successfully completion.
+if [ -s "${input}" ]; then
+  ${VCS_ROOT}/pipeline/translate/translate.sh "${input}" "${other_args[@]}"
+else
+  cp "${input}" "${input}".out
+fi
+
+zstd --rm "${input}.out"
+cp "${input}.out.zst" "${output_dir}"

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -38,7 +38,7 @@ defaults = get_defaults("")["training_config"]
 (any stages this choice depends on will be automatically included).""",
                 "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
-                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono", "translate-mono-trg", "collect-mono-trg"],
+                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono", "translate-mono-trg", "collect-mono-trg", "merge-augmented"],
             },
             "experiment": {
                 "type": "object",

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -38,7 +38,7 @@ defaults = get_defaults("")["training_config"]
 (any stages this choice depends on will be automatically included).""",
                 "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
-                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono"],
+                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono", "translate-mono-trg"],
             },
             "experiment": {
                 "type": "object",

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -38,7 +38,7 @@ defaults = get_defaults("")["training_config"]
 (any stages this choice depends on will be automatically included).""",
                 "default": defaults["target-stage"],
                 # TODO: this should probably be specified in ci/config.yml
-                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono", "translate-mono-trg"],
+                "enum": ["clean-corpus", "clean-mono", "bicleaner", "bicleaner-ai", "merge-corpus", "merge-devset", "merge-mono", "train-vocab", "train-backwards", "evaluate-backwards", "split-corpus", "split-mono", "translate-mono-trg", "collect-mono-trg"],
             },
             "experiment": {
                 "type": "object",

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -13,7 +13,7 @@ from voluptuous import Optional, Required
 def get_defaults(_):
     return {
         "training_config": {
-            "target-stage": "evaluate-backwards",
+            "target-stage": "translate-mono-trg",
             "experiment": {
                 "name": "training pipeline test config",
                 "src": "ru",

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -13,7 +13,7 @@ from voluptuous import Optional, Required
 def get_defaults(_):
     return {
         "training_config": {
-            "target-stage": "translate-mono-trg",
+            "target-stage": "collect-mono-trg",
             "experiment": {
                 "name": "training pipeline test config",
                 "src": "ru",

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -13,7 +13,7 @@ from voluptuous import Optional, Required
 def get_defaults(_):
     return {
         "training_config": {
-            "target-stage": "collect-mono-trg",
+            "target-stage": "merge-augmented",
             "experiment": {
                 "name": "training pipeline test config",
                 "src": "ru",

--- a/taskcluster/translations_taskgraph/transforms/chunking.py
+++ b/taskcluster/translations_taskgraph/transforms/chunking.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import copy
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import Schema, optionally_keyed_by, resolve_keyed_by
+from voluptuous import ALLOW_EXTRA, Required, Optional
+
+from translations_taskgraph.util.dict_helpers import deep_get
+from translations_taskgraph.util.substitution import substitute
+
+SCHEMA = Schema(
+    {
+        Required("chunk-config"): {
+            Required("total-chunks"): {
+                Required("from-parameters"): str,
+            },
+            Optional("substitution-fields"): [str],
+        }
+    },
+    extra=ALLOW_EXTRA,
+)
+
+chunk = TransformSequence()
+chunk.add_validate(SCHEMA)
+
+
+@chunk.add
+def chunk_jobs(config, jobs):
+    for job in jobs:
+        chunk_config = job.pop("chunk-config", None)
+        total_chunks = deep_get(config.params, chunk_config["total-chunks"]["from-parameters"])
+        
+        for this_chunk in range(1, total_chunks + 1):
+            subjob = copy.deepcopy(job)
+            
+            subs = {
+                "this_chunk": this_chunk,
+                "total_chunks": total_chunks,
+            }
+
+            for field in chunk_config["substitution-fields"]:
+                container, subfield = subjob, field
+                while "." in subfield:
+                    f, subfield = subfield.split(".", 1)
+                    container = container[f]
+
+                container[subfield] = substitute(container[subfield], **subs)
+
+            yield subjob

--- a/taskcluster/translations_taskgraph/util/substitution.py
+++ b/taskcluster/translations_taskgraph/util/substitution.py
@@ -1,3 +1,12 @@
+class PartialSubstitutionDict(dict):
+    """A dictionary that will return any missing keys as their formatable 
+       version. Useful when a string needs to be formatted multiple times
+       in different places to get to its final form."""
+
+    def __missing__(self, key):
+        return "{" + key + "}"
+
+
 def substitute(item, **subs):
     if isinstance(item, list):
         for i in range(len(item)):
@@ -5,11 +14,11 @@ def substitute(item, **subs):
     elif isinstance(item, dict):
         new_dict = {}
         for k, v in item.items():
-            k = k.format(**subs)
+            k = k.format_map(PartialSubstitutionDict(subs))
             new_dict[k] = substitute(v, **subs)
         item = new_dict
     elif isinstance(item, str):
-        item = item.format(**subs)
+        item = item.format_map(PartialSubstitutionDict(subs))
     else:
         item = item
 


### PR DESCRIPTION
This adds a few more specific steps: `translate-mono-trg`, `collect-mono-trg`, and `merge-augmented`. In addition to the boring parts in the kinds, there's a few things here:
* Addition of the new 4 GPU workers to the taskgraph config
* Allowing for substitutions to gracefully handle missing values (this lets us format in multiple passes)
* A new transform that handles chunking (one job in the kind turns into many tasks) and unchunking (many upstream tasks fold into one task).

Example run is over here: https://firefox-ci-tc.services.mozilla.com/tasks/groups/Tp4MiAlpQDuUhdlEFEed2A. One thing I noticed in the `merge-augmented` artifacts is that both the `ru` and the `en` versions contain lines partly in one language, and partly in the other. This might be indicative of a problem in one of these steps, or even further upstream....or it may just be a limitation of the limited datasets and sample sizes we use in the test config. Something to look into more - but I don't think it blocks getting these next steps landed.