### PR TITLE
Disable automatic retries in the Taskcluster pipeline

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -158,7 +158,7 @@ tasks:
                           'tasks_for == "cron"': low
                           'tasks_for == "github-push"|| isPullRequest': very-low
                           $default: lowest  # tasks_for == 'action'
-                  retries: 5
+                  retries: 0
 
                   payload:
                       $let:


### PR DESCRIPTION
We can retry manually as needed.