### PR TITLE
Add kind that demonstrates how to modify the upstream graph in a transform

### DIFF
--- a/taskcluster/kinds/all/kind.yml
+++ b/taskcluster/kinds/all/kind.yml
@@ -16,6 +16,7 @@ kind-dependencies:
     - evaluate
     - evaluate-quantized
     - evaluate-teacher-ensemble
+    - modify-graph
 
 tasks:
     all:

--- a/taskcluster/kinds/merge-corpus/kind.yml
+++ b/taskcluster/kinds/merge-corpus/kind.yml
@@ -6,14 +6,12 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.find_upstreams:by_locales
     - taskgraph.transforms.task_context
     - taskgraph.transforms.run:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - bicleaner
     - toolchain
 
 task-defaults:
@@ -32,14 +30,8 @@ task-defaults:
             - label
             - description
             - worker.env
-            - dependencies
-            - fetches
             - attributes
             - run.command
-    upstreams-config:
-        upstream-artifacts:
-            - "{dataset_sanitized}.{src_locale}.zst"
-            - "{dataset_sanitized}.{trg_locale}.zst"
     worker-type: b-cpu-largedisk
     worker:
         docker-image: {"in-tree": "train"}
@@ -83,12 +75,6 @@ tasks:
             stage: merge-corpus
             cache:
                 type: merge-corpus
-
-        upstreams-config:
-            upstream-task-attributes:
-                cleaning-type:
-                    by-cleaning-type:
-                        bicleaner-ai: bicleaner-ai
 
         task-context:
             from-object:

--- a/taskcluster/kinds/modify-graph/kind.yml
+++ b/taskcluster/kinds/modify-graph/kind.yml
@@ -6,24 +6,20 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - translations_taskgraph.transforms.skip_unless_pipeline_changed
+    - translations_taskgraph.transforms.modify_graph
     - taskgraph.transforms.task_context
-    - taskgraph.transforms.from_deps
-    - translations_taskgraph.transforms.dependency_dummies
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - export
-    - evaluate
-    - evaluate-quantized
-    - evaluate-teacher-ensemble
-    - modify-graph
+    - clean-corpus
+    - bicleaner
+    - merge-corpus
 
 tasks:
     all:
-        description: Dummy task that ensures all parts of training pipeline will run
+        description: Modify upstream parts of the graph
         attributes:
-            stage: all-pr
+            stage: all
             src_locale: "{src_locale}"
             trg_locale: "{trg_locale}"
         
@@ -34,9 +30,6 @@ tasks:
             substitution-fields:
                 - attributes
 
-        run-on-tasks-for: ["github-pull-request"]
+        run-on-tasks-for: []
+        expires-after: "90 days"
         worker-type: succeed
-
-        from-deps:
-            unique-kinds: false
-            group-by: all

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -144,6 +144,9 @@ def validate_pretrained_models(params):
                     },
                     "bicleaner": {
                         "properties": {
+                            "disable": {
+                                "type": "string",
+                            },
                             "default-threshold": {
                                 "type": "number",
                                 "description": "bicleaner threshold",

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -27,6 +27,7 @@ def get_defaults(_):
                 "best-model": "chrf",
                 "use-opuscleaner": "true",
                 "bicleaner": {
+                    "disable": "true",
                     "default-threshold": 0.5,
                     "dataset-thresholds": {
                         "opus_ada83/v1": 0.0,
@@ -126,6 +127,7 @@ extend_parameters_schema(
                 Required("best-model"): str,
                 Required("use-opuscleaner"): str,
                 Required("bicleaner"): {
+                    Required("disable"): str,
                     Required("default-threshold"): float,
                     Optional("dataset-thresholds"): {
                         str: float,

--- a/taskcluster/translations_taskgraph/transforms/modify_graph.py
+++ b/taskcluster/translations_taskgraph/transforms/modify_graph.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import json
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def enable_or_disable_bicleaner(config, jobs):
+    """Set the appropriate dependencies and fetches based on whether bicleaner
+    is enabled or disabled."""
+
+    merge_corpus_task = None
+    for name, task in config.kind_dependencies_tasks.items():
+        if name.startswith("merge-corpus"):
+            merge_corpus_task = task
+
+    if not merge_corpus_task:
+        raise Exception("Couldn't find merge corpus task!")
+
+    pull_from = "bicleaner"
+    if config.params["training_config"]["experiment"]["bicleaner"]["disable"]:
+        pull_from = "clean-corpus"
+
+    # If bicleaner is disabled, we pull upstream artifacts from `clean-corpus`
+    new_deps = {}
+    for name, task in config.kind_dependencies_tasks.items():
+        if name.startswith(pull_from):
+            new_deps[task.kind] = task.label
+
+    merge_corpus_task.dependencies.update(new_deps)
+    # Also need to set up fetches, which will involve setting the `MOZ_FETCHES` env var
+    # like the `run` transform does: https://github.com/taskcluster/taskgraph/blob/1a7dba0db709c84940fcf85a421c1dfc931f9747/src/taskgraph/transforms/run/__init__.py#L207
+    # this will have to get somehow combined with the existing `MOZ_FETCHES` present in merge_corpus_task.task["payload"]["env"]
+    fetches = json.loads(merge_corpus_task.task["payload"]["env"]["MOZ_FETCHES"]["task-reference"])
+    # Consult an existing task definition for the MOZ_FETCHES format
+    fetches.append([
+        {"artifact": "something", "extract": True, "task": f"<{pull_from}>"}
+    ])
+    merge_corpus_task.task["payload"]["env"]["MOZ_FETCHES"]["task-reference"] = json.dumps(fetches)
+
+    # We don't actually make any adjustements to the new jobs; this transform only exists
+    # to cause the side effects done above.
+    yield from jobs


### PR DESCRIPTION
This is a _very_ rough prototype for what's been discussed in https://github.com/mozilla/firefox-translations-training/issues/417 and https://github.com/taskcluster/taskgraph/issues/424. In this example, the decision about which tasks `merge-corpus` should depend on are being deferred and handled in the new `modify_graph` transform, which runs as part of the `modify-graph` task that happens right before `all`.

Because we're handling the `dependencies` later, we must also handle the `fetches` later - which means that knowledge about those artifact names moves _out_ of the `merge-corpus`  kind and into this transform.

I haven't tested this besides some `taskgraph full -Y` inspection, but it looks plausible - and the code certainly runs at the appropriate time, and has access to the necessary data to make the changes.

Any tasks that you need to modify or access _must_ be in a kind listed in the `modify-graph` kind's `kind-dependencies`, otherwise they will not show up in `config.kind_dependencies.tasks`.

And at the risk of being annoying and repeating myself, I will offer a couple of cautions:
- This sort of thing goes against the design of taskgraph. It could break without warning, and may not fit in well with future taskgraph features
- We used to manage Firefox build & release tasks/graphs with [similar imperative code](https://github.com/mozilla-releng/build-buildbotcustom/blob/master/process/factory.py#L396). Taskgraph was, in part, a reaction to how unmaintainable and spaghetti-like that became.