### PR TITLE
Update import sorting to fix local lint checks

### DIFF
--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -14,7 +14,6 @@ from itertools import groupby
 from pathlib import Path
 
 import wandb
-
 from translations_parser.data import Metric
 from translations_parser.parser import TrainingParser
 from translations_parser.publishers import WandB

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Sequence
 
 import wandb
-
 from translations_parser.data import Metric, TrainingEpoch, TrainingLog, ValidationEpoch
 
 logging.basicConfig(


### PR DESCRIPTION
...I have no idea why this is different for me locally...

However, these files are failing for me locally but not in CI. We should figure out why, but in the short term (assuming CI passes) I would at least like to do a quick fix on these. I wonder if it's black and ruff fighting each other. It might be worth trying to only use the ruff formatter.