### PR TITLE
Enable 'train' action for PRs against a supported repository

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -172,9 +172,9 @@ tasks:
                               'isPullRequest':
                                   - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
                               'tasks_for == "action"':
-                                  - 'assume:repo:${repoUrl[8:]}:action:${action.action_perm}'
+                                  - 'assume:repo:${baseRepoUrl[8:]}:action:${action.action_perm}'
                               'tasks_for == "pr-action"':
-                                  - 'assume:repo:${repoUrl[8:]}:pr-action:${action.action_perm}'
+                                  - 'assume:repo:${baseRepoUrl[8:]}:pr-action:${action.action_perm}'
                               $default:
                                   - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
     

--- a/taskcluster/translations_taskgraph/actions/train.py
+++ b/taskcluster/translations_taskgraph/actions/train.py
@@ -17,7 +17,10 @@ TRAIN_ON_PROJECTS = (
 
 
 def can_train(parameters):
-    return parameters["head_repository"] in TRAIN_ON_PROJECTS
+    return parameters["head_repository"] in TRAIN_ON_PROJECTS or (
+        parameters["base_repository"] in TRAIN_ON_PROJECTS
+        and parameters["tasks_for"].startswith("github-pull-request")
+    )
 
 
 defaults = get_defaults("")["training_config"]


### PR DESCRIPTION
Right now it's only enabled when `head_repository` is this or the staging repository.