### PR TITLE
A collection of fixes for the dataset, clean, and merge stages of the pipeline

### DIFF
--- a/pipeline/clean/merge-corpus.sh
+++ b/pipeline/clean/merge-corpus.sh
@@ -23,8 +23,8 @@ mkdir -p "${tmp}"
 
 echo "### Merging"
 if [[ "${inputs[0]}" == *.${ARTIFACT_EXT} ]]; then
-  cat `echo ${inputs[@]} | tr ' ' '\n' | grep ${SRC} | tr '\n' ' '` >"${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}"
-  cat `echo ${inputs[@]} | tr ' ' '\n' | grep ${TRG} | tr '\n' ' '` >"${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}"
+  cat `echo ${inputs[@]} | tr ' ' '\n' | grep "${SRC}.${ARTIFACT_EXT}" | tr '\n' ' '` >"${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}"
+  cat `echo ${inputs[@]} | tr ' ' '\n' | grep "${TRG}.${ARTIFACT_EXT}" | tr '\n' ' '` >"${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}"
 else
   cat "${inputs[@]/%/.${SRC}.${ARTIFACT_EXT}}" >"${tmp}/corpus.${SRC}.dup.${ARTIFACT_EXT}"
   cat "${inputs[@]/%/.${TRG}.${ARTIFACT_EXT}}" >"${tmp}/corpus.${TRG}.dup.${ARTIFACT_EXT}"

--- a/pipeline/data/download-mono.sh
+++ b/pipeline/data/download-mono.sh
@@ -12,6 +12,9 @@ max_sent=$3
 output_path=$4
 coef=0.1
 
+COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+ARTIFACT_EXT="${ARTIFACT_EXT:-gz}"
+
 echo "###### Downloading monolingual data for language ${lang} dataset ${dataset}"
 
 cd "$(dirname "${0}")"
@@ -24,19 +27,19 @@ original_prefix="${tmp}/${dataset}.original.${lang}"
 name=${dataset#*_}
 type=${dataset%%_*}
 
-test -s "${original_prefix}.gz" ||
+test -s "${original_prefix}.${ARTIFACT_EXT}" ||
   bash "importers/mono/${type}.sh" "${lang}" "${original_prefix}" "${name}"
 
 echo "### Sampling dataset"
 # temporary disable pipefail because perl operation causes SIGPIPE (141)
 set +o pipefail
-pigz -dc "${original_prefix}.gz" |
-shuf -n "$(bc -l <<<"${max_sent}+${max_sent}*${coef}")" |
+${COMPRESSION_CMD} -dc "${original_prefix}.${ARTIFACT_EXT}" |
+shuf -n "$(bc -l <<<"scale=0; (${max_sent}+${max_sent}*${coef}) / 1")" |
 perl -ne 'print if(split(/\s/, $_) < 100)' |
 head -n "${max_sent}" |
-pigz >"${output_path}"
+${COMPRESSION_CMD} >"${output_path}"
 set -o pipefail
 
-rm -rf "${original_prefix}.gz"
+rm -rf "${original_prefix}.${ARTIFACT_EXT}"
 
 echo "###### Done: Downloading monolingual data"

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -26,7 +26,7 @@ task-defaults:
                 - pipeline/bicleaner/bicleaner.sh
             from-parameters:
                 bicleaner_threshold:
-                    - training_config.experiment.bicleaner.dataset-thresholds.{provider}_{dataset_sanitized}
+                    - training_config.experiment.bicleaner.dataset-thresholds.{dataset}
                     - training_config.experiment.bicleaner.default-threshold
     dataset-config:
         substitution-fields:
@@ -60,7 +60,7 @@ task-defaults:
         command-context:
             from-parameters:
                 bicleaner_threshold:
-                    - training_config.experiment.bicleaner.dataset-thresholds.{provider}_{dataset_sanitized}
+                    - training_config.experiment.bicleaner.dataset-thresholds.{dataset}
                     - training_config.experiment.bicleaner.default-threshold
         command:
             - bash

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -99,8 +99,8 @@ task-defaults:
               extract: false
 
 tasks:
-    "{provider}-{dataset}-{src_locale}-{trg_locale}":
-        description: bicleaner for {provider} {dataset} dataset {src_locale}-{trg_locale}
+    "{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}":
+        description: bicleaner for {provider} {dataset_sanitized} dataset {src_locale}-{trg_locale}
         worker-type: b-linux-large
         worker:
             docker-image: {"in-tree": "train"}
@@ -126,8 +126,8 @@ tasks:
                 # auto = use `nproc` value
                 bicleaner_threads: auto
 
-    ai-{provider}-{dataset}-{src_locale}-{trg_locale}:
-        description: bicleaner-ai for {provider} {dataset} dataset {src_locale}-{trg_locale}
+    ai-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}:
+        description: bicleaner-ai for {provider} {dataset_sanitized} dataset {src_locale}-{trg_locale}
         worker-type: t-linux-v100-gpu
         worker:
             artifacts:

