### PR TITLE
Make workers more easily configurable (fixes #254)

### DIFF
--- a/taskcluster/ci/alignments/kind.yml
+++ b/taskcluster/ci/alignments/kind.yml
@@ -39,7 +39,7 @@ tasks:
                 - dependencies
                 - worker.env
                 - attributes
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/bicleaner/kind.yml
+++ b/taskcluster/ci/bicleaner/kind.yml
@@ -106,7 +106,7 @@ task-defaults:
 tasks:
     "{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}":
         description: bicleaner for {provider} {dataset_sanitized} dataset {src_locale}-{trg_locale}
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         worker:
             docker-image: {"in-tree": "train"}
             artifacts:
@@ -131,7 +131,7 @@ tasks:
 
     ai-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}:
         description: bicleaner-ai for {provider} {dataset_sanitized} dataset {src_locale}-{trg_locale}
-        worker-type: b-linux-v100-gpu-4-300gb
+        worker-type: b-largegpu-largedisk
         worker:
             artifacts:
                 - name: public/build

--- a/taskcluster/ci/cefilter/kind.yml
+++ b/taskcluster/ci/cefilter/kind.yml
@@ -39,7 +39,7 @@ tasks:
                 - dependencies
                 - fetches
                 - attributes
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/clean-corpus/kind.yml
+++ b/taskcluster/ci/clean-corpus/kind.yml
@@ -44,7 +44,7 @@ tasks:
             substitution-fields:
                 - description
                 - worker.env
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         dataset-config:
             category: train
             substitution-fields:

--- a/taskcluster/ci/clean-mono/kind.yml
+++ b/taskcluster/ci/clean-mono/kind.yml
@@ -46,7 +46,7 @@ task-defaults:
                         - pipeline/clean/tools/remove-non-printing-char.perl
                         - pipeline/clean/tools/clean_mono.py
                         - pipeline/clean/tools/langid_fasttext.py
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     dataset-config:
         substitution-fields:
             - description

--- a/taskcluster/ci/collect-corpus/kind.yml
+++ b/taskcluster/ci/collect-corpus/kind.yml
@@ -53,7 +53,7 @@ tasks:
                 merge-corpus:
                     - artifact: corpus.{trg_locale}.zst
 
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/collect-mono-src/kind.yml
+++ b/taskcluster/ci/collect-mono-src/kind.yml
@@ -34,7 +34,7 @@ task-defaults:
             - dependencies
             - fetches
             - attributes
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/collect-mono-trg/kind.yml
+++ b/taskcluster/ci/collect-mono-trg/kind.yml
@@ -34,7 +34,7 @@ task-defaults:
             - dependencies
             - fetches
             - attributes
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -16,36 +16,46 @@ taskgraph:
 
 workers:
     aliases:
-        b-linux-large:
+        # Use for quick tasks that don't require GPUs, eg: linting, tests
+        b-cpu:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: '{alias}-gcp'
-        b-linux-large-300gb:
+            worker-type: 'b-linux-large-gcp'
+        # Use for tasks that don't require GPUs, but need lots of disk space
+        # eg: dataset cleaning & merging
+        b-cpu-largedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
             worker-type: 'b-linux-large-gcp-300gb'
-        b-linux-v100-gpu:
+        # Use for quick tasks that need a GPU, eg: evaluate
+        b-gpu:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker
             os: linux
-            worker-type: '{alias}'
-        b-linux-v100-gpu-4:
+            worker-type: 'b-linux-v100-gpu'
+        # Use for tasks that need lots of GPU power, but not lots of disk space
+        # eg: translation & scoring
+        b-largegpu:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker
             os: linux
-            worker-type: '{alias}'
-        b-linux-v100-gpu-4-300gb:
+            worker-type: 'b-linux-v100-gpu-4'
+        # Use for tasks that needs lots of GPU power and increased disk space
+        # eg: bicleaner
+        b-largegpu-largedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker
             os: linux
-            worker-type: '{alias}'
-        b-linux-v100-gpu-4-1tb:
+            worker-type: 'b-linux-v100-gpu-4-300gb'
+        # Use for tasks that need lots of GPU power and immensive amounts of disk space
+        # eg: training
+        b-largegpu-xlargedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker
             os: linux
-            worker-type: '{alias}'
+            worker-type: 'b-linux-v100-gpu-4-1tb'
         images:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -61,3 +61,26 @@ workers:
             implementation: docker-worker
             os: linux
             worker-type: '{alias}-gcp'
