### PR TITLE
Adds directories generated by some taskgraph commands to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+artifacts
+docker-contexts
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
When I run `taskgraph test-action-callback` it generates a lot of artifacts that I don't want to commit. I'd rather not see them in diffs / `git status` / etc. 🤷‍♂️