### PR TITLE
Parse missing evaluation results

### DIFF
--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_backward_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_backward_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=nl
++ trg=en
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest nl en /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=nl
++ trg=en
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: nl-en, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: nl-en, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest.metrics
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest.en
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/backward/flores_devtest.en.ref -d -f text --score-only -l nl-en -m bleu chrf
+28.5
+57.8
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_backward_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_backward_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=nl
++ trg=en
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld nl en /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=nl
++ trg=en
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: nl-en, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: nl-en, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld.en.ref -d -f text --score-only -l nl-en -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/backward/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/backward/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+33.5
+58.2
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_student-finetuned_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_student-finetuned_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest.metrics
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest.nl
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz
+27.3
+58.6
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_student-finetuned_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_student-finetuned_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student-finetuned/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student-finetuned/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+30.0
+60.2
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_student_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_student_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/flores_devtest.metrics
+26.9
+58.4
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_student_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_student_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/student/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/student/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+29.9
+60.3
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base0_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base0_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/flores_devtest.metrics
+27.7
+59.0
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base0_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base0_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base0/final.model.npz.best-chrf.npz
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base0/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+34.9
+62.6
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base1_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base1_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest.en
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/flores_devtest.metrics
+28.0
+59.1
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base1_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-base1_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-base1/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-base1/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+34.5
+62.4
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-ensemble_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-ensemble_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest.metrics
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest.nl
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
+28.3
+59.4
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-ensemble_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-ensemble_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-ensemble/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+36.7
+63.1
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned0_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned0_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest.nl
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/flores_devtest.metrics
+28.4
+59.5
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned0_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned0_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned0/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned0/final.model.npz.best-chrf.npz
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+36.1
+62.7
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned1_flores_devtest.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned1_flores_devtest.log
@@ -1,0 +1,41 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest
++ mkdir -p flores_devtest
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/flores_devtest.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest.nl
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest.en
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/flores_devtest.metrics
+28.3
+59.3
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned1_mtdata_Neulab-tedtalks_test-1-eng-nld.log
+++ b/tests/data/experiments/logs/en-nl/prod/eval/eval_teacher-finetuned1_mtdata_Neulab-tedtalks_test-1-eng-nld.log
@@ -1,0 +1,44 @@
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ test -v GPUS
++ test -v MARIAN
++ test -v WORKSPACE
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml
++ models=("${@:6}")
+++ dirname pipeline/eval/eval-gpu.sh
++ cd pipeline/eval
++ bash eval.sh /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld en nl /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ set -euo pipefail
++ echo '###### Evaluation of a model'
+###### Evaluation of a model
++ res_prefix=/data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ dataset_prefix=/data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld
++ src=en
++ trg=nl
++ marian=/data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build
++ decoder_config=/data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml
++ args=("${@:7}")
+++ basename /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ mkdir -p mtdata_Neulab-tedtalks_test-1-eng-nld
++ echo '### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld'
+### Evaluating dataset: /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld, pair: en-nl, Results prefix: /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.gz
++ pigz -dc /data/rw/evgeny/data/en-nl/prod/original/eval/mtdata_Neulab-tedtalks_test-1-eng-nld.en.gz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld.en
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld.nl
++ sacrebleu /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld.nl.ref -d -f text --score-only -l en-nl -m bleu chrf
++ /data/rw/evgeny/firefox-translations-training/3rd_party/marian-dev/build/marian-decoder -c /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz.decoder.yml --quiet --quiet-translation --log /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld.log -w 8000 --devices 0 1 2 3 4 5 6 7 -m /data/rw/evgeny/models/en-nl/prod/teacher-finetuned1/final.model.npz.best-chrf.npz
++ tee /data/rw/evgeny/models/en-nl/prod/evaluation/teacher-finetuned1/mtdata_Neulab-tedtalks_test-1-eng-nld.metrics
+sacreBLEU: That's 100 lines that end in a tokenized period ('.')
+sacreBLEU: It looks like you forgot to detokenize your test data, which may hurt your score.
+sacreBLEU: If you insist your data is detokenized, or don't care, you can suppress this message with the `force` parameter.
+35.9
+62.9
+No subset information found. Consider using --origlang argument.
++ echo '###### Done: Evaluation of a model'
+###### Done: Evaluation of a model

--- a/tests/test_tracking_cli.py
+++ b/tests/test_tracking_cli.py
@@ -103,8 +103,6 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
                 logging.INFO,
                 f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/student",
             ),
-            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
             (logging.INFO, "Reading logs stream."),
             (logging.INFO, "Successfully parsed 1002 lines"),
             (logging.INFO, "Found 550 training entries"),