--- a/taskcluster/ci/clean-corpus/kind.yml
+++ b/taskcluster/ci/clean-corpus/kind.yml
@@ -17,7 +17,7 @@ kind-dependencies:
 
 tasks:
     "{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}":
-        description: Clean {provider} {dataset} dataset {src_locale}-{trg_locale}
+        description: Clean {provider} {dataset_sanitized} dataset {src_locale}-{trg_locale}
         attributes:
             cleaning-type: clean-corpus
             dataset-category: train

--- a/taskcluster/ci/clean-mono/kind.yml
+++ b/taskcluster/ci/clean-mono/kind.yml
@@ -87,8 +87,8 @@ task-defaults:
               extract: false
 
 tasks:
-    "{provider}-{dataset}-mono-src-{src_locale}-{trg_locale}":
-        description: Clean {provider} {dataset} dataset mono-src {locale}
+    "{provider}-{dataset_sanitized}-mono-src-{src_locale}-{trg_locale}":
+        description: Clean {provider} {dataset_sanitized} dataset mono-src {locale}
         attributes:
             dataset-category: mono-src
         treeherder:
@@ -97,8 +97,8 @@ tasks:
             include-categories:
                 - mono-src
 
-    "{provider}-{dataset}-mono-trg-{src_locale}-{trg_locale}":
-        description: Clean {provider} {dataset} dataset mono-trg {locale}
+    "{provider}-{dataset_sanitized}-mono-trg-{src_locale}-{trg_locale}":
+        description: Clean {provider} {dataset_sanitized} dataset mono-trg {locale}
         attributes:
             dataset-category: mono-trg
         treeherder:

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -10,6 +10,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.from_datasets:per_dataset
+    - translations_taskgraph.transforms.command_context_from_params:transforms
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cache:transforms
     - taskgraph.transforms.cached_tasks:transforms
@@ -26,12 +27,15 @@ task-defaults:
             - name
             - label
             - treeherder.symbol
+            - worker.env
     worker:
         docker-image: {in-tree: toolchain-build}
         max-run-time: 1800
         env:
             COMPRESSION_CMD: zstdmt
             ARTIFACT_EXT: zst
+            SRC: "{src_locale}"
+            TRG: "{trg_locale}"
         artifacts:
             - name: public/build
               path: /builds/worker/artifacts
@@ -57,11 +61,15 @@ tasks:
             cache:
                 resources:
                     - pipeline/data/importers/corpus/flores.sh
+                    - pipeline/data/download-corpus.sh
         run:
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/corpus/flores.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset} {dataset}
+                - >-
+                    $VCS_PATH/pipeline/data/download-corpus.sh
+                    {dataset}
+                    /builds/worker/artifacts/{dataset_sanitized}
 
     sacrebleu:
         description: Fetch sacrebleu dataset
@@ -73,11 +81,15 @@ tasks:
             cache:
                 resources:
                     - pipeline/data/importers/corpus/sacrebleu.sh
+                    - pipeline/data/download-corpus.sh
         run:
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/corpus/sacrebleu.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset} {dataset}
+                - >-
+                    $VCS_PATH/pipeline/data/download-corpus.sh
+                    {dataset}
+                    /builds/worker/artifacts/{dataset_sanitized}
 
     opus:
         description: Fetch opus dataset
@@ -90,11 +102,15 @@ tasks:
             cache:
                 resources:
                     - pipeline/data/importers/corpus/opus.sh
+                    - pipeline/data/download-corpus.sh
         run:
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/corpus/opus.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset_sanitized} {dataset}
+                - >-
+                    $VCS_PATH/pipeline/data/download-corpus.sh
+                    {dataset}
+                    /builds/worker/artifacts/{dataset_sanitized}
 
     mtdata:
         description: Fetch mtdata dataset
