### PR TITLE
Add documentation to various parts of the scripts and pipeline

### DIFF
--- a/configs/tc.prod.yml
+++ b/configs/tc.prod.yml
@@ -1,9 +1,154 @@
 # Example of a production config for Taskcluster
+#
+# See the training guide for more information:
+#   https://mozilla.github.io/firefox-translations-training/training-guide.html
+#
+# The defaults for these parameters are available at:
+#   taskcluster/translations_taskgraph/parameters.py
+
+# An "experiment" is an individual training run.
+experiment:
+  # Provide an identifiable name for your experiment.
+  name: baseline_en_ru
+
+  # The source and target languages. This is the language tag part of the
+  # BCP 47 locale identifier.
+  src: en
+  trg: ru
+
+  # The metric to use for computing the best model validation.
+  #   cross-entropy, ce-mean-words, perplexity, valid-script, translation, bleu,
+  #   bleu-segmented, chrf
+  # See: https://github.com/marian-nmt/marian/blob/65bf82ffce52f4854295d8b98482534f176d494e/src/common/config_parser.cpp#L588-L592
+  best-model: chrf
+
+  # Use the Opus Cleaner tool on the data cleaning step.
+  # https://github.com/hplt-project/OpusCleaner
+  use-opuscleaner: "true"
+
+  # Bicleaner is a tool that aims at detecting noisy sentence pairs in a parallel corpus.
+  # It indicates the likelihood of a pair of sentences being mutual translations (with a
+  # value near to 1) or not (with a value near to 0). Sentence pairs considered very
+  # noisy are scored with 0. Bicleaner AI will be used first if the language is
+  # available, otherwise it will fallback to the original non-AI Bicleaner.
+  #
+  # See:
+  #   https://github.com/bitextor/bicleaner-ai
+  #   https://github.com/bitextor/bicleaner
+  #
+  # For supported languages see:
+  #   https://github.com/bitextor/bicleaner-ai-data/releases
+  #   https://github.com/bitextor/bicleaner-data/releases
+  #
+  # New language releases are added to: taskcluster/ci/fetch/bicleaner.yml
+  bicleaner:
+    default-threshold: 0.5
+    dataset-thresholds:
+      opus_CCAligned/v1: 0.7
+      opus_LinguaTools-WikiTitles/v2014: 0.7
+      opus_OpenSubtitles/v2018: 0.8             # Example of a higher filtering level.
+      opus_ParaCrawl/v9: 0.0                    # Example of cleaning being disabled.
+      opus_WikiMatrix/v1: 0.7
+      opus_bible-uedin/v1: 0.7
+
+  # Limits the maximum sentences use in the monolingual data for both the source and target
+  # languages.
+  mono-max-sentences-src: 100_000_000
+  mono-max-sentences-trg: 20_000_000
+
+  # The number of sentences split out into separate files for the monolingual data.
+  # Also see taskcluster.split-chunks below.
+  split-length: 2_000_000
+
+  # How many bytes of the corpus are sampled to be used in SentencePiece
+  # tokenization training.
+  spm-sample-size: 10_000_000
+
+  # How big the vocab will be. The vocab is shared between the source and the
+  # target languages.
+  #
+  # In "Finding the Optimal Vocabulary Size for Neural Machine Translation", the
+  # researchers tests vocab sizes between 500 and 64,000. A general value table
+  # depends on the vocabulary size.
+  #
+  # | Corpus Size | Optimal vocab size |
+  # | ----------- | ------------------ |
+  # |   4,500,000 |    32,000 - 64,000 |
+  # |   1,000,000 |              8,000 |
+  # |     500,000 |     4,000 - 16,000 |
+  # |      30,000 |              1,000 |
+  #
+  # See section 4 for their conclusions.
+  #   https://aclanthology.org/2020.findings-emnlp.352.pdf
+  #
+  # The larger the vocab, the slower the training and the inference will be as each
+  # token in the vocab contributes to the amount of probabilities that will need
+  # to be generated when making a token prediction. This is a trade off on the quality
+  # of the translation, and the performance.
+  spm-vocab-size: 32_000
+
+  # Determine how many teachers to train. The teachers will be identical except they
+  # will be initialized with different random seeds. This has been shown to improve
+  # the performance during student distillation, as the translation probabilities will
+  # be combined from both models.
+  #
+  # While our current implementation only changes seeds, it's also possible to have
+  # ensembles that use different configurations or are trained on different datasets.
+  #
+  # Recommendations information from: https://nbogoychev.com/efficient-machine-translation/#ensembling
+  #
+  #   One very easy way to improve translation quality of the teacher is to produce an
+  #   ensemble of systems that produce translation together. This is done by training
+  #   identical systems, initialising them with different random seed. The more systems,
+  #   the better, although returns are diminishing.
+  #
+  #   For example, if we want to have an ensemble of two systems, we need to separate
+  #   configuration files for training, where the seed parameter is different.
+  #   Configuration one would have seed: 1111, whereas configuration two would have
+  #   seed: 2222.
+  teacher-ensemble: 2
+
+  # Path to a pretrained backward model (optional).
+  backward-model: NOT-YET-SUPPORTED
+
+  # Path to a pretrained vocabulary (optional).
+  vocab: NOT-YET-SUPPORTED
+
+# The lists of datasets. Each dataset is defined by a corpus key. This key is formed
+# by "{IMPORTER}_{DATASET}". These datasets and their corpus key can be found through
+#
+# TODO(docs) - Document augmentation in corpus keys.
+#
+# To find datasets run:
+#  poetry run utils/find_corpus.py en ru
 datasets:
