### PR TITLE
Fix typo in skip_unless_pipeline_changed transform

### DIFF
--- a/taskcluster/translations_taskgraph/transforms/skip_unless_pipeline_changed.py
+++ b/taskcluster/translations_taskgraph/transforms/skip_unless_pipeline_changed.py
@@ -12,9 +12,9 @@ EXCLUDE_KINDS = ["test"]
 # Touching any file in any of these directories is considered a pipeline change
 PIPELINE_DIRS = [
     "pipeline/**",
-    "taskcluster/docker/**"
-    "taskcluster/requirements.txt"
-    "taskcluster/scripts/**"
+    "taskcluster/docker/**",
+    "taskcluster/requirements.txt",
+    "taskcluster/scripts/**",
     "taskcluster/translations_taskgraph/**",
 ]
 PIPELINE_DIRS.extend(


### PR DESCRIPTION
There's some implicit string joining happening at the moment, which means most pipeline changes aren't going to be noticed.