### PR TITLE
Use a run_task abstraction for eval-tests.py

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,9 +1,16 @@
+import json
 import os
+import re
+import shlex
 import shutil
+import subprocess
 import sys
 from subprocess import CompletedProcess
+from typing import Optional, Union
 
 import zstandard as zstd
+
+from utils.preflight_check import get_taskgraph_parameters, run_taskgraph
 
 FIXTURES_PATH = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.abspath(os.path.join(FIXTURES_PATH, "../../data"))
@@ -36,6 +43,8 @@ class DataDir:
     Creates a persistent data directory in data/tests_data/{dir_name} that will be
     cleaned out before a test run. This should help in persisting artifacts between test
     runs to manually verify the results.
+
+    Taskcluster tasks can be run directly using the data dir via the run_task method.
     """
 
     def __init__(self, dir_name: str) -> None:
@@ -96,6 +105,77 @@ class DataDir:
 
         return text_path
 
+    def mkdir(self, name) -> str:
+        path = self.join(name)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def run_task(
+        self,
+        task_name: str,
+        work_dir: Optional[str] = None,
+        fetches_dir: Optional[str] = None,
+        env: dict[str, str] = {},
+    ):
+        """
+        Runs a task from the taskgraph. See artifacts/full-task-graph.json after running a
+        test for the full list of task names
+
+        Arguments:
+
+        task_name - The full task name like "split-mono-src-en"
+            or "evaluate-backward-sacrebleu-wmt09-en-ru".
+
+        data_dir - The test's DataDir
+
+        work_dir - This is the TASK_WORKDIR, in tests generally the test's DataDir.
+
+        fetches_dir - The MOZ_FETCHES_DIR, generally set as the test's DataDir.
+
+        env - Any environment variable overrides.
+        """
+
+        command_parts, task_env = get_task_command_and_env(task_name)
+
+        # There are some non-string environment variables that involve taskcluster references
+        # Remove these.
+        for key in task_env:
+            if not isinstance(task_env[key], str):
+                task_env[key] = ""
+
+        current_folder = os.path.dirname(os.path.abspath(__file__))
+        root_path = os.path.abspath(os.path.join(current_folder, "../.."))
+
+        if not work_dir:
+            work_dir = self.path
+        if not fetches_dir:
+            fetches_dir = self.path
+
+        # Manually apply the environment variables, as they don't get added to the args
+        # through the subprocess.run
+        command_parts = [
+            part.replace("$TASK_WORKDIR/$VCS_PATH", root_path)
+            .replace("$TASK_WORKDIR", work_dir)
+            .replace("$MOZ_FETCHES_DIR", fetches_dir)
+            for part in command_parts
+        ]
+
+        result = subprocess.run(
+            command_parts,
+            env={
+                **os.environ,
+                **task_env,
+                "TASK_WORKDIR": work_dir,
+                "MOZ_FETCHES_DIR": fetches_dir,
+                "VCS_PATH": root_path,
+                **env,
+            },
+            cwd=root_path,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        fail_on_error(result)
+
 
 def fail_on_error(result: CompletedProcess[bytes]):
     """When a process fails, surface the stderr."""
@@ -104,3 +184,119 @@ def fail_on_error(result: CompletedProcess[bytes]):
             print(line, file=sys.stderr)
 
         raise Exception(f"{result.args[0]} exited with a status code: {result.returncode}")
+
+
+# Only (lazily) create the full taskgraph once per test suite run as it's quite slow.
+_full_taskgraph: Optional[dict[str, object]] = None
+
+
+def get_full_taskgraph():
+    """
+    Generates the full taskgraph and stores it for re-use. It uses the config.pytest.yml
+    in this directory.
+    """
+    global _full_taskgraph  # noqa: PLW0603
+    if _full_taskgraph:
+        return _full_taskgraph
+    current_folder = os.path.dirname(os.path.abspath(__file__))
+    config = os.path.join(current_folder, "config.pytest.yml")
+    task_graph_json = os.path.join(current_folder, "../../artifacts/full-task-graph.json")
+
+    run_taskgraph(config, get_taskgraph_parameters())
+
+    with open(task_graph_json, "rb") as file:
+        _full_taskgraph = json.load(file)
+    return _full_taskgraph
+
+
+# Match a pipeline script like:
+# pipeline/data/dataset_importer.py
+SCRIPT_REGEX = re.compile(r"\/pipeline\/([\w\/-]+)\.(py|sh)")
+
+
+def find_pipeline_script(commands: Union[list[str], list[list[str]]]) -> str:
+    """
+    Extract the pipeline script and arguments from a command list.
+
+    Commands take the form:
+    [
+       ['chmod', '+x', 'run-task'],
+       ['./run-task', '--firefox_translations_training-checkout=./checkouts/vcs/', '--', 'bash', '-c', "full command"]
+    ]
+
+    or
+
+    [
+          "/usr/local/bin/run-task",
+          "--firefox_translations_training-checkout=/builds/worker/checkouts/vcs/",
+          "--", "bash", "-c",
+          "full command"
+    ]
+    """
+    command: str
+    if isinstance(commands[-1], str):
+        command = commands[-1]
+    elif isinstance(commands[-1][-1], str):
+        command = commands[-1][-1]
+    else:
+        print(command)
+        raise Exception("Unable to find a string in the nested command.")
+
+    match = re.search(r"\/pipeline\/([\w\/-]+)\.(py|sh)", command)
+    #                               ^^^^^^^^^^   ^^^^^
+    #                               |            |
+    #    Match the path to the script            Match the extension
+
+    if not match:
+        raise Exception(f"Could not find a pipeline script in the command: {command}")
+
+    script = f"pipeline/{match.group(1)}.{match.group(2)}"
+
+    # Return the parts after the script name.
+    parts = command.split(script)
+    if len(parts) != 2:
+        raise Exception(f"Could not find {script} in: {command}")
+    args = parts[1].strip()
+
+    return f"{script} {args}"
+
+
+def get_task_command_and_env(task_name: str, script=None) -> tuple[str, dict[str, str]]:
+    """
+    Extracts a task's command from the full taskgraph. This allows for testing
+    the full taskcluster pipeline and the scripts that it generates.
+    See artifacts/full-task-graph.json for the full list of what is generated.
+
+    task_name - The full task name like "split-mono-src-en"
+        or "evaluate-backward-sacrebleu-wmt09-en-ru".
+    script - If this is provided, then it will return all of the arguments provided
+        to a script, and ignore everything that came before it.
+    """
+    full_taskgraph = get_full_taskgraph()
+    task = full_taskgraph.get(task_name)
+    if not task:
+        print("Available tasks:")
+        for key in full_taskgraph.keys():
+            print(f' - "{key}"')
+        raise Exception(f"Could not find the task {task_name}")
+
+    env = task["task"]["payload"]["env"]
+
+    commands = task["task"]["payload"]["command"]
+    pipeline_script = find_pipeline_script(commands)
+
+    print(f'Running: "{task_name}":')
+    print(" > Commands:", commands)
+    print(" > Running:", pipeline_script)
+    print(" > Env:", env)
+
+    command_parts = [
+        part
+        for part in shlex.split(pipeline_script)
+        # subprocess.run doesn't understand how to redirect stderr to stdout, so ignore this
+        # if it's part of the command.
+        if part != "2>&1"
+    ]
+
+    # Return the full command.
+    return command_parts, env

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -20,14 +20,14 @@ Instantly the wicked woman gave a loud cry of fear, and then, as Dorothy looked 
 “I’m very sorry, indeed,” said Dorothy, who was truly frightened to see the Witch actually melting away like brown sugar before her very eyes.
 """
 