+  # The datasets used for validation while training. These should not be the same
+  # ones used in test or train. This is what is used to determine when to stop training.
   devtest:
     - flores_dev
     - sacrebleu_wmt08
     - mtdata_Neulab-tedtalks_dev-1-eng-hun
+
+  # The datasets used for the final evaluation to determine the quality of the trained
+  # model.
+  test:
+    - flores_devtest
+    - sacrebleu_wmt09
+    - mtdata_Neulab-tedtalks_test-1-eng-hun
+
+  # The parallel training data.
+  train:
+    - opus_Books/v1
+    - opus_CCAligned/v1
+    - opus_CCMatrix/v1
+    - opus_DGT/v2019
+    - opus_ECB/v1
+    - opus_ECDC/v2016-03-16
+    - opus_ELITR-ECA/v1
+    - opus_ELRC-2019-EUIPO_2017/v1
+    - opus_ELRC-2715-EMEA/v1
+
+  # Monolingual data sources for the source language.
   mono-src:
     - news-crawl_news.2021
     - news-crawl_news.2020
@@ -20,6 +165,8 @@ datasets:
     - news-crawl_news.2009
     - news-crawl_news.2008
     - news-crawl_news.2007
+
+  # Monolingual data sources for the target language.
   mono-trg:
     - news-crawl_news.2021
     - news-crawl_news.2020
@@ -36,107 +183,10 @@ datasets:
     - news-crawl_news.2009
     - news-crawl_news.2008
     - news-crawl_news.2007
-  test:
-    - flores_devtest
-    - sacrebleu_wmt09
-    - mtdata_Neulab-tedtalks_test-1-eng-hun
-  train:
-    - opus_Books/v1
-    - opus_CCAligned/v1
-    - opus_CCMatrix/v1
-    - opus_DGT/v2019
-    - opus_ECB/v1
-    - opus_ECDC/v2016-03-16
-    - opus_ELITR-ECA/v1
-    - opus_ELRC-2019-EUIPO_2017/v1
-    - opus_ELRC-2715-EMEA/v1
-    - opus_ELRC-2744-vaccination/v1
-    - opus_ELRC-2876-EU_publications_medi/v1
-    - opus_ELRC-3064-wikipedia_health/v1
-    - opus_ELRC-3203-antibiotic/v1
-    - opus_ELRC-3294-EUROPARL_covid/v1
-    - opus_ELRC-3465-EC_EUROPA_covid/v1
-    - opus_ELRC-3566-EUR_LEX_covid/v1
-    - opus_ELRC-3607-presscorner_covid/v1
-    - opus_ELRC-5067-SciPar/v1
-    - opus_ELRC-EC_EUROPA/v1
-    - opus_ELRC-EMEA/v1
-    - opus_ELRC-EUIPO_2017/v1
-    - opus_ELRC-EUROPARL_covid/v1
-    - opus_ELRC-EUR_LEX/v1
-    - opus_ELRC-EU_publications/v1
-    - opus_ELRC-antibiotic/v1
-    - opus_ELRC-presscorner_covid/v1
-    - opus_ELRC-vaccination/v1
-    - opus_ELRC-wikipedia_health/v1
-    - opus_ELRC_2922/v1
-    - opus_ELRC_2923/v1
-    - opus_ELRC_3382/v1
-    - opus_EMEA/v3
-    - opus_EUbookshop/v2
-    - opus_EUconst/v1
-    - opus_Europarl/v8
-    - opus_GNOME/v1
-    - opus_GlobalVoices/v2018q4
-    - opus_JRC-Acquis/v3.0
-    - opus_KDE4/v2
-    - opus_LinguaTools-WikiTitles/v2014
-    - opus_NeuLab-TedTalks/v1
-    - opus_OpenSubtitles/v2018
-    - opus_PHP/v1
-    - opus_ParaCrawl/v9
-    - opus_QED/v2.0a
-    - opus_TED2020/v1
-    - opus_Tatoeba/v2022-03-03
-    - opus_TildeMODEL/v2018
-    - opus_Ubuntu/v14.10
-    - opus_WikiMatrix/v1
-    - opus_Wikipedia/v1.0
-    - opus_XLEnt/v1.2
-    - opus_bible-uedin/v1
-    - opus_wikimedia/v20210402
-    - mtdata_ELRC-antibiotic-1-eng-hun
-    - mtdata_ELRC-ec_europa_covid-1-eng-hun
-    - mtdata_ELRC-emea-1-eng-hun
-    - mtdata_ELRC-eu_publications_medical_v2-1-eng-hun
-    - mtdata_ELRC-euipo_2017-1-eng-hun
-    - mtdata_ELRC-eur_lex_covid-1-eng-hun
-    - mtdata_ELRC-presscorner_covid-1-eng-hun
-    - mtdata_ELRC-vaccination-1-eng-hun
-    - mtdata_ELRC-wikipedia_health-1-eng-hun
-    - mtdata_EU-dcep-1-eng-hun
-    - mtdata_EU-eac_forms-1-eng-hun
-    - mtdata_EU-eac_reference-1-eng-hun
-    - mtdata_EU-ecdc-1-eng-hun
-    - mtdata_LinguaTools-wikititles-2014-eng-hun
-    - mtdata_Neulab-tedtalks_train-1-eng-hun
-    - mtdata_Tilde-ecb-2017-eng-hun
-    - mtdata_Tilde-eesc-2017-eng-hun
-    - mtdata_Tilde-ema-2016-eng-hun
-    - mtdata_Tilde-rapid-2016-eng-hun
-    - mtdata_Lindat-khresmoi_summary_dev-2-eng-hun
-    - mtdata_Lindat-khresmoi_summary_test-2-eng-hun
-experiment:
-  backward-model: NOT-YET-SUPPORTED
-  best-model: chrf
-  bicleaner:
-    dataset-thresholds:
-      opus_CCAligned/v1: 0.7
-      opus_LinguaTools-WikiTitles/v2014: 0.7
-      opus_OpenSubtitles/v2018: 0.8
-      opus_ParaCrawl/v9: 0.0
-      opus_WikiMatrix/v1: 0.7
-      opus_bible-uedin/v1: 0.7
-    default-threshold: 0.5
-  mono-max-sentences-src: 100000000
-  mono-max-sentences-trg: 20000000
-  name: baseline_enhu
-  split-length: 2000000
-  spm-sample-size: 10000000
-  src: en
-  teacher-ensemble: 2
-  trg: hu
-  vocab: NOT-YET-SUPPORTED
+
+# Arguments that are provided to Marian, the underlying machine learning system used
+# to train language.
+# https://marian-nmt.github.io/docs/cmd/marian/
 marian-args:
   decoding-backward:
     beam-size: '12'