@@ -114,8 +112,6 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
                 logging.INFO,
                 f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned0",
             ),
-            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
             (logging.INFO, "Reading logs stream."),
             (logging.INFO, "Successfully parsed 993 lines"),
             (logging.INFO, "Found 567 training entries"),
@@ -125,20 +121,17 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
                 logging.INFO,
                 f"Parsing folder {samples_dir}/experiments/models/en-nl/prod/teacher-finetuned1",
             ),
-            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
             (logging.INFO, "Reading logs stream."),
             (logging.INFO, "Successfully parsed 1000 lines"),
             (logging.INFO, "Found 573 training entries"),
             (logging.INFO, "Found 191 validation entries"),
-            # Group extra logs
+            # Publish group files and quantized/evaluated metrics
             (
                 logging.INFO,
-                "Publishing 'en-nl' group 'prod' metrics and files to a last fake run 'group_logs'",
+                "Publishing 'en-nl/prod' evaluation metrics and files (fake run 'group_logs')",
             ),
-            # Metrics for `speed` directory
-            (logging.INFO, "Reading metrics file mtdata_Neulab-tedtalks_test-1-eng-nld.metrics"),
-            (logging.INFO, "Reading metrics file flores_devtest.metrics"),
+            (logging.INFO, "Found 2 quantized metrics"),
+            (logging.INFO, "Found 16 evaluation metrics"),
         ]
     )
     log_calls, metrics_calls = [], []
@@ -152,12 +145,12 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
     # Custom calls for .metrics files publication
     assert set([list(v.keys())[0] for c in metrics_calls for v in c.args]) == set(
         [
-            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-            "Flores_devtest summary",
-            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-            "Flores_devtest summary",
-            "Mtdata_neulab-tedtalks_test-1-eng-nld summary",
-            "Flores_devtest summary",
+            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "flores_devtest",
+            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "flores_devtest",
+            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "flores_devtest",
         ]
     )
 

--- a/tests/test_tracking_cli.py
+++ b/tests/test_tracking_cli.py
@@ -132,6 +132,12 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
             ),
             (logging.INFO, "Found 2 quantized metrics"),
             (logging.INFO, "Found 16 evaluation metrics"),
+            (20, "Creating missing run backward with associated metrics"),
+            (20, "Creating missing run quantized with associated metrics"),
+            (20, "Creating missing run student-finetuned with associated metrics"),
+            (20, "Creating missing run teacher-base0 with associated metrics"),
+            (20, "Creating missing run teacher-base1 with associated metrics"),
+            (20, "Creating missing run teacher-ensemble with associated metrics"),
         ]
     )
     log_calls, metrics_calls = [], []
