### PR TITLE
Add fetches deterministically in `find_upstreams`

### DIFF
--- a/taskcluster/translations_taskgraph/transforms/find_upstreams.py
+++ b/taskcluster/translations_taskgraph/transforms/find_upstreams.py
@@ -108,7 +108,7 @@ def upstreams_for_locales(config, jobs):
         # Now that we've resolved which type of upstream task we want, we need to
         # find all instances of that task for our locale pair, add them to our
         # dependencies, and the necessary artifacts to our fetches.
-        for task in config.kind_dependencies_tasks.values():
+        for task in sorted(config.kind_dependencies_tasks.values(), key=lambda t: t.label):
             # Filter out any tasks that don't match the desired attributes.
             if any(task.attributes.get(k) != v for k, v in upstream_task_attributes.items()):
                 continue
@@ -129,7 +129,7 @@ def upstreams_for_locales(config, jobs):
 
             subjob["dependencies"][task.label] = task.label
             subjob["fetches"].setdefault(task.label, [])
-            for artifact in artifacts:
+            for artifact in sorted(artifacts):
                 subjob["fetches"][task.label].append(
                     {
                         "artifact": artifact.format(**subs),
@@ -156,7 +156,7 @@ def upstreams_for_mono(config, jobs):
         artifacts = upstreams_config["upstream-artifacts"]
         substitution_fields = upstreams_config.get("substitution-fields", [])
 
-        for task in config.kind_dependencies_tasks.values():
+        for task in sorted(config.kind_dependencies_tasks.values(), key=lambda t: t.label):
             # Filter out any tasks that don't match the desired attributes.
             if any(task.attributes.get(k) != v for k, v in upstream_task_attributes.items()):
                 continue
@@ -197,7 +197,7 @@ def upstreams_for_mono(config, jobs):
 
                 container[subfield] = substitute(container[subfield], **subs)
 
-            for artifact in artifacts:
+            for artifact in sorted(artifacts):
                 job["fetches"][task.label].append(
                     {
                         "artifact": artifact.format(**subs),


### PR DESCRIPTION
While working on integrating some upstream `taskgraph` changes I kept getting annoying and difficult to read diffs in some `MOZ_FETCHES` variables. It turns out this is because `find_upstreams` doesn't add these in a deterministic order.

This minor change will make it much easier to reason about taskgraph diffs (especially if you _are_ expecting changes in some fetches).