@@ -152,6 +202,14 @@ marian-args:
     early-stopping: '20'
   training-student-finetuned:
     early-stopping: '20'
+
+# Run all of the training pipeline with "all", or run a specific stage such as
+# "merge-corpus". For more information see:
+#
+# https://mozilla.github.io/firefox-translations-training/task-cluster.html#running-up-to-a-specific-step
 target-stage: all
+
 taskcluster:
+  # After the parallel corpora are merged and de-duplicated, the combined file is
+  # then split into an even number of chunks.
   split-chunks: 10

--- a/configs/tc.prod.yml
+++ b/configs/tc.prod.yml
@@ -27,27 +27,14 @@ experiment:
   use-opuscleaner: "true"
 
   # Bicleaner is a tool that aims at detecting noisy sentence pairs in a parallel corpus.
-  # It indicates the likelihood of a pair of sentences being mutual translations (with a
-  # value near to 1) or not (with a value near to 0). Sentence pairs considered very
-  # noisy are scored with 0. Bicleaner AI will be used first if the language is
-  # available, otherwise it will fallback to the original non-AI Bicleaner.
-  #
-  # See:
-  #   https://github.com/bitextor/bicleaner-ai
-  #   https://github.com/bitextor/bicleaner
-  #
-  # For supported languages see:
-  #   https://github.com/bitextor/bicleaner-ai-data/releases
-  #   https://github.com/bitextor/bicleaner-data/releases
-  #
-  # New language releases are added to: taskcluster/ci/fetch/bicleaner.yml
+  # See: docs/bicleaner.md
   bicleaner:
     default-threshold: 0.5
     dataset-thresholds:
       opus_CCAligned/v1: 0.7
       opus_LinguaTools-WikiTitles/v2014: 0.7
-      opus_OpenSubtitles/v2018: 0.8             # Example of a higher filtering level.
-      opus_ParaCrawl/v9: 0.0                    # Example of cleaning being disabled.
+      opus_OpenSubtitles/v2018: 0.8           # Example of a higher filtering level.
+      opus_ParaCrawl/v9: 0.0                  # Example of cleaning being disabled.
       opus_WikiMatrix/v1: 0.7
       opus_bible-uedin/v1: 0.7
 
@@ -64,48 +51,8 @@ experiment:
   # tokenization training.
   spm-sample-size: 10_000_000
 