+
+# Keys are worker type, and align with the `worker-type` entries in the
+# `worker.aliases` above.
+worker-configuration:
+    b-linux-v100-gpu:
+        env:
+            GPUS: "0"
+            WORKSPACE: "12000"
+
+    b-linux-v100-gpu-4:
+        env:
+            GPUS: "0 1 2 3"
+            WORKSPACE: "12000"
+
+    b-linux-v100-gpu-4-300gb:
+        env:
+            GPUS: "0 1 2 3"
+            WORKSPACE: "12000"
+
+    b-linux-v100-gpu-4-1tb:
+        env:
+            GPUS: "0 1 2 3"
+            WORKSPACE: "12000"

--- a/taskcluster/ci/dataset/kind.yml
+++ b/taskcluster/ci/dataset/kind.yml
@@ -16,7 +16,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 task-defaults:
-    worker-type: b-linux-large
+    worker-type: b-cpu
     attributes:
         cache:
             type: dataset

--- a/taskcluster/ci/evaluate-quantized/kind.yml
+++ b/taskcluster/ci/evaluate-quantized/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.from_datasets:per_dataset
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
@@ -62,8 +63,6 @@ task-defaults:
         env:
             SRC: "{src_locale}"
             TRG: "{trg_locale}"
-            GPUS: "0"
-            WORKSPACE: "8000"
             COMPRESSION_CMD: zstdmt
             ARTIFACT_EXT: zst
 

--- a/taskcluster/ci/evaluate-quantized/kind.yml
+++ b/taskcluster/ci/evaluate-quantized/kind.yml
@@ -51,7 +51,7 @@ task-defaults:
             # but in practice we have not been able to make this work.
             pipeline_setup: >-
 
-    worker-type: b-linux-v100-gpu
+    worker-type: b-gpu
     expires-after: "90 days"
     worker:
         artifacts:

--- a/taskcluster/ci/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/ci/evaluate-teacher-ensemble/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.from_datasets:per_dataset
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.from_deps
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
@@ -53,8 +54,6 @@ task-defaults:
         env:
             SRC: "{src_locale}"
             TRG: "{trg_locale}"
-            GPUS: "0"
-            WORKSPACE: "8000"
             COMPRESSION_CMD: zstdmt
             ARTIFACT_EXT: zst
 

--- a/taskcluster/ci/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/ci/evaluate-teacher-ensemble/kind.yml
@@ -42,7 +42,7 @@ task-defaults:
             best_model: training_config.experiment.best-model
             src_locale: training_config.experiment.src
             trg_locale: training_config.experiment.trg
-    worker-type: b-linux-v100-gpu
+    worker-type: b-gpu
     expires-after: "90 days"
     worker:
         artifacts:

--- a/taskcluster/ci/evaluate/kind.yml
+++ b/taskcluster/ci/evaluate/kind.yml
@@ -47,7 +47,7 @@ task-defaults:
             src_locale: training_config.experiment.src
             trg_locale: training_config.experiment.trg
             split_chunks: training_config.experiment.teacher-ensemble
-    worker-type: b-linux-v100-gpu
+    worker-type: b-gpu
     expires-after: "90 days"
     worker:
         artifacts:

--- a/taskcluster/ci/evaluate/kind.yml
+++ b/taskcluster/ci/evaluate/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.from_datasets:per_dataset
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - translations_taskgraph.transforms.cast_to
     - taskgraph.transforms.chunking
@@ -58,8 +59,6 @@ task-defaults:
         env:
             SRC: "{src_locale}"
             TRG: "{trg_locale}"
-            GPUS: "0"
-            WORKSPACE: "12000"
             COMPRESSION_CMD: zstdmt
             ARTIFACT_EXT: zst
 

--- a/taskcluster/ci/export/kind.yml
+++ b/taskcluster/ci/export/kind.yml
@@ -41,7 +41,7 @@ tasks:
                 - worker.env
                 - attributes
         expires-after: "90 days"
-        worker-type: b-linux-large
+        worker-type: b-cpu
         worker:
             docker-image: {"in-tree": "train"}
             max-run-time: 86400

--- a/taskcluster/ci/extract-best/kind.yml
+++ b/taskcluster/ci/extract-best/kind.yml
@@ -57,7 +57,7 @@ tasks:
                 - fetches
                 - run.command
 
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/finetune-student/kind.yml
+++ b/taskcluster/ci/finetune-student/kind.yml
@@ -53,7 +53,7 @@ tasks:
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
 
-        worker-type: b-linux-v100-gpu-4-1tb
+        worker-type: b-largegpu-xlargedisk
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/finetune-student/kind.yml
+++ b/taskcluster/ci/finetune-student/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
@@ -58,13 +59,6 @@ tasks:
         worker:
             max-run-time: 2592000
             env:
