### PR TITLE
Make CI happy again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,17 +121,17 @@ dag:
 # OpusCleaner is a data cleaner for training corpus
 # More details are in docs/cleaning.md
 opuscleaner-ui:
-	poetry install --only opuscleaner
+	poetry install --only opuscleaner --no-root
 	opuscleaner-server serve --host=0.0.0.0 --port=8000
 
 # Utils to find corpus etc
 install-utils:
-	poetry install --only utils
+	poetry install --only utils --no-root
 
 # Black is a code formatter for Python files. Running this command will check that
 # files are correctly formatted, but not fix them.
 black:
-	poetry install --only black
+	poetry install --only black --no-root
 	@if poetry run black . --check --diff; then \
 		echo "The python code formatting is correct."; \
 	else \
@@ -144,17 +144,17 @@ black:
 
 # Runs black, but also fixes the errors.
 black-fix:
-	poetry install --only black
+	poetry install --only black --no-root
 	poetry run black .
 
 # Runs ruff, a linter for python.
 lint:
-	poetry install --only lint
+	poetry install --only lint --no-root
 	poetry run ruff check .
 
 # Runs ruff, but also fixes the errors.
 lint-fix:
-	poetry install --only lint
+	poetry install --only lint --no-root
 	poetry run ruff check . --fix
 
 # Fix all automatically fixable errors. This is useful to run before pushing.
@@ -164,7 +164,7 @@ fix-all:
 
 # Run unit tests
 run-tests:
-	poetry install --only tests --only utils
+	poetry install --only tests --only utils --no-root
 	PYTHONPATH=$$(pwd) poetry run pytest tests -vv
 
 # Validates Taskcluster task graph locally
@@ -186,7 +186,7 @@ endif
 # Downloads Marian training logs for a Taskcluster task group
 download-logs:
 	mkdir -p data/taskcluster-logs
-	poetry install --only taskcluster
+	poetry install --only taskcluster --no-root
 	poetry run python utils/taskcluster_downloader.py \
 		--output=data/taskcluster-logs/$(LOGS_TASK_GROUP) \
 		--mode=logs \
@@ -196,7 +196,7 @@ download-logs:
 # This includes BLEU and chrF metrics for each dataset and trained model
 download-evals:
 	mkdir -p data/taskcluster-logs
-	poetry install --only taskcluster
+	poetry install --only taskcluster --no-root
 	poetry run python utils/taskcluster_downloader.py \
 		--output=data/taskcluster-evals/$(LOGS_TASK_GROUP) \
 		--mode=evals \
@@ -207,7 +207,7 @@ download-evals:
 # then go to http://localhost:6006
 tensorboard:
 	mkdir -p data/tensorboard-logs
-	poetry install --only tensorboard
+	poetry install --only tensorboard --no-root
 	poetry run marian-tensorboard \
 		--offline \
 		--log-file data/taskcluster-logs/**/*.log \
@@ -229,5 +229,5 @@ serve-docs:
 	&& bundle exec jekyll serve
 
 preflight-check:
-	poetry install --only utils
+	poetry install --only utils --no-root
 	poetry run python -W ignore utils/preflight_check.py

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ black-fix:
 # Runs ruff, a linter for python.
 lint:
 	poetry install --only lint --no-root
+	poetry run ruff --version
 	poetry run ruff check .
 
 # Runs ruff, but also fixes the errors.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1960,17 +1960,6 @@ redis = ["redis"]
 tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-flake8 (>=1.0.5)", "pytest-mypy (>=0.8.0)", "redis", "sphinx (>=3.0.3)"]
 
 [[package]]
-name = "pprintpp"
-version = "0.4.0"
-description = "A drop-in replacement for pprint that's actually pretty"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
-    {file = "pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"},
-]
-
-[[package]]
 name = "prefixed"
 version = "0.7.0"
 description = "Prefixed alternative numeric library"