-  # How big the vocab will be. The vocab is shared between the source and the
-  # target languages.
-  #
-  # In "Finding the Optimal Vocabulary Size for Neural Machine Translation", the
-  # researchers tests vocab sizes between 500 and 64,000. A general value table
-  # depends on the vocabulary size.
-  #
-  # | Corpus Size | Optimal vocab size |
-  # | ----------- | ------------------ |
-  # |   4,500,000 |    32,000 - 64,000 |
-  # |   1,000,000 |              8,000 |
-  # |     500,000 |     4,000 - 16,000 |
-  # |      30,000 |              1,000 |
-  #
-  # See section 4 for their conclusions.
-  #   https://aclanthology.org/2020.findings-emnlp.352.pdf
-  #
-  # The larger the vocab, the slower the training and the inference will be as each
-  # token in the vocab contributes to the amount of probabilities that will need
-  # to be generated when making a token prediction. This is a trade off on the quality
-  # of the translation, and the performance.
-  spm-vocab-size: 32_000
-
-  # Determine how many teachers to train. The teachers will be identical except they
-  # will be initialized with different random seeds. This has been shown to improve
-  # the performance during student distillation, as the translation probabilities will
-  # be combined from both models.
-  #
-  # While our current implementation only changes seeds, it's also possible to have
-  # ensembles that use different configurations or are trained on different datasets.
-  #
-  # Recommendations information from: https://nbogoychev.com/efficient-machine-translation/#ensembling
-  #
-  #   One very easy way to improve translation quality of the teacher is to produce an
-  #   ensemble of systems that produce translation together. This is done by training
-  #   identical systems, initialising them with different random seed. The more systems,
-  #   the better, although returns are diminishing.
-  #
-  #   For example, if we want to have an ensemble of two systems, we need to separate
-  #   configuration files for training, where the seed parameter is different.
-  #   Configuration one would have seed: 1111, whereas configuration two would have
-  #   seed: 2222.
+  # Determine how many teachers to train.
+  # See: docs/teacher-ensemble.md
   teacher-ensemble: 2
 
   # Path to a pretrained backward model (optional).

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "just-the-docs", "~> 0.7.0"
+gem "jekyll-relative-links", "~> 0.7.0"
 gem "jekyll-remote-theme", "~> 0.4.3"
+gem "just-the-docs", "~> 0.7.0"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.7.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
@@ -81,6 +83,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3)
+  jekyll-relative-links (~> 0.7.0)
   jekyll-remote-theme (~> 0.4.3)
   just-the-docs (~> 0.7.0)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,4 +10,5 @@ aux_links:
   "GitHub":
     - "https://github.com/mozilla/firefox-translations-training"
 plugins:
+  - jekyll-relative-links
   - jekyll-remote-theme

