### PR TITLE
Use the latest Ubuntu for GitHub workflow

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   test-run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository files


### PR DESCRIPTION
The 18.04 version was deprecated. Resolves #169.