### PR TITLE
Don't run taskgraph-diff on pushes

### DIFF
--- a/taskcluster/kinds/tests/kind.yml
+++ b/taskcluster/kinds/tests/kind.yml
@@ -133,7 +133,7 @@ tasks:
           docker-image: {in-tree: base}
           max-run-time: 1200
       description: "Create diffs of taskgraphs vs. base revision."
-      run-on-tasks-for: ["github-push", "github-pull-request"]
+      run-on-tasks-for: ["github-pull-request"]
       optimization:
         skip-unless-changed:
             - taskcluster/**


### PR DESCRIPTION
This only makes sense in the context of PRs, where we want to see the effect it has on the taskgraph