-                # TODO: what should we _actually_ use for the workspace value?
-                # and should we centralize this, since it seems to depend on available
-                # memory?
-                WORKSPACE: "12000"
-                # TODO: this needs to be updated, ideally to have the script detect
-                # GPUs. it should _always_ be aligned with the # of GPUs on the intsance
-                GPUS: "0 1 2 3"
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
             artifacts:

--- a/taskcluster/ci/merge-corpus/kind.yml
+++ b/taskcluster/ci/merge-corpus/kind.yml
@@ -51,7 +51,7 @@ task-defaults:
         upstream-artifacts:
             - "{dataset_sanitized}.{src_locale}.zst"
             - "{dataset_sanitized}.{trg_locale}.zst"
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/merge-devset/kind.yml
+++ b/taskcluster/ci/merge-devset/kind.yml
@@ -51,7 +51,7 @@ task-defaults:
         upstream-artifacts:
             - "{dataset_sanitized}.{src_locale}.zst"
             - "{dataset_sanitized}.{trg_locale}.zst"
-    worker-type: b-linux-large
+    worker-type: b-cpu
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -46,7 +46,7 @@ task-defaults:
         upstream-artifacts:
             - "{dataset_sanitized}.{locale}.zst"
 
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: { "in-tree": "train" }

--- a/taskcluster/ci/merge-translated/kind.yml
+++ b/taskcluster/ci/merge-translated/kind.yml
@@ -38,7 +38,7 @@ task-defaults:
             - fetches
             - run.command
             - attributes
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/quantize/kind.yml
+++ b/taskcluster/ci/quantize/kind.yml
@@ -45,7 +45,7 @@ tasks:
                 - fetches.finetune-student
                 - run.command
                 - attributes
-        worker-type: b-linux-large
+        worker-type: b-cpu
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/score/kind.yml
+++ b/taskcluster/ci/score/kind.yml
@@ -6,6 +6,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms

--- a/taskcluster/ci/score/kind.yml
+++ b/taskcluster/ci/score/kind.yml
@@ -43,7 +43,7 @@ tasks:
                 - attributes
                 - run.command
 
-        worker-type: b-linux-v100-gpu-4
+        worker-type: b-largegpu
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/split-corpus/kind.yml
+++ b/taskcluster/ci/split-corpus/kind.yml
@@ -43,7 +43,7 @@ tasks:
                 - dependencies
                 - attributes
                 - run.command
-        worker-type: b-linux-large-300gb
+        worker-type: b-cpu-largedisk
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/split-mono-src/kind.yml
+++ b/taskcluster/ci/split-mono-src/kind.yml
@@ -42,7 +42,7 @@ task-defaults:
             - attributes
             - run.command
 
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: { "in-tree": "train" }

--- a/taskcluster/ci/split-mono-trg/kind.yml
+++ b/taskcluster/ci/split-mono-trg/kind.yml
@@ -42,7 +42,7 @@ task-defaults:
             - attributes
             - run.command
 
-    worker-type: b-linux-large-300gb
+    worker-type: b-cpu-largedisk
     expires-after: "90 days"
     worker:
         docker-image: { "in-tree": "train" }

--- a/taskcluster/ci/tests/kind.yml
+++ b/taskcluster/ci/tests/kind.yml
@@ -26,7 +26,7 @@ tasks:
     # Ensure that the snakemake workflow is still executing correctly, even though
     # taskcluster is the preferred execution environment.
     expires-after: "90 days"
-    worker-type: b-linux-large
+    worker-type: b-cpu
     worker:
       max-run-time: 3600
       docker-image: {in-tree: test}
@@ -59,7 +59,7 @@ tasks:
   black:
     # Run python's black formatter, which formats python files.
     expires-after: "90 days"
-    worker-type: b-linux-large
+    worker-type: b-cpu
     worker:
       max-run-time: 3600
       docker-image: {in-tree: test}
@@ -75,7 +75,7 @@ tasks:
   lint:
     # Run ruff, a python linter.
     expires-after: "90 days"
-    worker-type: b-linux-large
+    worker-type: b-cpu
     worker:
       max-run-time: 3600
       docker-image: {in-tree: test}
@@ -91,7 +91,7 @@ tasks:
   test:
     # Run unit tests
     expires-after: "90 days"
-    worker-type: b-linux-large
+    worker-type: b-cpu
     worker:
       max-run-time: 3600
       docker-image: {in-tree: test}
@@ -112,7 +112,7 @@ tasks:
 
   taskgraph-definition:
       expires-after: "90 days"
-      worker-type: b-linux-large
+      worker-type: b-cpu
       worker:
           docker-image: {in-tree: base}
           max-run-time: 3600