-ca_sample = """La nena, en veure que havia perdut una de les seves boniques sabates, es va enfadar i va dir a la bruixa: "Torna'm la sabata!"
-"No ho faré", va replicar la Bruixa, "perquè ara és la meva sabata, i no la teva".
-"Ets una criatura dolenta!" va cridar la Dorothy. "No tens dret a treure'm la sabata".
-"Me'l guardaré, igualment", va dir la Bruixa, rient-se d'ella, "i algun dia t'agafaré l'altre també".
-Això va fer enfadar tant la Dorothy que va agafar la galleda d'aigua que hi havia a prop i la va llançar sobre la Bruixa, mullant-la de cap a peus.
-A l'instant, la malvada dona va fer un fort crit de por, i aleshores, mentre la Dorothy la mirava meravellada, la Bruixa va començar a encongir-se i a caure.
-"Mira què has fet!" ella va cridar. "D'aquí a un minut em fondreré".
-"Ho sento molt, de veritat", va dir la Dorothy, que es va espantar veritablement de veure que la Bruixa es va desfer com el sucre moreno davant els seus mateixos ulls.
+ru_sample = """Маленькая девочка, увидев, что потеряла одну из своих красивых туфелек, рассердилась и сказала Ведьме: «Верни мне мою туфельку!»
+«Я не буду, — парировала Ведьма, — потому что теперь это моя туфля, а не твоя».
+«Ты злое существо!» - воскликнула Дороти. «Ты не имеешь права забирать у меня туфлю».
+«Я все равно сохраню его, — сказала Ведьма, смеясь над ней, — и когда-нибудь я получу от тебя и другой».
+Это так разозлило Дороти, что она взяла стоявшее рядом ведро с водой и облила им Ведьму, обмочив ее с головы до ног.
+Мгновенно злая женщина громко вскрикнула от страха, а затем, когда Дороти с удивлением посмотрела на нее, Ведьма начала сжиматься и падать.
+«Посмотри, что ты наделал!» она закричала. «Через минуту я растаю».
+«Мне действительно очень жаль», — сказала Дороти, которая была по-настоящему напугана, увидев, что Ведьма тает, как коричневый сахар, у нее на глазах.
 """
 
 

--- a/tests/fixtures/config.pytest.yml
+++ b/tests/fixtures/config.pytest.yml
@@ -1,0 +1,54 @@
+experiment:
+  name: pytest_en_ru
+  src: en
+  trg: ru
+  best-model: chrf
+  use-opuscleaner: "true"
+  bicleaner:
+    default-threshold: 0.5
+    dataset-thresholds:
+      opus_Books/v1: 0.0
+      opus_CCAligned/v1: 0.7
+  mono-max-sentences-src: 100_000_000
+  mono-max-sentences-trg: 20_000_000
+  spm-sample-size: 10_000_000
+  teacher-ensemble: 2
+  backward-model: NOT-YET-SUPPORTED
+  vocab: NOT-YET-SUPPORTED
+datasets:
+  devtest:
+    - flores_dev
+    - sacrebleu_wmt08
+    - mtdata_Neulab-tedtalks_dev-1-eng-rus
+  test:
+    - flores_devtest
+    - sacrebleu_wmt09
+    - mtdata_Neulab-tedtalks_test-1-eng-rus
+  train:
+    - opus_Books/v1
+    - opus_CCAligned/v1
+    - opus_CCMatrix/v1
+  mono-src:
+    - news-crawl_news.2021
+    - news-crawl_news.2020
+  mono-trg:
+    - news-crawl_news.2021
+    - news-crawl_news.2020
+marian-args:
+  decoding-backward:
+    beam-size: '12'
+    mini-batch-words: '2000'
+  decoding-teacher:
+    mini-batch-words: '4000'
+    precision: float16
+  training-backward:
+    early-stopping: '5'
+  training-teacher:
+    early-stopping: '30'
+  training-student:
+    early-stopping: '20'
+  training-student-finetuned:
+    early-stopping: '20'
+target-stage: all
+taskcluster:
+  split-chunks: 10

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -5,6 +5,7 @@ Tests evaluations
 import json
 import os
 
+import pytest
 from fixtures import DataDir, en_sample, ru_sample
 
 en_fake_translated = "\n".join([line.upper() for line in ru_sample.split("\n")])
@@ -15,141 +16,95 @@ fixtures_path = os.path.join(current_folder, "fixtures")
 root_path = os.path.abspath(os.path.join(current_folder, ".."))
 
 
-def create_test_data() -> DataDir:
-    # See /data/test_data/test_eval for the artifacts after a failure.
+def get_base_marian_args(data_dir: DataDir, model_name: str):
+    return [
+        "--config", data_dir.join("final.model.npz.best-chrf.npz.decoder.yml"),
+        "--quiet",
+        "--quiet-translation",
+        "--log", data_dir.join("artifacts/wmt09.log"),
+        '--workspace', '12000',
+        '--devices', '4',
+        "--models", data_dir.join(model_name),
+    ]  # fmt: skip
+
+
+def get_quantized_marian_args(data_dir: DataDir, model_name: str):
+    return [
+        "--config", os.path.join(root_path, "pipeline/quantize/decoder.yml"),
+        "--quiet",
+        "--quiet-translation",
+        "--log", data_dir.join("artifacts/wmt09.log"),
+        "--models", data_dir.join(model_name),
+        '--vocabs', data_dir.join("vocab.spm"), data_dir.join("vocab.spm"),
+        '--shortlist', data_dir.join("lex.s2t.pruned"), 'false',
+        '--int8shiftAlphaAll',
+    ]  # fmt: skip
+
+
+test_data = [
+    # task_name                                                   model_type   model_name
+    ("evaluate-backward-sacrebleu-wmt09-en-ru",                   "base",      "final.model.npz.best-chrf.npz"),
+    ("evaluate-finetuned-student-sacrebleu-wmt09-en-ru",          "base",      "final.model.npz.best-chrf.npz"),
+    ("evaluate-student-sacrebleu-wmt09-en-ru",                    "base",      "final.model.npz.best-chrf.npz"),
+    ("evaluate-teacher-ensemble-sacrebleu-sacrebleu_wmt09-en-ru", "base",      "model*/*.npz"),
+    ("evaluate-quantized-sacrebleu-wmt09-en-ru",                  "quantized", "model.intgemm.alphas.bin")
+]  # fmt:skip
+
+
+@pytest.mark.parametrize("params", test_data, ids=[d[0] for d in test_data])
+def test_evaluate(params) -> None:
+    (task_name, model_type, model_name) = params
+
     data_dir = DataDir("test_eval")
     data_dir.create_zst("wmt09.en.zst", en_sample)
     data_dir.create_zst("wmt09.ru.zst", ru_sample)
-    return data_dir
 
+    bleu = 0.4
+    chrf = 0.6
 
-def run_normal_eval_task(data_dir: DataDir, task_name: str) -> None:
-    data_dir.run_task(
-        task_name,
-        env={
+    if model_type == "base":
+        expected_marian_args = get_base_marian_args(data_dir, model_name)
+        env = {
             # This is where the marian_decoder_args will get stored.
             "TEST_ARTIFACTS": data_dir.path,
             # Replace marian with the one in the fixtures path.
             "MARIAN": fixtures_path,
             # This is included via the poetry install
             "COMPRESSION_CMD": "zstd",
-        },
-    )
-
-
-class Assert:
-    """
-    A collection of assertions for evaluation tests.
-    """
-
-    @staticmethod
-    def forward_eval(data_dir: DataDir, metrics: str) -> None:
-        """Assert en -> ru (forward translation)"""
-        assert data_dir.load("artifacts/wmt09.en") == en_sample
-        assert data_dir.load("artifacts/wmt09.ru.ref") == ru_sample
-        assert data_dir.load("artifacts/wmt09.ru") == ru_fake_translated
-        assert metrics in data_dir.load("artifacts/wmt09.metrics")
-
-    @staticmethod
-    def backward_eval(data_dir: DataDir, metrics: str) -> None:
-        """Assert ru -> en (back translations)"""
-        assert data_dir.load("artifacts/wmt09.ru") == ru_sample
-        assert data_dir.load("artifacts/wmt09.en.ref") == en_sample
-        assert data_dir.load("artifacts/wmt09.en") == en_fake_translated
-        assert metrics in data_dir.load("artifacts/wmt09.metrics")
-
-    @staticmethod
-    def base_marian_args(
-        data_dir: DataDir, model_name: str = "final.model.npz.best-chrf.npz"
-    ) -> None:
-        """
-        Marian is passed a certain set of arguments. This assertion will need to be
-        updated if the Marian configuration changes.
-        """
-        marian_decoder_args = json.loads(data_dir.load("marian-decoder.args.txt"))
-
-        expected_args = [
-            "--config", data_dir.join("final.model.npz.best-chrf.npz.decoder.yml"),
-            "--quiet",
-            "--quiet-translation",
-            "--log", data_dir.join("artifacts/wmt09.log"),
-            '--workspace', '12000',
-            '--devices', '0',
-            "--models", data_dir.join(model_name),
-        ]  # fmt: skip
-
-        assert marian_decoder_args == expected_args, "The marian arguments matched."
-
-    @staticmethod
-    def quantized_marian_args(data_dir: DataDir) -> None:
-        """
-        The quantized arguments are somewhat different
-        """
-        marian_decoder_args = json.loads(data_dir.load("marian-decoder.args.txt"))
-
-        expected_args = [
-            "--config", os.path.join(root_path, "pipeline/quantize/decoder.yml"),
-            "--quiet",
-            "--quiet-translation",
-            "--log", data_dir.join("artifacts/wmt09.log"),
-            "--models", data_dir.join("model.intgemm.alphas.bin"),
-            '--vocabs', data_dir.join("vocab.spm"), data_dir.join("vocab.spm"),
-            '--shortlist', data_dir.join("lex.s2t.pruned"), 'false',
-            '--int8shiftAlphaAll',
-        ]  # fmt: skip
-
-        assert marian_decoder_args == expected_args, "The marian arguments matched."
-
-
-def test_evaluate_backward() -> None:
-    data_dir = create_test_data()
-    run_normal_eval_task(data_dir, "evaluate-backward-sacrebleu-wmt09-en-ru")
-    Assert.backward_eval(data_dir, "0.4\n0.6")
-    Assert.base_marian_args(data_dir)
-
-
-def test_evaluate_finetuned() -> None:
-    data_dir = create_test_data()
-    run_normal_eval_task(data_dir, "evaluate-finetuned-student-sacrebleu-wmt09-en-ru")
-    Assert.forward_eval(data_dir, "0.4\n0.6")
-    Assert.base_marian_args(data_dir)
-
-
-def test_evaluate_student() -> None:
-    data_dir = create_test_data()
-    run_normal_eval_task(data_dir, "evaluate-student-sacrebleu-wmt09-en-ru")
-    Assert.forward_eval(data_dir, "0.4\n0.6")
-    Assert.base_marian_args(data_dir)
-
-
-def test_evaluate_teacher_ensemble() -> None:
-    data_dir = create_test_data()
-    run_normal_eval_task(
-        data_dir,
-        "evaluate-teacher-ensemble-sacrebleu-sacrebleu_wmt09-en-ru",
-    )
-    Assert.forward_eval(data_dir, "0.4\n0.6")
-    Assert.base_marian_args(data_dir, model_name="model*/*.npz")
-
-
-def test_evaluate_quantized() -> None:
-    """
-    This test is a little different as the quantized step requires a separate marian
-    configuration.
-    """
-    data_dir = create_test_data()
-
-    data_dir.run_task(
-        "evaluate-quantized-sacrebleu-wmt09-en-ru",
-        env={
+            "GPUS": "4",
+        }
+    elif model_type == "quantized":
+        expected_marian_args = get_quantized_marian_args(data_dir, model_name)
+        env = {
             # This is where the marian_decoder_args will get stored.
             "TEST_ARTIFACTS": data_dir.path,
             # Replace marian with the one in the fixtures path.
             "BMT_MARIAN": fixtures_path,
             # This is included via the poetry install
             "COMPRESSION_CMD": "zstd",
-        },
+        }
+
+    # Run the evaluation.
+    data_dir.run_task(
+        task_name,
+        env=env,
     )
 
-    Assert.forward_eval(data_dir, "0.4\n0.6")
-    Assert.quantized_marian_args(data_dir)
+    # Test that the data files are properly written out.
+    if "backward" in task_name:
+        # Backwards evaluation.
+        assert data_dir.load("artifacts/wmt09.ru") == ru_sample
+        assert data_dir.load("artifacts/wmt09.en.ref") == en_sample
+        assert data_dir.load("artifacts/wmt09.en") == en_fake_translated
+    else:
+        # Forwards evaluation.
+        assert data_dir.load("artifacts/wmt09.en") == en_sample
+        assert data_dir.load("artifacts/wmt09.ru.ref") == ru_sample
+        assert data_dir.load("artifacts/wmt09.ru") == ru_fake_translated
+
+    # Test that text metrics get properly generated.
+    assert f"{bleu}\n{chrf}\n" in data_dir.load("artifacts/wmt09.metrics")
+
+    # Test that marian is given the proper arguments.
+    marian_decoder_args = json.loads(data_dir.load("marian-decoder.args.txt"))
+    assert marian_decoder_args == expected_marian_args, "The marian arguments matched."

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -1,4 +1,5 @@
 import io
+import os
 from contextlib import redirect_stdout
 from typing import Optional
 
@@ -14,8 +15,11 @@ def get_preflight_check_output(*args):
         nonlocal opened_url
         opened_url = url
 
+    current_folder = os.path.dirname(os.path.abspath(__file__))
+    config = os.path.join(current_folder, "fixtures/config.pytest.yml")
+
     with redirect_stdout(f):
-        preflight_check(args, open_in_browser)
+        preflight_check([*args, "--config", config], open_in_browser)
 
     return f.getvalue(), opened_url
 

--- a/tests/test_spm_vocab.py
+++ b/tests/test_spm_vocab.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 import pytest
-from fixtures import DataDir, ca_sample, en_sample
+from fixtures import DataDir, en_sample, ru_sample
 
 current_folder = os.path.dirname(os.path.abspath(__file__))
 fixtures_path = os.path.join(current_folder, "fixtures")
@@ -28,7 +28,7 @@ def run_spm_test(arguments: list[str]) -> list[str]:
     command = [
         "pipeline/train/spm-vocab.sh",
         test_data_dir.create_zst("corpus.en.zst", en_sample),
-        test_data_dir.create_zst("corpus.ca.zst", ca_sample),
+        test_data_dir.create_zst("corpus.ru.zst", ru_sample),
         test_data_dir.join("vocab.spm"),
         *arguments,
     ]

--- a/utils/preflight_check.py
+++ b/utils/preflight_check.py
@@ -100,10 +100,23 @@ def get_taskgraph_parameters() -> Parameters:
     return parameters
 
 
+_last_config_path = None
+
+
 def run_taskgraph(cfg_path: str, parameters: Parameters) -> None:
     # The callback can be a few standard things like "cancel" and "rerun". Custom actions
     # can be created in taskcluster/translations_taskgraph/actions/ such as the train action.
     callback = "train"
+    cfg_path = os.path.realpath(cfg_path)
+    global _last_config_path  # noqa: PLW0602
+    if _last_config_path:
+        if cfg_path != _last_config_path:
+            raise Exception(
+                "Changing the config paths and re-running run_taskgraph is not supported."
+            )
+        # Don't regenerate the taskgraph for tests, as this can be slow. It's likely that
+        # tests will exercise this codepath.
+        return
     input = load_yml(cfg_path)
 
     # This command outputs the stdout. Ignore it here.


### PR DESCRIPTION
Instead of testing at the script level, this tests at the run-task level, which I feel is the integration test level.

```py
    run_task(
        task_name="evaluate-quantized-sacrebleu-wmt09-en-ru",
        script="pipeline/eval/eval-quantized.sh",
        work_dir=test_data_dir.path,
        fetches_dir=test_data_dir.path,
        env={
            # This is where the marian_decoder_args will get stored.
            "TEST_ARTIFACTS": test_data_dir.path,
            # Replace marian with the one in the fixtures path.
            "BMT_MARIAN": fixtures_path,
            # This is included via the poetry install
            "COMPRESSION_CMD": "zstd",
        },
    )
```

<s>I'm keeping this as draft because it contains work from #364 that I would like to land first. I also wanted to get a CI run in. The most relevant commit here is ecd27933ca12a6ec973bce31e1497e5e52097a3b</s>

Edit: This is ready for review.