### PR TITLE
Consolidate transitory artifacts in the /data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,7 @@ dmypy.json
 .bin
 .snakemake
 
-tests_data
+/data
 
 # Jekyll files.
 /docs/_site

--- a/Makefile
+++ b/Makefile
@@ -185,14 +185,21 @@ endif
 
 # Downloads Marian training logs for a Taskcluster task group
 download-logs:
+	mkdir -p data/taskcluster-logs
 	poetry install --only taskcluster
-	python utils/tc_marian_logs.py --output=$$(pwd)/logs --task-group-id=$(LOGS_TASK_GROUP)
+	poetry run python utils/tc_marian_logs.py \
+		--output=data/taskcluster-logs/$(LOGS_TASK_GROUP) \
+		--task-group-id=$(LOGS_TASK_GROUP)
 
 # Runs Tensorboard for Marian training logs in ./logs directory
 # then go to http://localhost:6006
 tensorboard:
+	mkdir -p data/tensorboard-logs
 	poetry install --only tensorboard
-	marian-tensorboard --offline -f logs/*.log
+	poetry run marian-tensorboard \
+		--offline \
+		--log-file data/taskcluster-logs/**/*.log \
+		--work-dir data/tensorboard-logs
 
 # Run the GitHub pages Jekyll theme locally.
 # TODO - This command would be better to be run in a docker container, as the

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -15,7 +15,7 @@ os.environ["TRG"] = TRG
 
 from pipeline.data.dataset_importer import run_import
 
-OUTPUT_DIR = "tests_data"
+OUTPUT_DIR = "data/tests"
 # the augmentation is probabilistic, here is a range for 0.1 probability
 AUG_MAX_RATE = 0.3
 AUG_MIN_RATE = 0.01


### PR DESCRIPTION
My working directory is frequently dirty right now with the various subcommands. This PR consolidates the transitory artifacts to be created in the `data` directory, which is in the`.gitignore`.
```
├── data
│   ├── taskcluster-logs
│   ├── tensorboard-logs
│   ├── tests
│   └── train-parts
```

In addition it fixes the commands for downloading logs and viewing logs so that they work correctly in poetry. Currently they are using the root python install and modules rather than the poetry installed ones.