### PR TITLE
Fix ordering of concatenated .out files to be numerically correct in collect.sh

### DIFF
--- a/pipeline/translate/collect.sh
+++ b/pipeline/translate/collect.sh
@@ -15,7 +15,7 @@ mono_path=$3
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
 
 echo "### Collecting translations"
-cat "${dir}"/*.out | ${COMPRESSION_CMD} >"${output_path}"
+find "${dir}" -name '*.out' | sort -t '.' -k2,2n | xargs cat | ${COMPRESSION_CMD} >"${output_path}"
 
 echo "### Comparing number of sentences in source and artificial target files"
 src_len=$(${COMPRESSION_CMD} -dc "${mono_path}" | wc -l)


### PR DESCRIPTION
fixes #220 

1. `find "${dir}" -name '*.out'`: This will list all the `.out` files in the directory.
2. `sort -t '.' -k2,2n`: This sorts the filenames numerically based on the number after the `.`. The `-t '.'` tells `sort` to use the period as a delimiter, and `-k2,2n` tells it to sort numerically using the second field.
3. `xargs cat`: This takes the sorted list of filenames and uses `cat` to concatenate them.

This change will ensure that `file.10.out` comes after `file.9.out` and so on.