### PR TITLE
fix(snakefile): get cuda path from the machine

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,6 @@
 import yaml
 import os
+import subprocess
 
 from snakemake.utils import min_version
 from pipeline.bicleaner import packs
@@ -17,7 +18,7 @@ container: 'Singularity.sif'
 
 install_deps = config['deps'] == 'true'
 data_root_dir = config['root']
-cuda_dir = config['cuda']
+cuda_dir = config.get('cuda', os.path.dirname(os.path.dirname(subprocess.check_output('which nvcc', shell=True).decode().strip())))
 cudnn_dir = config['cudnn']
 gpus_num = config['numgpus']
 # marian occupies all GPUs on a machine if `gpus` are not specified


### PR DESCRIPTION
This is just an idea, and could and probably should be extended to other `tool` variables.

On the University of Zurich slurm cluster, you must run `module load gpu` to make cuda available, and when it is, cuda is set weirdly, like in `/apps/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/cuda-11.8.0-ifsva5xy3gliwzlokewxc5lxklbej3gj` for example.

I don't think this path is persistent, and so I was thinking it would be nicer to just take the path from the machine rather than the config.

(Note: I did not yet successfully run even a `test` job on this cluster, but this was one issue I had to solve)