@@ -2286,21 +2275,6 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
-
-[[package]]
-name = "pytest-clarity"
-version = "1.0.1"
-description = "A plugin providing an alternative, colourful diff output for failing assertions."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pytest-clarity-1.0.1.tar.gz", hash = "sha256:505fe345fad4fe11c6a4187fe683f2c7c52c077caa1e135f3e483fe112db7772"},
-]
-
-[package.dependencies]
-pprintpp = ">=0.4.0"
-pytest = ">=3.5.0"
-rich = ">=8.0.0"
 
 [[package]]
 name = "python-dateutil"
@@ -3706,4 +3680,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5f914d97e6a10d6db20cbe749e952f77614c2d6f53fc5c4f58a69aa5f632b3d9"
+content-hash = "bcc1fa16feb20ed991eec7dd21bc6705ed3cfabd66ba9ef4a5434f6820aff39c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2699,28 +2699,28 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.0.287"
-description = "An extremely fast Python linter, written in Rust."
+version = "0.1.13"
+description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.287-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:1e0f9ee4c3191444eefeda97d7084721d9b8e29017f67997a20c153457f2eafd"},
-    {file = "ruff-0.0.287-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:e9843e5704d4fb44e1a8161b0d31c1a38819723f0942639dfeb53d553be9bfb5"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca1ed11d759a29695aed2bfc7f914b39bcadfe2ef08d98ff69c873f639ad3a8"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1cf4d5ad3073af10f186ea22ce24bc5a8afa46151f6896f35c586e40148ba20b"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66d9d58bcb29afd72d2afe67120afcc7d240efc69a235853813ad556443dc922"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:06ac5df7dd3ba8bf83bba1490a72f97f1b9b21c7cbcba8406a09de1a83f36083"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2bfb478e1146a60aa740ab9ebe448b1f9e3c0dfb54be3cc58713310eef059c30"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00d579a011949108c4b4fa04c4f1ee066dab536a9ba94114e8e580c96be2aeb4"},
-    {file = "ruff-0.0.287-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3a810a79b8029cc92d06c36ea1f10be5298d2323d9024e1d21aedbf0a1a13e5"},
-    {file = "ruff-0.0.287-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:150007028ad4976ce9a7704f635ead6d0e767f73354ce0137e3e44f3a6c0963b"},
-    {file = "ruff-0.0.287-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a24a280db71b0fa2e0de0312b4aecb8e6d08081d1b0b3c641846a9af8e35b4a7"},
-    {file = "ruff-0.0.287-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2918cb7885fa1611d542de1530bea3fbd63762da793751cc8c8d6e4ba234c3d8"},
-    {file = "ruff-0.0.287-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:33d7b251afb60bec02a64572b0fd56594b1923ee77585bee1e7e1daf675e7ae7"},
-    {file = "ruff-0.0.287-py3-none-win32.whl", hash = "sha256:022f8bed2dcb5e5429339b7c326155e968a06c42825912481e10be15dafb424b"},
-    {file = "ruff-0.0.287-py3-none-win_amd64.whl", hash = "sha256:26bd0041d135a883bd6ab3e0b29c42470781fb504cf514e4c17e970e33411d90"},
-    {file = "ruff-0.0.287-py3-none-win_arm64.whl", hash = "sha256:44bceb3310ac04f0e59d4851e6227f7b1404f753997c7859192e41dbee9f5c8d"},
-    {file = "ruff-0.0.287.tar.gz", hash = "sha256:02dc4f5bf53ef136e459d467f3ce3e04844d509bc46c025a05b018feb37bbc39"},
+    {file = "ruff-0.1.13-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e3fd36e0d48aeac672aa850045e784673449ce619afc12823ea7868fcc41d8ba"},
+    {file = "ruff-0.1.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9fb6b3b86450d4ec6a6732f9f60c4406061b6851c4b29f944f8c9d91c3611c7a"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b13ba5d7156daaf3fd08b6b993360a96060500aca7e307d95ecbc5bb47a69296"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9ebb40442f7b531e136d334ef0851412410061e65d61ca8ce90d894a094feb22"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:226b517f42d59a543d6383cfe03cccf0091e3e0ed1b856c6824be03d2a75d3b6"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5f0312ba1061e9b8c724e9a702d3c8621e3c6e6c2c9bd862550ab2951ac75c16"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2f59bcf5217c661254bd6bc42d65a6fd1a8b80c48763cb5c2293295babd945dd"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e6894b00495e00c27b6ba61af1fc666f17de6140345e5ef27dd6e08fb987259d"},
+    {file = "ruff-0.1.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1600942485c6e66119da294c6294856b5c86fd6df591ce293e4a4cc8e72989"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ee3febce7863e231a467f90e681d3d89210b900d49ce88723ce052c8761be8c7"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dcaab50e278ff497ee4d1fe69b29ca0a9a47cd954bb17963628fa417933c6eb1"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f57de973de4edef3ad3044d6a50c02ad9fc2dff0d88587f25f1a48e3f72edf5e"},
+    {file = "ruff-0.1.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7a36fa90eb12208272a858475ec43ac811ac37e91ef868759770b71bdabe27b6"},
+    {file = "ruff-0.1.13-py3-none-win32.whl", hash = "sha256:a623349a505ff768dad6bd57087e2461be8db58305ebd5577bd0e98631f9ae69"},
+    {file = "ruff-0.1.13-py3-none-win_amd64.whl", hash = "sha256:f988746e3c3982bea7f824c8fa318ce7f538c4dfefec99cd09c8770bd33e6539"},
+    {file = "ruff-0.1.13-py3-none-win_arm64.whl", hash = "sha256:6bbbc3042075871ec17f28864808540a26f0f79a4478c357d3e3d2284e832998"},
+    {file = "ruff-0.1.13.tar.gz", hash = "sha256:e261f1baed6291f434ffb1d5c6bd8051d1c2a26958072d38dfbec39b3dda7352"},
 ]
 
 [[package]]
