### PR TITLE
Fail schema validation if unknown properties are passed into `pretrained-models`

### DIFF
--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -164,6 +164,7 @@ def validate_pretrained_models(params):
                     # pretrained models hosted elsewhere.
                     "pretrained-models": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
                             "train-teacher": {
                                 "type": "object",


### PR DESCRIPTION
We shouldn't allow `additionalProperties` in the `pretrained-models` parameter schema.