### PR TITLE
Fix Bicleaner-ai GPU usage

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -83,8 +83,9 @@ else
        parallel -j ${#CUDA_VISIBLE_ARRAY[@]} --pipe -k --block 10M biclean "${pack_dir}"/*.yaml {%} |
        ${COMPRESSION_CMD} >"${output_prefix}.scored.${ARTIFACT_EXT}"
   else
+   export BICLEANER_AI_THREADS=${threads}
    paste <(${COMPRESSION_CMD} -dc "${corpus_prefix}.${SRC}.${ARTIFACT_EXT}") <(${COMPRESSION_CMD} -dc "${corpus_prefix}.${TRG}.${ARTIFACT_EXT}") |
-     bicleaner-ai-classify ${hardrules} --scol ${scol} --tcol ${tcol} --processes "${threads}"  - - "${pack_dir}"/*.yaml |
+     bicleaner-ai-classify ${hardrules} --scol ${scol} --tcol ${tcol} "${threads}"  - - "${pack_dir}"/*.yaml |
      ${COMPRESSION_CMD} >"${output_prefix}.scored.${ARTIFACT_EXT}"
   fi
 

--- a/taskcluster/kinds/bicleaner/kind.yml
+++ b/taskcluster/kinds/bicleaner/kind.yml
@@ -111,7 +111,7 @@ tasks:
             toolchain:
                 - hunspell
                 - kenlm
-                - cuda-toolkit
+                - cuda-toolkit-11
             "{provider}":
                 - artifact: "{dataset_sanitized}.{src_locale}.zst"
                   extract: false

--- a/taskcluster/kinds/fetch/toolchains.yml
+++ b/taskcluster/kinds/fetch/toolchains.yml
@@ -49,3 +49,13 @@ cuda:
         sha256: 68699036c12d71adb9ad2799dce2ff070270fab4488b90920b9756ab3f52c41c
         size: 4245586997
         artifact-name: cuda-source.run
+
+
+cuda-11:
+    description: CUDA 11.2.0 Source
+    fetch:
+        type: static-url
+        url: https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run  # yamllint disable-line rule:line-length
+        sha256: 9c50283241ac325d3085289ed9b9c170531369de41165ce271352d4a898cbdce
+        size: 3046790184
+        artifact-name: cuda-source.run

--- a/taskcluster/kinds/toolchain/kind.yml
+++ b/taskcluster/kinds/toolchain/kind.yml
@@ -23,7 +23,7 @@ task-defaults:
 
 tasks:
     cuda-toolkit:
-        description: CUDA Toolkit preparation
+        description: CUDA Toolkit 12 preparation
         run:
             script: build-cuda-toolkit.sh
             resources:
@@ -33,6 +33,16 @@ tasks:
             fetch:
                 - cuda
 
+    cuda-toolkit-11:
+        description: CUDA Toolkit 11.2 preparation
+        run:
+            script: build-cuda-toolkit.sh
+            resources:
+                - taskcluster/scripts/toolchain/build-cuda-toolkit.sh
+            toolchain-artifact: public/build/cuda-toolkit.tar.zst
+        fetches:
+            fetch:
+                - cuda-11
     marian:
         description: Marian
         worker-type: b-cpu

--- a/taskcluster/scripts/toolchain/build-cuda-toolkit.sh
+++ b/taskcluster/scripts/toolchain/build-cuda-toolkit.sh
@@ -19,6 +19,7 @@ chmod +x $CUDA_INSTALLER
 # in the current working directory. The files we care about
 # will end up in `pkg/builds`.
 EXTRACT_DIR="$(pwd)/cuda-toolkit"
-$CUDA_INSTALLER --toolkit --toolkitpath=$EXTRACT_DIR --silent
+# it complains on compiler version check on Ubuntu 22 for cuda toolkit 11.2. overriding helps
+$CUDA_INSTALLER --toolkit --toolkitpath=$EXTRACT_DIR --silent --override
 
 tar --zstd -cf $TARFILE.zst cuda-toolkit


### PR DESCRIPTION
- add a toolchain for cuda toolkit 11.2 and use it for Bicleaner-AI
- fix warning with Bicleaner --processes argument

It was tested manually in an interactive task and it's using GPUs properly. 

There's still a warning about TensorRT which is optional. We can try installing it, maybe it can improve inference speed.
There's also a NUMA warning which was there before. I didn't look into it.

fixes #388 

Timing from running a separate `bicleaner-ai-classify` that uses one GPU:
```
2024-01-24 20:08:20,733 - INFO - Total: 125009 rows
2024-01-24 20:08:20,733 - INFO - Elapsed time 149.88 s
2024-01-24 20:08:20,733 - INFO - Troughput: 834 rows/s
```

The speed in CI is 10x rows/sec vs the old version.

```
2024-01-24 19:27:35.838633: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA                          
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.                                                                                                                                                                                                
2024-01-24 19:27:36.968549: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/ubuntu/tasks/task_17
0611894115341/fetches/cuda-toolkit11/lib64:/home/ubuntu/tasks/task_170611894115341/fetches/cuda-toolkit11:LD_LIBRARY_PATH:                                                                                                                                                                 
2024-01-24 19:27:36.968708: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/ubuntu
/tasks/task_170611894115341/fetches/cuda-toolkit11/lib64:/home/ubuntu/tasks/task_170611894115341/fetches/cuda-toolkit11:LD_LIBRARY_PATH:                                                                                                                                                   
2024-01-24 19:27:36.968721: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.               
2024-01-24 19:27:40.840766: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:40.850216: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:40.851341: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:40.852366: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA                          
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.                                                                                                                                                                                                
2024-01-24 19:27:40.852902: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:40.853573: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:40.854466: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:41.838808: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:41.839268: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:41.839703: I tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc:981] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero                                                   
2024-01-24 19:27:41.840062: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1613] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 14621 MB memory:  -> device: 0, name: Tesla V100-SXM2-16GB, pci bus id: 0000:00:04.0, compute capability: 7.0                        
2024-01-24 19:27:45,438 - WARNING - LM filter not present in metadata, disabling.                                                                                                                                                                                                          
2024-01-24 19:27:45,444 - INFO - Arguments processed                                                                                                                                                                                                                                       
2024-01-24 19:27:45,445 - INFO - Starting process                                                                                                                                                                                                                                          
2024-01-24 19:29:52,006 - INFO - Finished                                                                                                                                                                                                                                                  
2024-01-24 19:29:52,006 - INFO - Total: 41027 rows                                                                                                                                                                                                                                         
2024-01-24 19:29:52,006 - INFO - Elapsed time 126.56 s                                                                                                                                                                                                                                     
2024-01-24 19:29:52,006 - INFO - Troughput: 324 rows/s                                                                                                                                                                                                                                     
2024-01-24 19:29:52,006 - INFO - Program finished
```

[skip ci]