@@ -3706,4 +3706,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22ebaa82943258f04e99bf0628484efbe74c441b1c19092ec052dfff26afdde"
+content-hash = "5f914d97e6a10d6db20cbe749e952f77614c2d6f53fc5c4f58a69aa5f632b3d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ requests="2.26.0"
 pytest="7.4.3"
 # use the latest main, switch to PyPi when released
 opustrainer = {git = "https://github.com/hplt-project/OpusTrainer.git", rev="9133e1525c7ee37f53ea14ee6a180152bf7ea192"}
-pytest-clarity = "^1.0.1"
 requests-mock = "^1.11.0"
 sh = "^2.0.6"
 zstandard = "^0.22.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ pip-tools = "^7.3.0"
 black = "^23.7.0"
 
 [tool.poetry.group.lint.dependencies]
-ruff = "^0.0.287"
+ruff = "^0.1.13"
 translations_parser = {path="./tracking/", develop=true}
 
 [tool.poetry.group.opuscleaner.dependencies]

--- a/tests/test_tracking_cli.py
+++ b/tests/test_tracking_cli.py
@@ -94,50 +94,53 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
     wandb_mock.plot.bar = lambda *args, **kwargs: (args, kwargs)
     wandb_mock.Table = lambda *args, **kwargs: (args, kwargs)
     experiments_publish.main()