@@ -128,7 +128,7 @@ tasks:
 
   taskgraph-diff:
       expires-after: "90 days"
-      worker-type: b-linux-large
+      worker-type: b-cpu
       worker:
           docker-image: {in-tree: base}
           max-run-time: 1200

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -13,7 +13,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 task-defaults:
-    worker-type: b-linux-large
+    worker-type: b-cpu
     expires-after: "90 days"
     worker:
         docker-image: {"in-tree": "toolchain-build"}
@@ -36,7 +36,7 @@ tasks:
 
     marian:
         description: Marian
-        worker-type: b-linux-large
+        worker-type: b-cpu
         run:
             script: build-marian.sh
             resources:
@@ -51,7 +51,7 @@ tasks:
 
     browsermt-marian:
         description: Browsermt Marian
-        worker-type: b-linux-large
+        worker-type: b-cpu
         run:
             script: build-marian.sh
             arguments:

--- a/taskcluster/ci/train-backwards/kind.yml
+++ b/taskcluster/ci/train-backwards/kind.yml
@@ -51,7 +51,7 @@ tasks:
                 - dependencies
                 - attributes
                 - run.command
-        worker-type: b-linux-v100-gpu-4-300gb
+        worker-type: b-largegpu-largedisk
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/train-backwards/kind.yml
+++ b/taskcluster/ci/train-backwards/kind.yml
@@ -8,6 +8,7 @@ loader: taskgraph.loader.transform:loader
 transforms:
     - translations_taskgraph.transforms.training_continuation:transforms
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
@@ -56,13 +57,6 @@ tasks:
         worker:
             max-run-time: 2592000
             env:
-                # TODO: what should we _actually_ use for the workspace value?
-                # and should we centralize this, since it seems to depend on available
-                # memory?
-                WORKSPACE: "12000"
-                # TODO: this needs to be updated, ideally to have the script detect
-                # GPUs. it should _always_ be aligned with the # of GPUs on the intsance
-                GPUS: "0 1 2 3"
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
             artifacts:

--- a/taskcluster/ci/train-student/kind.yml
+++ b/taskcluster/ci/train-student/kind.yml
@@ -47,7 +47,7 @@ tasks:
                     - pipeline/train/train.sh
                 from-parameters:
                     marian_args: training_config.marian-args.training-student
-        worker-type: b-linux-v100-gpu-4-1tb
+        worker-type: b-largegpu-xlargedisk
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/train-student/kind.yml
+++ b/taskcluster/ci/train-student/kind.yml
@@ -7,6 +7,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - taskgraph.transforms.job:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
@@ -52,13 +53,6 @@ tasks:
         worker:
             max-run-time: 2592000
             env:
-                # TODO: what should we _actually_ use for the workspace value?
-                # and should we centralize this, since it seems to depend on available
-                # memory?
-                WORKSPACE: "12000"
-                # TODO: this needs to be updated, ideally to have the script detect
-                # GPUs. it should _always_ be aligned with the # of GPUs on the intsance
-                GPUS: "0 1 2 3"
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
             artifacts:

--- a/taskcluster/ci/train-teacher/kind.yml
+++ b/taskcluster/ci/train-teacher/kind.yml
@@ -69,7 +69,7 @@ tasks:
                     marian_args: training_config.marian-args.training-teacher
                     teacher-ensemble: training_config.experiment.teacher-ensemble
                     pretrained_teacher: training_config.experiment.pretrained-models.train-teacher
-        worker-type: b-linux-v100-gpu-4-1tb
+        worker-type: b-largegpu-xlargedisk
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/train-teacher/kind.yml
+++ b/taskcluster/ci/train-teacher/kind.yml
@@ -8,6 +8,7 @@ loader: taskgraph.loader.transform:loader
 transforms:
     - translations_taskgraph.transforms.training_continuation:transforms
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - translations_taskgraph.transforms.cast_to
     - taskgraph.transforms.chunking
@@ -74,13 +75,6 @@ tasks:
         worker:
             max-run-time: 2592000
             env:
-                # TODO: what should we _actually_ use for the workspace value?
-                # and should we centralize this, since it seems to depend on available
-                # memory?
-                WORKSPACE: "12000"
-                # TODO: this needs to be updated, ideally to have the script detect
-                # GPUs. it should _always_ be aligned with the # of GPUs on the intsance
-                GPUS: "0 1 2 3"
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
             artifacts:

--- a/taskcluster/ci/train-vocab/kind.yml
+++ b/taskcluster/ci/train-vocab/kind.yml
@@ -43,7 +43,7 @@ tasks:
                 - dependencies
                 - attributes
                 - run.command
