### PR TITLE
Add taskgraph-diff ci job

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,11 +37,22 @@ tasks:
                   'tasks_for == "github-push"': ${event.ref}
                   'tasks_for == "github-release"': '${event.release.target_commitish}'
                   'tasks_for in ["action", "cron"]': '${push.branch}'
+          base_ref:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
+                  'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
+                  'tasks_for == "github-push"': ${event.ref}
+                  'tasks_for in ["cron", "action"]': '${push.branch}'
           head_ref:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
                   'tasks_for == "github-push"': ${event.ref}
                   'tasks_for in ["cron", "action"]': '${push.branch}'
+          base_sha:
+              $switch:
+                  'tasks_for == "github-push"': '${event.before}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
+                  'tasks_for in ["cron", "action"]': '${push.revision}'
           head_sha:
               $switch:
                   'tasks_for == "github-push"': '${event.after}'
@@ -169,6 +180,8 @@ tasks:
                               # `taskgraph decision` are all on the command line.
                               $merge:
                                   - ${normProjectUpper}_BASE_REPOSITORY: '${baseRepoUrl}'
+                                    ${normProjectUpper}_BASE_REF: '${base_ref}'
+                                    ${normProjectUpper}_BASE_REV: '${base_sha}'
                                     ${normProjectUpper}_HEAD_REPOSITORY: '${repoUrl}'
                                     ${normProjectUpper}_HEAD_REF: '${head_ref}'
                                     ${normProjectUpper}_HEAD_REV: '${head_sha}'
@@ -222,6 +235,8 @@ tasks:
                                         --repository-type=git
                                         --tasks-for='${tasks_for}'
                                         --base-repository='${baseRepoUrl}'
+                                        --base-ref='${base_ref}'
+                                        --base-rev='${base_sha}'
                                         --head-repository='${repoUrl}'
                                         --head-ref='${head_ref}'
                                         --head-rev='${head_sha}'

--- a/Makefile
+++ b/Makefile
@@ -167,9 +167,21 @@ run-tests:
 	poetry install --only tests
 	PYTHONPATH=$$(pwd) poetry run pytest tests
 
-# Validates Task Cluster task graph locally
+# Validates Taskcluster task graph locally
 validate-taskgraph:
 	pip3 install -r taskcluster/requirements.txt && taskgraph full
+
+# Generates diffs of the full taskgraph against $BASE_REV. Any parameters that were
+# different between the current code and $BASE_REV will have their diffs logged to $OUTPUT_DIR.
+diff-taskgraph:
+ifndef OUTPUT_DIR
+	$(error OUTPUT_DIR must be defined)
+endif
+ifndef BASE_REV
+	$(error BASE_REV must be defined)
+endif
+	pip3 install -r taskcluster/requirements.txt
+	taskgraph full -p "taskcluster/test/params" -o "$(OUTPUT_DIR)" --diff "$(BASE_REV)" -J
 
 # Downloads Marian training logs for a Taskcluster task group
 download-logs:

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -6,11 +6,17 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
 task-defaults:
   description: "Run tests"
+  task-context:
+    from-parameters:
+      base_rev: base_rev
+    substitution-fields:
+      - run.command
   run:
     using: run-task
     cwd: '{checkout}'
@@ -119,3 +125,18 @@ tasks:
       run:
           command: >-
               make validate-taskgraph
+
+  taskgraph-diff:
+      expires-after: "90 days"
+      worker-type: b-linux-large
+      worker:
+          docker-image: {in-tree: base}
+          max-run-time: 1200
+      description: "Create diffs of taskgraphs vs. base revision."
+      run-on-tasks-for: ["github-push", "github-pull-request"]
+      optimization:
+        skip-unless-changed:
+            - taskcluster/**
+      run:
+          command: >-
+              make diff-taskgraph BASE_REV={base_rev} OUTPUT_DIR=/builds/worker/artifacts


### PR DESCRIPTION
These task diffs the full JSON graph of a couple of different training runs, comparing a PR against a base revision, or a push against the previous push.
    
It is an informational task designed not to fail even if there are differences. Any parameters that cause changes in the resulting taskgraph will cause an artifact with a diff of the before/after to be generated.

(Marking this as a draft for now - it most likely depends on #275 landing first to function correctly.)