--- a/docs/bicleaner.md
+++ b/docs/bicleaner.md
@@ -1,0 +1,50 @@
+---
+layout: default
+title: Bicleaner
+parent: Data cleaning
+---
+# Bicleaner
+
+Bicleaner is a tool that aims at detecting noisy sentence pairs in a parallel corpus. The classifier scores parallel sentences from 0 to 1 where 0 means a very noisy translation and 1 is a good translation. In the pipeline, Bicleaner AI will be used first if [the language is available][ai-releases], otherwise it will fallback to the original non-AI Bicleaner.
+
+See:
+  * [https://github.com/bitextor/bicleaner-ai](https://github.com/bitextor/bicleaner-ai)
+  * [https://github.com/bitextor/bicleaner](https://github.com/bitextor/bicleaner)
+
+For supported languages see:
+  * [Bicleaner AI Releases][ai-releases]
+  * [Bicleaner Releases][releases]
+
+New language releases should be added to: `taskcluster/ci/fetch/bicleaner.yml`
+
+## How to configure for training
+
+The configuration specifies a default threshold and a per-dataset threshold. A sentence pair will be kept if its score is **above** the given threshold.
+
+- `0.5` should be a [good default value].
+- Increase the threshold for noisier datasets.
+- Set the threshold to `0` to skip cleaning entirely.
+
+## Recommendations for specific datasets
+
+| Data set      | Threshold | Reason                   |
+| ------------- | --------- | -------                  |
+| OpenSubtitles | 0.8       | This is a noiser dataset |
+| ParaCrawl     | 0         | This dataset has already been cleaned by bicleaner. See [Bicleaner AI: Bicleaner Goes Neural], section 4.2.2 |
+
+## Example config:
+
+```
+  bicleaner:
+    default-threshold: 0.5
+    dataset-thresholds:
+      opus_CCAligned/v1: 0.7
+      opus_OpenSubtitles/v2018: 0.8
+      opus_ParaCrawl/v9: 0
+      ...
+```
+
+[good default value]: https://github.com/bitextor/bicleaner-ai/wiki/How-to-train-your-Bicleaner-AI#bicleaning-a-corpus
+[ai-releases]: https://github.com/bitextor/bicleaner-ai-data/releases
+[releases]: https://github.com/bitextor/bicleaner-data/releases
+[Bicleaner AI: Bicleaner Goes Neural]: https://aclanthology.org/2022.lrec-1.87.pdf

--- a/docs/cleaning.md
+++ b/docs/cleaning.md
@@ -2,6 +2,7 @@
 layout: default
 title: Data cleaning
 nav_order: 5
+has_children: true
 ---
 
 # Data cleaning
@@ -10,7 +11,6 @@ Making datasets less noisy to improve quality of translation.
 
 ## Regular pipeline
 
-
 Config setting:
 ```
   use-opuscleaner: false
@@ -18,9 +18,9 @@ Config setting:
 
 ### Dataset fixing
 
-Some datasets require fixes like detokenization. 
+Some datasets require fixes like detokenization.
 Dataset and language specific fixes are implemented in [https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/clean/fixes](https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/clean/fixes).
-Naming convention: 
+Naming convention:
 - `<dataset_name>.sh` for parallel dataset cleaning
 - `<dataset_name>.<lang>.sh` for language specific cleaning of parallel or monolingual dataset
 - `/` in dataset name should be replaced with `_`
@@ -32,8 +32,8 @@ Make sure the language is present in [clean_parallel](https://github.com/mozilla
 
 ### Bicleaner
 
-It is recommended to use Bicleaner ML models to filter noisy data. 
-See more details on how to configure it in the [Model training guide, Bicleaner section](training-guide.md/#bicleaner).
+It is recommended to use Bicleaner ML models to filter noisy data.
+See the [bicleaner documentation](bicleaner.md) for more details on how to configure it.
 
 
 ## OpusCleaner
@@ -46,7 +46,8 @@ Config setting:
 ```
 
 ## Custom filter configs
-The idea behind the OpusCleaner is customizing filter rules for each language pair and dataset 
+
+The idea behind the OpusCleaner is customizing filter rules for each language pair and dataset
 to get a training corpus with less noise and train higher quality translation models.
 
 Filtering rules can be tuned in an interactive UI.

--- a/docs/pipeline-steps.md
+++ b/docs/pipeline-steps.md
@@ -2,6 +2,7 @@
 layout: default
 title: Pipeline steps
 nav_order: 3
+has_children: true
 ---
 
 # Pipeline steps

--- a/docs/teacher-ensemble.md
+++ b/docs/teacher-ensemble.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Teacher Ensemble
+parent: Pipeline steps
+---
+
+# Teacher Ensemble
+
+Teacher models are larger and slower translation models that have higher BLEU scores. In the pipeline they are used to distill smaller and faster student models at the cost of a lower BLEU score.
+
+In the config files, you can specify how many teachers to train via `experiment.teacher-ensemble` key. The teachers will be identical except they will be initialized with different random seeds. This has been shown to improve the performance during student distillation, as the translation probabilities will be combined from both models.
+
+While our current implementation only changes seeds, it's also possible to have ensembles that use different configurations or are trained on different datasets.
+
+Recommendations information from [Efficient machine translation](https://nbogoychev.com/efficient-machine-translation/#ensembling):
+
+> One very easy way to improve translation quality of the teacher is to produce an ensemble of systems that produce translation together. This is done by training identical systems, initialising them with different random seed. The more systems, the better, although returns are diminishing.
+>
+> For example, if we want to have an ensemble of two systems, we need to separate configuration files for training, where the seed parameter is different. Configuration one would have seed: 1111, whereas configuration two would have seed: 2222.
+
+We typically use two teacher models in our training.

--- a/docs/training-guide.md
+++ b/docs/training-guide.md
@@ -6,11 +6,11 @@ nav_order: 2
 
 # Model training guide
 
-A step-by-step guide on how to train a translation model. 
+A step-by-step guide on how to train a translation model.
 
-The configuration of the training run happens mostly in the training configuration file. 
+The configuration of the training run happens mostly in the training configuration file.
 Look at the examples of the full production configs for
-[Taskcluster](https://github.com/mozilla/firefox-translations-training/tree/main/configs/tc.prod.yml) and 
+[Taskcluster](https://github.com/mozilla/firefox-translations-training/tree/main/configs/tc.prod.yml) and
 [Snakemake](https://github.com/mozilla/firefox-translations-training/tree/main/configs/config.prod.yml).
 
 ## 1. Choose a language
@@ -131,39 +131,18 @@ To use the default data cleaning pipeline set:
 ```
   use-opuscleaner: false
 ```
+
 Make sure the language is present in [clean_parallel](https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/clean/tools/clean_parallel.py#L19) script.
 
-For more advanced cleaning and for using OpusCleaner look at the [Data cleaning](cleaning.md) doc.
-
-### Bicleaner
-It is recommended to use [Bicleaner](https://github.com/bitextor/bicleaner-ai) ML models to filter noisy data. 
-Bicleaner classifier scores parallel sentences from 0 to 1 where 0 means a very noisy translation and 1 is a good translation.
-Most of the scores will be between 0 and 1.
-
-Check that the bicleaner-ai model is [available](https://github.com/bitextor/bicleaner-ai-data/releases) for your language pair
-and add filtering thresholds to the config.
-
-- `0.5` should be a [good default value](https://github.com/bitextor/bicleaner-ai/wiki/How-to-train-your-Bicleaner-AI#bicleaning-a-corpus).
-- Noisier datasets like OpenSubtitles should have higher threshold. 
-- Set the threshold to `0` to skip cleaning entirely, for example for ParaCrawl dataset that comes already cleaned by Bicleaner 
-  (see [Bicleaner AI: Bicleaner Goes Neural](https://aclanthology.org/2022.lrec-1.87.pdf), section 4.2.2).
-
-```
-  bicleaner:
-    default-threshold: 0.5
-    dataset-thresholds:
-      opus_CCAligned/v1: 0.7
-      opus_OpenSubtitles/v2018: 0.8
-      opus_ParaCrawl/v9: 0
-      ...
-```
+For more details on data cleaning see the documents on [Data cleaning](cleaning.md) [Bicleaner](bicleaner.md).
 
 ## 4. Set hyperparameters
 
-The pipeline supports overriding the default [Marian settings](https://marian-nmt.github.io/docs/cmd/marian/) in the training config.
-The default settings are in the `pipeline/train/configs` directory, 
-for example [teacher.train.yml](https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/train/configs/training/teacher.train.yml) 
-and in the [train.sh](https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/train/train.sh) script.
+The pipeline supports overriding the default [Marian settings](https://marian-nmt.github.io/docs/cmd/marian/) in the training config. The default settings are in the `pipeline/train/configs` directory,
+for example [`teacher.train.yml`] and in the [`train.sh`] script.
+
+[teacher.train.yml]: https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/train/configs/training/teacher.train.yml
+[train.sh]: https://github.com/mozilla/firefox-translations-training/tree/main/pipeline/train/train.sh
 
 ### Model training
 I often increase early stopping for teachers to make sure the training converges.
@@ -180,7 +159,7 @@ marian-args:
 
 ### Decoding (translation)
 
-`mini-batch-words` can be set depending on available GPU memory and the number of teachers. 
+`mini-batch-words` can be set depending on available GPU memory and the number of teachers.
 It affects the batch size and decoding speed for the `traslate` steps.
 ```
 marian-args:
@@ -331,5 +310,3 @@ Reduce the Marian workspace or batch size.
 
 It happens on Taskcluster, because we train on increasingly large datasets especially close to the end of the pipeline. 
 Just increase the disk size, it's cheap compared to the GPUs.
-
-

--- a/docs/vocab-size.md
+++ b/docs/vocab-size.md
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Vocab Size
+parent: Pipeline steps
+---
+
+# Vocab Size
+
+The vocab size can be changed in the config via `experiments.spm-vocab-size`. The vocab is shared between the source and the target languages. The vocab is built by [SentencePiece](https://github.com/google/sentencepiece).
+
+In "Finding the Optimal Vocabulary Size for Neural Machine Translation", the
+researchers tests vocab sizes between 500 and 64,000. A general value table
+depends on the vocabulary size.
+
+| Corpus Size | Optimal vocab size |
+| ----------- | ------------------ |
+|   4,500,000 |    32,000 - 64,000 |
+|   1,000,000 |              8,000 |
+|     500,000 |     4,000 - 16,000 |
+|      30,000 |              1,000 |
+
+See section 4 for their conclusions.
+  https://aclanthology.org/2020.findings-emnlp.352.pdf
+
+The larger the vocab, the slower the training and the inference will be as each
+token in the vocab contributes to the amount of probabilities that will need
+to be generated when making a token prediction. This is a trade off on the quality
+of the translation, and the performance.

--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -2,6 +2,8 @@
 ##
 # Cleans corpus using bicleaner-ai or bicleaner
 #
+# See:
+#   docs/bicleaner.md
 
 set -x
 set -euo pipefail

--- a/pipeline/clean/merge-mono.sh
+++ b/pipeline/clean/merge-mono.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 ##
-# Merges monolingual datasets
+# Merges monolingual datasets. The datasets are input as a glob-style string.
+# Each file in that directory will be used as input. The files will be deduplicated,
+# shuffled, and written out to a single archive.
+#
+# Kinds:
+#   taskcluster/ci/merge-mono/kind.yml
+#
+# Example usage:
+#
+#   pipeline/clean/merge-mono.sh             \
+#      /builds/worker/artifacts/mono.en.zst  \
+#      100000000                             \
+#      $MOZ_FETCHES_DIR/*.zst
 #
 
 set -x
@@ -9,18 +21,26 @@ test -v BIN
 
 echo "###### Merging monolingual datasets"
 
+#                      Example inputs:
+# The path to the output compressed file, e.g. "/builds/worker/artifacts/mono.en.zst"
 output=$1
-max_sent=$2
+# The maximum number of sentences that will be merged. e.g. 100000000
+# These sentences are randomly sampled from the datasets.
+max_sentences=$2
+# A glob-style path to the mono datasets, e.g. /path/to/*.zst
 datasets=( "${@:3}" )
 
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
+
+echo "### Merging the following datasets:"
+ls $datasets
 
 dir=$(dirname "${output}")
 mkdir -p "${dir}"
 
 ${COMPRESSION_CMD} -dc "${datasets[@]}" |
   ${BIN}/dedupe |
-  shuf -n "${max_sent}" |
+  shuf -n "${max_sentences}" |
   ${COMPRESSION_CMD} >"${output}"
 
 

--- a/pipeline/train/configs/model/teacher.yml
+++ b/pipeline/train/configs/model/teacher.yml
@@ -1,6 +1,13 @@
 # https://discourse.translatelocally.com/t/marian-configuration-to-use/24
 dim-vocabs: [32000, 32000]
 type: transformer
+
+# Per recommendations from: https://nbogoychev.com/efficient-machine-translation/
+#
+#   You could train your teacher with two separate configuration prefixes:
+#   Either task: transformer-base or task: transformer-big. As a rule of thumb,
+#   if you have a high resource language >5M sentence pairs, you will likely see
+#   gains from using transformer-big.
+#
 # tasks: https://github.com/marian-nmt/marian-dev/blob/master/src/common/aliases.cpp
 task: transformer-big
-#task: transformer-base  # use smaller model for low resource (<5M sentences)

--- a/pipeline/train/spm-vocab.sh
+++ b/pipeline/train/spm-vocab.sh
@@ -1,18 +1,40 @@
 #!/bin/bash
 ##
-# Train SentencePiece vocabulary model
+# Train the SentencePiece vocabulary model. This outputs a ".spm" binary file, and the
+# ".vocab" file which is a human readable list of the vocabulary. The vocab file is
+# what is used to tokenize text input for the machine learning model. The vocab that
+# is generated is a mix of the source and target languages.
 #
+# Kinds:
+#   taskcluster/ci/train-vocab/kind.yml
+#
+# Example usage:
+#
+#   export MARIAN=$MOZ_FETCHES_DIR                 && \
+#   spm-vocab.sh                                      \
+#       fetches/corpus.en.zst  `# merged_corpus_src`  \
+#       fetches/corpus.ca.zst  `# merged_corpus_trg`  \
+#       artifacts/vocab.spm    `# vocab_output`       \
+#       10000000               `# sample_size`        \
+#       auto                   `# threads`            \
+#       32000                  `# vocab_size`
 
 set -x
 set -euo pipefail
 
 test -v MARIAN
 
-corpus_src=$1
-corpus_trg=$2
+# The name of the source corpus, e.g. "fetches/corpus.en.zst".
+merged_corpus_src=$1
+# The name of the target corpus, e.g. "fetches/corpus.ca.zst".
+merged_corpus_trg=$2
+# Where the vocab file will be output, e.g. "artifacts/vocab.spm"
 vocab_output=$3
+# The maximum number of sentences to train on, e.g. 10000000
 sample_size=$4
-threads=$5
+# The thread count, either "auto" or an int.
+num_threads=$5
+# The size of the final vocab. Defaults to 32000.
 vocab_size="${6:-32000}"
 
 if (( vocab_size % 8 != 0 )); then
@@ -20,8 +42,8 @@ if (( vocab_size % 8 != 0 )); then
   exit 1
 fi
 
-if [ "$threads" = "auto" ]; then
-  threads=$(nproc)
+if [ "$num_threads" = "auto" ]; then
+  num_threads=$(nproc)
 fi
 
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
@@ -29,21 +51,29 @@ COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
 vocab_dir=$(dirname "${vocab_output}")
 mkdir -p "${vocab_dir}"
 
-${COMPRESSION_CMD} -dc "${corpus_src}" >"${vocab_dir}/data.src.txt"
-${COMPRESSION_CMD} -dc "${corpus_trg}" >"${vocab_dir}/data.trg.txt"
+${COMPRESSION_CMD} -dc "${merged_corpus_src}" >"${vocab_dir}/data.src.txt"
+${COMPRESSION_CMD} -dc "${merged_corpus_trg}" >"${vocab_dir}/data.trg.txt"
 
+# The input arguments are available here:
+#   https://github.com/google/sentencepiece/blob/master/doc/options.md
+#
 # https://github.com/hplt-project/OpusTrainer/tree/main#generating-vocabulary-and-tags-before-training
 # byte_fallback - decomposes unknown pieces into UTF-8 bytes
 # user_defined_symbols - placeholders
 # character_coverage - CJK is recommended to have 0.9995, vocab languages probably you want 1
-"${MARIAN}/spm_train" --bos_id=-1 --eos_id=0 --unk_id=1 \
+"${MARIAN}/spm_train" \
+  --bos_id=-1 \
+  --eos_id=0 \
+  --unk_id=1 \
   --user_defined_symbols="__source__,__target__,__done__,__start__,__end__" \
-  --model_prefix="${vocab_dir}/vocab" --vocab_size="${vocab_size}" \
+  --model_prefix="${vocab_dir}/vocab" \
+  --vocab_size="${vocab_size}" \
   --input="${vocab_dir}/data.src.txt,${vocab_dir}/data.trg.txt" \
-  --input_sentence_size="${sample_size}" --shuffle_input_sentence=true \
+  --input_sentence_size="${sample_size}" \
+  --shuffle_input_sentence=true \
   --byte_fallback \
   --character_coverage=1.0 \
-  --num_threads "${threads}"
+  --num_threads "${num_threads}"
 
 rm "${vocab_dir}/data.src.txt" "${vocab_dir}/data.trg.txt"
 

--- a/pipeline/train/spm-vocab.sh
+++ b/pipeline/train/spm-vocab.sh
@@ -5,6 +5,9 @@
 # what is used to tokenize text input for the machine learning model. The vocab that
 # is generated is a mix of the source and target languages.
 #
+# Docs:
+#   docs/vocab-size.md
+#
 # Kinds:
 #   taskcluster/ci/train-vocab/kind.yml
 #

--- a/pipeline/translate/collect.sh
+++ b/pipeline/translate/collect.sh
@@ -1,25 +1,53 @@
 #!/bin/bash
 #
-# Merges translation outputs into a dataset
+# Collects chunked translation data of the form "out-file.N.out" where N is a number.
+# The datasets are initially chunked so that tasks can work on smaller sets of data
+# to better parallelize the work. After processing, any chunked data is reassembled
+# with this script.
 #
+# Example tasks running on chunked data (before this script):
+#   extract-best-en-ca-1/10
+#   translate-corpus-en-ca-1/10
+#   translate-mono-src-en-ca-1/10
+#   translate-mono-trg-en-ca-1/10
+#
+# Kinds:
+#   taskcluster/ci/collect-mono-trg/kind.yml
+#   taskcluster/ci/collect-mono-src/kind.yml
+#   taskcluster/ci/collect-corpus/kind.yml
+#
+# Example usage:
+#
+#   pipeline/translate/collect.sh    \
+#      fetches                       \
+#      artifacts/mono.en.zst         \
+#      $MOZ_FETCHES_DIR/mono.ca.zst
 
 set -x
 set -euo pipefail
 
-
-dir=$1
+# The directory with chunks of the form "fetches/out-file.N.out", where N is a number.
+chunks_dir=$1
+# The full file name path to the output compressed file, e.g. "artifacts/mono.en.zst"
 output_path=$2
+# The path to the monolingual data to compare against, e.g. "$MOZ_FETCHES_DIR/mono.hu.zst"
 mono_path=$3
 
 
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
 
 echo "### Collecting translations"
-find "${dir}" -name '*.out' | sort -t '.' -k2,2n | xargs cat | ${COMPRESSION_CMD} >"${output_path}"
+
+find "${chunks_dir}" -name '*.out' |  # For example, finds "fetches/out-file.1.out", "fetches/out-file.2.out", etc.
+  sort -t '.' -k2,2n |                      # Sort by the number in "out-file.1.out", e.g. 1 here.
+  xargs cat |                               # Combine all of these files together.
+  ${COMPRESSION_CMD} >"${output_path}"
 
 echo "### Comparing number of sentences in source and artificial target files"
+
 src_len=$(${COMPRESSION_CMD} -dc "${mono_path}" | wc -l)
 trg_len=$(${COMPRESSION_CMD} -dc "${output_path}" | wc -l)
+
 if [ "${src_len}" != "${trg_len}" ]; then
   echo "### Error: length of ${mono_path} ${src_len} is different from ${output_path} ${trg_len}"
   exit 1

--- a/pipeline/translate/collect.sh
+++ b/pipeline/translate/collect.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # Collects chunked translation data of the form "out-file.N.out" where N is a number.
-# The datasets are initially chunked so that tasks can work on smaller sets of data
-# to better parallelize the work. After processing, any chunked data is reassembled
-# with this script.
+# The datasets are chunked earlier in the pipeline by split-{corpus,mono}.sh so that
+# tasks can work on smaller sets of data to better parallelize the work. After processing,
+# any chunked data is reassembled with this script.
 #
 # Example tasks running on chunked data (before this script):
 #   extract-best-en-ca-1/10

--- a/taskcluster/ci/collect-corpus/kind.yml
+++ b/taskcluster/ci/collect-corpus/kind.yml
@@ -64,9 +64,13 @@ tasks:
                   type: directory
             env:
                 COMPRESSION_CMD: zstdmt
-    
+
         run:
             using: run-task
+            # collect.sh arguments:
+            #   1) chunks_dir
+            #   2) output_path
+            #   3) mono_path
             command:
                 - bash
                 - -c

--- a/taskcluster/ci/collect-mono-src/kind.yml
+++ b/taskcluster/ci/collect-mono-src/kind.yml
@@ -54,6 +54,10 @@ task-defaults:
         command:
             - bash
             - -c
+            # Arguments:
+            #   1) chunks_dir
+            #   2) output_path
+            #   3) mono_path
             - >-
                 zstd -d --rm $MOZ_FETCHES_DIR/out-file* &&
                 $VCS_PATH/pipeline/translate/collect.sh

--- a/taskcluster/ci/collect-mono-trg/kind.yml
+++ b/taskcluster/ci/collect-mono-trg/kind.yml
@@ -51,6 +51,10 @@ task-defaults:
 
     run:
         using: run-task
+        # Arguments:
+        #   1) chunks_dir
+        #   2) output_path
+        #   3) mono_path
         command:
             - bash
             - -c

--- a/taskcluster/ci/merge-mono/kind.yml
+++ b/taskcluster/ci/merge-mono/kind.yml
@@ -68,9 +68,9 @@ task-defaults:
             - bash
             - -c
             # Arguments are:
-            # 1) output directory
-            # 2) max_sent (sent to shuf -n to output at most max_sent lines)
-            # 3) input files
+            # 1) output
+            # 2) max_sentences
+            # 3) datasets
             - >-
                 export BIN=$MOZ_FETCHES_DIR &&
                 $VCS_PATH/pipeline/clean/merge-mono.sh

--- a/taskcluster/ci/train-vocab/kind.yml
+++ b/taskcluster/ci/train-vocab/kind.yml
@@ -64,11 +64,11 @@ tasks:
                 - bash
                 - -c
                 # Arguments are:
-                # 1) merged src corpus file
-                # 2) merged trg corpus file
-                # 3) output file
-                # 4) sample size
-                # 5) number of threads (auto = output of nproc)
+                # 1) merged_corpus_src
+                # 2) merged_corpus_trg
+                # 3) vocab_output
+                # 4) sample_size
+                # 5) num_threads (auto = output of nproc)
                 - >-
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/pipeline/train/spm-vocab.sh


### PR DESCRIPTION
This is work that I split off from my #284 work. My goal here is to:

* Document argument parameters in the scripts and Taskcluster tasks.
* Document scripts with a header that explains how they are used with examples.
* Document every parameter of the example training config.
* Add links to literature and prior art for when certain hyper-parameters are chosen or design choices made
* Be consistent with argument and variable naming to make it easier to search across the codebase.

The commits are logically ordered if you wish to review them that way.