@@ -106,11 +122,15 @@ tasks:
             cache:
                 resources:
                     - pipeline/data/importers/corpus/mtdata.sh
+                    - pipeline/data/download-corpus.sh
         run:
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/corpus/mtdata.sh {src_locale} {trg_locale} /builds/worker/artifacts/{dataset} {dataset}
+                - >-
+                    $VCS_PATH/pipeline/data/download-corpus.sh
+                    {dataset}
+                    /builds/worker/artifacts/{dataset_sanitized}
 
     news-crawl:
         description: Fetch news-crawl dataset
@@ -122,8 +142,30 @@ tasks:
             cache:
                 resources:
                     - pipeline/data/importers/mono/news-crawl.sh
+                    - pipeline/data/download-mono.sh
+                from-parameters:
+                    max_sent_src:
+                        - training_config.experiment.mono-max-sentences-src
+                    max_sent_trg:
+                        - training_config.experiment.mono-max-sentences-trg
         run:
+            command-context:
+                from-parameters:
+                    max_sent_src:
+                        - training_config.experiment.mono-max-sentences-src
+                    max_sent_trg:
+                        - training_config.experiment.mono-max-sentences-trg
             command:
                 - bash
                 - -c
-                - $VCS_PATH/pipeline/data/importers/mono/news-crawl.sh {src_locale} /builds/worker/artifacts/{dataset_sanitized}.{src_locale} {dataset} && $VCS_PATH/pipeline/data/importers/mono/news-crawl.sh {trg_locale} /builds/worker/artifacts/{dataset_sanitized}.{trg_locale} {dataset}
+                - >-
+                    $VCS_PATH/pipeline/data/download-mono.sh
+                    {dataset}
+                    {src_locale}
+                    {max_sent_src}
+                    /builds/worker/artifacts/{dataset_sanitized}.{src_locale}.zst &&
+                    $VCS_PATH/pipeline/data/download-mono.sh
+                    {dataset}
+                    {trg_locale}
+                    {max_sent_trg}
+                    /builds/worker/artifacts/{dataset_sanitized}.{trg_locale}.zst

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -53,7 +53,7 @@ task-defaults:
 tasks:
     flores:
         description: Fetch flores101 dataset
-        label: dataset-flores-{dataset}-{src_locale}-{trg_locale}
+        label: dataset-flores-{dataset_sanitized}-{src_locale}-{trg_locale}
         dataset-config:
             include-datasets:
                 flores: {}
@@ -73,7 +73,7 @@ tasks:
 
     sacrebleu:
         description: Fetch sacrebleu dataset
-        label: dataset-sacrebleu-{dataset}-{src_locale}-{trg_locale}
+        label: dataset-sacrebleu-{dataset_sanitized}-{src_locale}-{trg_locale}
         dataset-config:
             include-datasets:
                 sacrebleu: {}
@@ -114,7 +114,7 @@ tasks:
 
     mtdata:
         description: Fetch mtdata dataset
-        label: dataset-mtdata-{dataset}-{src_locale}-{trg_locale}
+        label: dataset-mtdata-{dataset_sanitized}-{src_locale}-{trg_locale}
         dataset-config:
             include-datasets:
                 mtdata: {}

--- a/taskcluster/ci/evaluate/kind.yml
+++ b/taskcluster/ci/evaluate/kind.yml
@@ -92,8 +92,8 @@ task-defaults:
             - marian
 
 tasks:
-    backward-{provider}-{dataset}-{src_locale}-{trg_locale}:
-        description: backwards evaluation for {dataset} {src_locale}-{trg_locale}
+    backward-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}:
+        description: backwards evaluation for {dataset_sanitized} {src_locale}-{trg_locale}
         attributes:
             stage: evaluate-backwards
             dataset-category: test

--- a/taskcluster/docker/toolchain-build/Dockerfile
+++ b/taskcluster/docker/toolchain-build/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update -qq \
                           tar \
                           libxml2 \
                           libhunspell-dev \
+                          bc \
     && apt-get clean
 
 RUN locale-gen "$LANG"

--- a/taskcluster/translations_taskgraph/transforms/cache.py
+++ b/taskcluster/translations_taskgraph/transforms/cache.py
@@ -1,3 +1,5 @@
+import itertools
+
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.hash import hash_path
 from taskgraph.util.schema import Schema, optionally_keyed_by, resolve_keyed_by
