### PR TITLE
Add CI optimizations for training tasks

### DIFF
--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -93,8 +93,6 @@ tasks:
       optimization:
         skip-unless-changed:
             - pipeline/**
-            - envs/**
-            - configs/**
             - taskcluster/**
       run:
           command: >-

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -25,6 +25,11 @@ tasks:
       max-run-time: 3600
       docker-image: {in-tree: test}
     run-on-tasks-for: ["github-push", "github-pull-request"]
+    optimization:
+        skip-unless-changed:
+            - pipeline/**
+            - envs/**
+            - configs/**
     run:
       command:
         - bash
@@ -85,6 +90,12 @@ tasks:
           max-run-time: 3600
       description: "Test the full `translations_taskgraph` to validate the latest changes"
       run-on-tasks-for: ["github-push", "github-pull-request"]
+      optimization:
+        skip-unless-changed:
+            - pipeline/**
+            - envs/**
+            - configs/**
+            - taskcluster/**
       run:
           command: >-
               make validate-taskgraph


### PR DESCRIPTION
I believe this will prevent CI from running training tasks when touching other folders.