@@ -145,11 +151,11 @@ def test_experiments(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
     # Custom calls for .metrics files publication
     assert set([list(v.keys())[0] for c in metrics_calls for v in c.args]) == set(
         [
-            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "mtdata_Neulab-tedtalks_test-1-eng-nld",
             "flores_devtest",
-            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "mtdata_Neulab-tedtalks_test-1-eng-nld",
             "flores_devtest",
-            "mtdata_neulab-tedtalks_test-1-eng-nld",
+            "mtdata_Neulab-tedtalks_test-1-eng-nld",
             "flores_devtest",
         ]
     )

--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -55,7 +55,7 @@ def parse_experiment(
     metrics = []
     if metrics_dir:
         for metrics_file in metrics_dir.glob("*.metrics"):
-            metrics.append(Metric.from_file(model_name=name, metrics_file=metrics_file))
+            metrics.append(Metric.from_file(model_name=f"{group}.{name}", metrics_file=metrics_file))
 
     with logs_file.open("r") as f:
         lines = (line.strip() for line in f.readlines())
@@ -103,7 +103,7 @@ def publish_group_logs(
     # Add "quantized" metrics
     metrics = []
     for file in quantized_metrics:
-        metrics.append(Metric.from_file("quantized", file))
+        metrics.append(Metric.from_file(f"{group}.quantized", file))
     # Add experiment (runs) metrics
     for file in evaluation_metrics:
         model_name = file.stem.lstrip("eval_")
@@ -114,6 +114,8 @@ def publish_group_logs(
             if keyword in model_name:
                 index = model_name.index(keyword)
                 model_name, dataset = model_name[:index].strip("_"), model_name[index:]
+                # Prefix model name with group, so it is distinguishable among groups in W&B
+                model_name = f"{group}.{model_name}"
                 break
             else:
                 continue
@@ -213,7 +215,7 @@ def main() -> None:
                 logger.warning("Evaluation metrics files not found, skipping.")
             try:
                 parse_experiment(project, group, name, file, metrics_dir=metrics_dir)
-                existing_runs.append(name)
+                existing_runs.append(f"{group}.{name}")
             except Exception as e:
                 logger.error(f"An exception occured parsing {file}: {e}")
 

--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -55,9 +55,7 @@ def parse_experiment(
     metrics = []
     if metrics_dir:
         for metrics_file in metrics_dir.glob("*.metrics"):
-            metrics.append(
-                Metric.from_file(model_name=f"{group}.{name}", metrics_file=metrics_file)
-            )
+            metrics.append(Metric.from_file(metrics_file=metrics_file))
 
     with logs_file.open("r") as f:
         lines = (line.strip() for line in f.readlines())
@@ -106,7 +104,7 @@ def publish_group_logs(
     metrics = defaultdict(list)
     # Add "quantized" metrics
     for file in quantized_metrics:
-        metrics["quantized"].append(Metric.from_file(f"{group}.quantized", file))
+        metrics["quantized"].append(Metric.from_file(file))
     # Add experiment (runs) metrics
     for file in evaluation_metrics:
         model_name = file.stem.lstrip("eval_")
@@ -117,8 +115,6 @@ def publish_group_logs(
             if keyword in model_name:
                 index = model_name.index(keyword)
                 model_name, dataset = model_name[:index].strip("_"), model_name[index:]
-                # Prefix model name with group, so it is distinguishable among groups in W&B
-                prefixed_name = f"{group}.{model_name}"
                 break
             else:
                 continue
@@ -129,7 +125,7 @@ def publish_group_logs(
         with file.open("r") as f:
             lines = f.readlines()
         try:
-            metrics[model_name].append(Metric.from_tc_context(prefixed_name, dataset, lines))
+            metrics[model_name].append(Metric.from_tc_context(dataset, lines))
         except ValueError as e:
             logger.error(f"Could not parse metrics from {file.resolve()}: {e}")
 

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -1,14 +1,24 @@
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Sequence
 
 logging.basicConfig(
     level=logging.INFO,
     format="[%(levelname)s] %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+METRIC_LOG_RE = re.compile(
+    r"|".join(
+        [
+            r"\+ tee .+\.metrics",
+            r"\+ sacrebleu .+",
+        ]
+    )
+)
 
 
 @dataclass
@@ -35,12 +45,16 @@ class ValidationEpoch:
 class Metric:
     """Data extracted from a `.metrics` file"""
 
-    name: str
+    # Evaluation identifiers
+    model_name: str
+    dataset: str
+    augmentation: str | None
+    # Scores
     chrf: float
     bleu_detok: float
 
     @classmethod
-    def from_file(cls, metrics_file: Path):
+    def from_file(cls, model_name: str, metrics_file: Path):
         logger.info(f"Reading metrics file {metrics_file.name}")
         values = []
         try:
@@ -55,7 +69,37 @@ class Metric:
         except Exception as e:
             raise ValueError(f"Metrics file could not be parsed: {e}")
         bleu_detok, chrf = values
-        return cls(name=metrics_file.stem, chrf=chrf, bleu_detok=bleu_detok)
+        return cls(
+            model_name=model_name,
+            dataset=metrics_file.stem,
+            augmentation=None,
+            chrf=chrf,
+            bleu_detok=bleu_detok,
+        )
+
+    def from_tc_context(cls, model_name: str, dataset: str, lines: Sequence[str]):
+        """
+        Try reading a metric from Taskcluster logs, looking for two
+        successive floats after a line maching METRIC_LOG_RE.
+        """
+        for index, line in enumerate(lines):
+            if not METRIC_LOG_RE.match(line):
+                continue
+            try:
+                values = [float(val) for val in lines[index + 1 : index + 3]]
+            except ValueError:
+                continue
+            if len(values) != 2:
+                continue
+            bleu_detok, chrf = values
+            return cls(
+                model_name=model_name,
+                dataset=dataset,
+                augmentation=None,
+                chrf=chrf,
+                bleu_detok=bleu_detok,
+            )
+        raise ValueError("Metrics logs could not be parsed")
 
 
 @dataclass

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -15,7 +15,11 @@ METRIC_LOG_RE = re.compile(
     r"|".join(
         [
             r"\+ tee .+\.metrics",
+            r"\+ tee .+\.en",
             r"\+ sacrebleu .+",
+            r"\+ .+\/marian-decoder .+",
+            # Ignore potential comments
+            r"^sacreBLEU:",
         ]
     )
 )

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -50,7 +50,6 @@ class Metric:
     """Data extracted from a `.metrics` file"""
 
     # Evaluation identifiers
-    model_name: str
     dataset: str
     augmentation: str | None
     # Scores
@@ -58,7 +57,7 @@ class Metric:
     bleu_detok: float
 
     @classmethod
-    def from_file(cls, model_name: str, metrics_file: Path):
+    def from_file(cls, metrics_file: Path):
         logger.debug(f"Reading metrics file {metrics_file.name}")
         values = []
         try:
@@ -74,7 +73,6 @@ class Metric:
             raise ValueError(f"Metrics file could not be parsed: {e}")
         bleu_detok, chrf = values
         return cls(
-            model_name=model_name,
             dataset=metrics_file.stem,
             augmentation=None,
             chrf=chrf,
@@ -82,7 +80,7 @@ class Metric:
         )
 
     @classmethod
-    def from_tc_context(cls, model_name: str, dataset: str, lines: Sequence[str]):
+    def from_tc_context(cls, dataset: str, lines: Sequence[str]):
         """
         Try reading a metric from Taskcluster logs, looking for two
         successive floats after a line maching METRIC_LOG_RE.
@@ -98,7 +96,6 @@ class Metric:
                 continue
             bleu_detok, chrf = values
             return cls(
-                model_name=model_name,
                 dataset=dataset,
                 augmentation=None,
                 chrf=chrf,

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -55,7 +55,7 @@ class Metric:
 
     @classmethod
     def from_file(cls, model_name: str, metrics_file: Path):
-        logger.info(f"Reading metrics file {metrics_file.name}")
+        logger.debug(f"Reading metrics file {metrics_file.name}")
         values = []
         try:
             with metrics_file.open("r") as f:
@@ -77,6 +77,7 @@ class Metric:
             bleu_detok=bleu_detok,
         )
 
+    @classmethod
     def from_tc_context(cls, model_name: str, dataset: str, lines: Sequence[str]):
         """
         Try reading a metric from Taskcluster logs, looking for two

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -263,11 +263,6 @@ class TrainingParser:
         for publisher in self.publishers:
             publisher.open(self)
 
-        # Publish optional metrics
-        if self.metrics:
-            for publisher in self.publishers:
-                publisher.handle_metrics(self.metrics)
-
         # Run training and validation data parser
         self.parse_data(logs_iter)
         self.parsed = True
@@ -276,10 +271,14 @@ class TrainingParser:
         for publisher in self.publishers:
             try:
                 publisher.publish(self.output)
+                # Publish optional metrics
+                if self.metrics:
+                    publisher.handle_metrics(self.metrics)
             except Exception as e:
                 logger.error(f"Error publishing data using {publisher.__class__.__name__}: {e}")
-            finally:
-                publisher.close()
+
+        for publisher in self.publishers:
+            publisher.close()
 
     @property
     def logs_str(self) -> str:

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -129,17 +129,14 @@ class WandB(Publisher):
             # Publish a bar chart (a table with values will also be available from W&B)
             self.wandb.log(
                 {
-                    f"{metric.dataset.capitalize()}": wandb.plot.bar(
+                    metric.dataset.lower(): wandb.plot.bar(
                         wandb.Table(
                             columns=["Metric", "Value"],
-                            data=[
-                                [key, getattr(metric, key)]
-                                for key in ("chrf", "bleu_detok")
-                            ],
+                            data=[[key, getattr(metric, key)] for key in ("bleu_detok", "chrf")],
                         ),
                         "Metric",
                         "Value",
-                        title=f"{metric.dataset.capitalize()} summary",
+                        title=metric.dataset.capitalize(),
                     )
                 }
             )

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -129,7 +129,7 @@ class WandB(Publisher):
             # Publish a bar chart (a table with values will also be available from W&B)
             self.wandb.log(
                 {
-                    metric.dataset.lower(): wandb.plot.bar(
+                    metric.dataset: wandb.plot.bar(
                         wandb.Table(
                             columns=["Metric", "Value"],
                             data=[[key, getattr(metric, key)] for key in ("bleu_detok", "chrf")],

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -129,17 +129,17 @@ class WandB(Publisher):
             # Publish a bar chart (a table with values will also be available from W&B)
             self.wandb.log(
                 {
-                    f"{metric.name.capitalize()} summary": wandb.plot.bar(
+                    f"{metric.dataset.capitalize()}": wandb.plot.bar(
                         wandb.Table(
                             columns=["Metric", "Value"],
                             data=[
-                                [f"{metric.name} - {key}", getattr(metric, key)]
+                                [key, getattr(metric, key)]
                                 for key in ("chrf", "bleu_detok")
                             ],
                         ),
                         "Metric",
                         "Value",
-                        title=f"{metric.name.capitalize()} summary",
+                        title=f"{metric.dataset.capitalize()} summary",
                     )
                 }
             )


### PR DESCRIPTION
Closes #334 \
Closes #336

Displays a table will all evaluation metrics on `group_logs`.
Metrics by run are still published individually.

Results have been updated on https://wandb.ai/teklia/projects. \
I still need to update tests on this PR.