### PR TITLE
Fix the docs building by using the remote theme

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
 gem "just-the-docs", "~> 0.7.0"
+gem "jekyll-remote-theme", "~> 0.4.3"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -33,6 +33,11 @@ GEM
       webrick (~> 1.7)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
@@ -62,6 +67,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (4.2.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass-embedded (1.69.5-arm64-darwin)
       google-protobuf (~> 3.23)
@@ -75,6 +81,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 4.3)
+  jekyll-remote-theme (~> 0.4.3)
   just-the-docs (~> 0.7.0)
 
 BUNDLED WITH

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,4 @@
 remote_theme: just-the-docs/just-the-docs
-theme: just-the-docs
 #color_scheme: dark
 title: Firefox Translations Training
 description: Documentation for the Firefox Translations training pipelines
@@ -10,3 +9,5 @@ favicon_ico: "img/logo.svg"
 aux_links:
   "GitHub":
     - "https://github.com/mozilla/firefox-translations-training"
+plugins:
+  - jekyll-remote-theme


### PR DESCRIPTION
Yup, they broke like you suggested @eu9ene. I had to add the remote `jekyll-remote-theme` plugin. I had to keep the gem install of `just-the-docs` as the remote dependencies weren't installed.