-        worker-type: b-linux-large
+        worker-type: b-cpu
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}

--- a/taskcluster/ci/translate-corpus/kind.yml
+++ b/taskcluster/ci/translate-corpus/kind.yml
@@ -88,7 +88,7 @@ tasks:
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
 
-        worker-type: b-linux-v100-gpu-4-1tb
+        worker-type: b-largegpu-xlargedisk
         expires-after: "90 days"
         worker:
             max-run-time: 2592000

--- a/taskcluster/ci/translate-corpus/kind.yml
+++ b/taskcluster/ci/translate-corpus/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - translations_taskgraph.transforms.cast_to
     - taskgraph.transforms.chunking
@@ -97,8 +98,6 @@ tasks:
                   path: artifacts
                   type: directory
             env:
-                GPUS: "0 1 2 3"
-                WORKSPACE: "12000"
                 CUDA_DIR: fetches/cuda-toolkit
                 CUDNN_DIR: fetches/cuda-toolkit
 

--- a/taskcluster/ci/translate-mono-src/kind.yml
+++ b/taskcluster/ci/translate-mono-src/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - translations_taskgraph.transforms.cast_to
     - taskgraph.transforms.chunking
@@ -50,8 +51,6 @@ task-defaults:
               path: artifacts
               type: directory
         env:
-            GPUS: "0 1 2 3"
-            WORKSPACE: "12000"
             CUDA_DIR: fetches/cuda-toolkit
             CUDNN_DIR: fetches/cuda-toolkit
 

--- a/taskcluster/ci/translate-mono-src/kind.yml
+++ b/taskcluster/ci/translate-mono-src/kind.yml
@@ -41,7 +41,7 @@ task-defaults:
             - worker.env
             - attributes
 
-    worker-type: b-linux-v100-gpu-4
+    worker-type: b-largegpu
     expires-after: "90 days"
     worker:
         max-run-time: 2592000

--- a/taskcluster/ci/translate-mono-trg/kind.yml
+++ b/taskcluster/ci/translate-mono-trg/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.marian_args:transforms
+    - translations_taskgraph.transforms.worker_env
     - taskgraph.transforms.task_context
     - translations_taskgraph.transforms.cast_to
     - taskgraph.transforms.chunking
@@ -57,8 +58,6 @@ task-defaults:
               path: artifacts
               type: directory
         env:
-            GPUS: "0 1 2 3"
-            WORKSPACE: "12000"
             CUDA_DIR: fetches/cuda-toolkit
             CUDNN_DIR: fetches/cuda-toolkit
 

--- a/taskcluster/ci/translate-mono-trg/kind.yml
+++ b/taskcluster/ci/translate-mono-trg/kind.yml
@@ -48,7 +48,7 @@ task-defaults:
     marian-args:
         from-parameters: training_config.marian-args.decoding-backward
 
-    worker-type: b-linux-v100-gpu-4
+    worker-type: b-largegpu
     expires-after: "90 days"
     worker:
         max-run-time: 2592000

--- a/taskcluster/translations_taskgraph/transforms/worker_env.py
+++ b/taskcluster/translations_taskgraph/transforms/worker_env.py
@@ -1,0 +1,31 @@
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def inject_worker_env(config, jobs):
+    for job in jobs:
+        # It's called worker-type in jobs, but in reality it's an alias resolved in the graph config...
+        worker_alias = job["worker-type"]
+
+        worker_definition = config.graph_config["workers"]["aliases"].get(worker_alias)
+        if not worker_definition:
+            raise Exception(f"Couldn't find worker definition for {worker_alias} in graph config!")
+
+        worker_type = worker_definition["worker-type"]
+        worker_config = config.graph_config["worker-configuration"].get(worker_type)
+        if not worker_config:
+            raise Exception(
+                f"Couldn't find worker configuration for {worker_type} in graph config!"
+            )
+
+        worker_env = worker_config["env"]
+        if "GPUS" not in worker_env or "WORKSPACE" not in worker_env:
+            raise Exception(
+                "GPUS and/or WORKSPACE values missing from worker env, this is probably misconfiguration."
+            )
+
+        job["worker"]["env"].update(worker_env)
+
+        yield job


### PR DESCRIPTION
Two things here, more fully described in the individual commit messages
- Make worker aliases more abstract
- Move GPUS/WORKSPACE definitions to `config.yml`

With these two things, it should be easy to switch between GCP and on-prem, or add in new types of GCP machines to try out. We just need `worker-definition` entries for each new `worker-type`, and to switch out the `worker-type` in each of the worker `aliases` blocks.