### PR TITLE
Allow Taskcluster to run on pushes to any branch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -59,8 +59,7 @@ tasks:
               $eval: 'tasks_for[:19] == "github-pull-request"'
       in:
           $if: >
-              tasks_for in ["action", "cron"]
-              || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || (repoUrl == "https://github.com/mozilla-releng/staging-firefox-translations-training" && head_branch[:15] == "refs/heads/dev-")))
+              tasks_for in ["action", "cron", "github-push"]
               || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
           then:
               $let:


### PR DESCRIPTION
Normally we try to restrict this to save on resources, but this repository builds very little on push (and what it does build is typically already cached). It sounds like we're going to use branches to help keep track of various experiments as well, so we'll need to be able to build from fairly arbitrary names. (If this becomes problematic at any point we can consider using a prefix for these experiment branches instead.)