-    assert [(level, message) for _module, level, message in caplog.record_tuples] == [
-        (logging.INFO, "Reading 3 train.log data"),
-        # student
-        (
-            logging.INFO,
-            f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/student",
-        ),
-        (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-        (logging.INFO, "Reading metrics file flores_devtest.metrics"),
-        (logging.INFO, "Reading logs stream."),
-        (logging.INFO, "Successfully parsed 1002 lines"),
-        (logging.INFO, "Found 550 training entries"),
-        (logging.INFO, "Found 108 validation entries"),
-        # teacher-finetuned0
-        (
-            logging.INFO,
-            f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned0",
-        ),
-        (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-        (logging.INFO, "Reading metrics file flores_devtest.metrics"),
-        (logging.INFO, "Reading logs stream."),
-        (logging.INFO, "Successfully parsed 993 lines"),
-        (logging.INFO, "Found 567 training entries"),
-        (logging.INFO, "Found 189 validation entries"),
-        # teacher-finetuned1
-        (
-            logging.INFO,
-            f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned1",
-        ),
-        (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-        (logging.INFO, "Reading metrics file flores_devtest.metrics"),
-        (logging.INFO, "Reading logs stream."),
-        (logging.INFO, "Successfully parsed 1000 lines"),
-        (logging.INFO, "Found 573 training entries"),
-        (logging.INFO, "Found 191 validation entries"),
-        # Group extra logs
-        (
-            logging.INFO,
-            "Publishing 'en-nl' group 'prod' metrics and files to a last fake run 'group_logs'",
-        ),
-        # Metrics for `speed` directory
-        (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-        (logging.INFO, "Reading metrics file flores_devtest.metrics"),
-    ]
+    # Assert on a `set` since the logging order may vary between runs.
+    assert set([(level, message) for _module, level, message in caplog.record_tuples]) == set(
+        [
+            (logging.INFO, "Reading 3 train.log data"),
+            # student
+            (
+                logging.INFO,
+                f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/student",
+            ),
+            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
+            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
+            (logging.INFO, "Reading logs stream."),
+            (logging.INFO, "Successfully parsed 1002 lines"),
+            (logging.INFO, "Found 550 training entries"),
+            (logging.INFO, "Found 108 validation entries"),
+            # teacher-finetuned0
+            (
+                logging.INFO,
+                f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned0",
+            ),
+            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
+            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
+            (logging.INFO, "Reading logs stream."),
+            (logging.INFO, "Successfully parsed 993 lines"),
+            (logging.INFO, "Found 567 training entries"),
+            (logging.INFO, "Found 189 validation entries"),
+            # teacher-finetuned1
+            (
+                logging.INFO,
+                f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned1",
+            ),
+            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
+            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
+            (logging.INFO, "Reading logs stream."),
+            (logging.INFO, "Successfully parsed 1000 lines"),
+            (logging.INFO, "Found 573 training entries"),
+            (logging.INFO, "Found 191 validation entries"),
+            # Group extra logs
+            (
+                logging.INFO,
+                "Publishing 'en-nl' group 'prod' metrics and files to a last fake run 'group_logs'",
+            ),
+            # Metrics for `speed` directory
+            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
+            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
+        ]
+    )
     log_calls, metrics_calls = [], []
     for log in wandb_mock.init.return_value.log.call_args_list:
         if log.args:
@@ -147,14 +150,16 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
     with (samples_dir / "experiments_wandb_calls.json").open("r") as f:
         assert log_calls == [call(**entry) for entry in json.load(f)]
     # Custom calls for .metrics files publication
-    assert [list(v.keys())[0] for c in metrics_calls for v in c.args] == [
-        "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-        "Flores_devtest summary",
-        "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-        "Flores_devtest summary",
-        "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-        "Flores_devtest summary",
-    ]
+    assert set([list(v.keys())[0] for c in metrics_calls for v in c.args]) == set(
+        [
+            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
+            "Flores_devtest summary",
+            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
+            "Flores_devtest summary",
+            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
+            "Flores_devtest summary",
+        ]
+    )
 
 
 @patch(


### PR DESCRIPTION
Fixes #365

This PR is fixing a whole slew of issues with the CI.

I was sure if ruff was working because of this `--no-root` issue.

```
[task 2024-01-11T21:16:22.015Z]   • Installing wandb (0.16.1)
[task 2024-01-11T21:16:22.356Z]   • Installing ruff (0.0.287)
[task 2024-01-11T21:16:22.695Z]   • Installing translations-parser (0.1.0 /builds/worker/checkouts/vcs/tracking)
[task 2024-01-11T21:16:24.195Z] 
[task 2024-01-11T21:16:24.196Z] Installing the current project: firefox-translations-training (0.1.0)
[task 2024-01-11T21:16:24.197Z] 
[task 2024-01-11T21:16:24.197Z] The current project could not be installed: No file/folder found for package firefox-translations-training
[task 2024-01-11T21:16:24.197Z] If you do not want to install the current project use --no-root
[taskcluster 2024-01-11 21:16:25.264Z] === Task Finished ===
[taskcluster 2024-01-11 21:16:25.264Z] Successful task run with exit code: 0 completed in 18.569 seconds
```

And then pytest-clarity wasn't adding clarity due to colors not being displayed.

I also updated ruff since I was getting local errors.