@@ -44,6 +46,7 @@ def add_cache(config, jobs):
         cache_resources = cache["resources"]
         cache_parameters = cache.get("from-parameters", {})
         digest_data = []
+        digest_data.extend(list(itertools.chain.from_iterable(job["worker"]["command"])))
 
         if cache_resources:
             for r in cache_resources:

--- a/taskcluster/translations_taskgraph/transforms/command_context_from_params.py
+++ b/taskcluster/translations_taskgraph/transforms/command_context_from_params.py
@@ -2,7 +2,7 @@ import copy
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import Schema
-from voluptuous import ALLOW_EXTRA, Required, Any
+from voluptuous import ALLOW_EXTRA, Required, Any, Optional
 
 from translations_taskgraph.util.dict_helpers import deep_get
 
@@ -10,7 +10,7 @@ SCHEMA = Schema(
     {
         Required("run"): {
             Required("command-context"): {
-                Required("from-parameters"): {
+                Optional("from-parameters"): {
                     str: Any([str], str),
                 },
             },
@@ -28,7 +28,7 @@ def render_command(config, jobs):
     for job in jobs:
         subjob = copy.deepcopy(job)
 
-        for param, path in job["run"]["command-context"]["from-parameters"].items():
+        for param, path in job["run"]["command-context"].get("from-parameters", {}).items():
             if isinstance(path, str):
                 value = deep_get(config.params, path)
                 subjob["run"]["command-context"][param] = value

--- a/taskcluster/translations_taskgraph/transforms/from_datasets.py
+++ b/taskcluster/translations_taskgraph/transforms/from_datasets.py
@@ -129,7 +129,7 @@ def jobs_from_datasets(config, jobs):
                     subjob = copy.deepcopy(job)
                     subs = {
                         "provider": provider,
-                        "dataset": dataset,
+                        "dataset": f"{provider}_{dataset}",
                         "dataset_short": shorten_dataset_name(dataset),
                         "dataset_sanitized": sanitize_dataset_name(dataset),
                         "src_locale": pair["src"],
@@ -205,7 +205,7 @@ def jobs_for_mono_datasets(config, jobs):
                     subjob = copy.deepcopy(job)
                     subs = {
                         "provider": provider,
-                        "dataset": dataset,
+                        "dataset": f"{provider}_{dataset}",
                         "dataset_short": shorten_dataset_name(dataset),
                         "dataset_sanitized": sanitize_dataset_name(dataset),
                         "locale": locale,


### PR DESCRIPTION
While I was working on #135 I noticed that the output to `merge-augmented` was a bit odd: it contained partly translated lines rather than fully translated lines. After going through the implemented steps with a fine-toothed comb and comparing them against runs done in the Berlin cluster, I discovered a number of issues that contributed to this, all of which are fixed in this PR:
* We weren't using `download-mono.sh` to pull mono datasets. This meant we were ignoring the sample size that is supposed to be used.
* We weren't applying mono-lingual fixes, because the `dataset` string passed to the download scripts was not in the form of `$provider_$dataset`.
* My earlier changes to `merge-corpus.sh` didn't grep selectively enough -- and caused some src and trg files to be pulled in for _both_ output files (this is what ultimately caused the poor translations mentioned aboved).
* Some bicleaner thresholds were not being respected, because we were looking for them up via `dataset_sanitized` rather than the unaltered `dataset`.

There's a couple of other necessary changes here as well - the only one I'll call out is that `cache.py` will now include the `command`, if present, as part of the digest data. This makes the cache invalidation much better.

Here are test runs for [the mono side of the pipeline](https://firefox-ci-tc.services.mozilla.com/tasks/groups/f2BLnyDASiivEUn7zEFF-A) and [the corpus side of the pipeline](https://firefox-ci-tc.services.mozilla.com/tasks/groups/OL_W33qaSGawYTBW7EPWJQ). The most notable thing here is the BLEU scores in the `evaluate-backwards` steps. With these changes they usually end up around ~12 (which is actually higher than we see in the Berlin cluster run I'm comparing against). Previously they were around ~1 in [jobs such as this one](https://firefox-ci-tc.services.mozilla.com/tasks/cNSp69ypSSy_-MdOambDpQ).