### PR TITLE
Test the taskgraph definition is valid

### DIFF
--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -70,3 +70,14 @@ tasks:
             pip install poetry &&
             make lint
     run-on-tasks-for: ["github-push", "github-pull-request"]
+
+  taskgraph-definition:
+      worker-type: b-linux-large
+      worker:
+          docker-image: {in-tree: base}
+          max-run-time: 3600
+      description: "Test the full `translations_taskgraph` to validate the latest changes"
+      run-on-tasks-for: ["github-push", "github-pull-request"]
+      run:
+          command: >-
+              pip3 install -r taskcluster/requirements.txt && taskgraph full


### PR DESCRIPTION
Bonus: I can run `taskgraph target-graph -p taskcluster/test/params/train.yml` to examine the task graph locally.