### PR TITLE
Allow group traversal from training tasks dependencies during Taskcluster task group publication

### DIFF
--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -291,6 +291,7 @@ def list_dependent_group_ids(task_id: str, known: set[str]):
         yield group_id
         known.add(group_id)
 
+        # Shared instance of `known` to propagate discovered groups in real time across all recursion branches
         yield from list_dependent_group_ids(dependent_task_id, known)
 
 

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -205,10 +205,15 @@ def publish_task_group(group_id: str) -> None:
     group_name = f'{experiment["name"]}_{group_id}'
 
     grouped_tasks = list_completed_tasks(group_id)
+    training_tasks = list_training_tasks(group_id, grouped_tasks)
     metrics_tasks = list_metrics_tasks(group_id, grouped_tasks)
 
+    if not training_tasks:
+        logger.warning(f"Skipping task group {group_id} as it is empty")
+        return
+
     # Publish training tasks as runs
-    for training_task in list_training_tasks(group_id, grouped_tasks):
+    for training_task in training_tasks:
         # Associate metrics to each runs (evaluate tasks that depends on the training task)
         dependent_tasks = []
         for eval_id, eval_task in metrics_tasks.items():

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -41,6 +41,11 @@ def get_args() -> argparse.Namespace:
         help="ID of the Taskcluster training task group.",
     )
     parser.add_argument(
+        "--no-recursive-lookup",
+        help="Disable group traversal from provided group_id tasks dependencies.",
+        action="store_true",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         help="Print debug messages.",
@@ -54,6 +59,7 @@ def get_args() -> argparse.Namespace:
 def get_logs(task: dict) -> list[str]:
     """Retrieve training logs from Taskcluster"""
     task_id = task["status"]["taskId"]
+
     logger.info(f"Downloading logs for task {task_id}")
     log, _ = downloadArtifactToBuf(
         taskId=task_id,
@@ -81,11 +87,14 @@ def publish_task(project: str, group: str, name: str, task: dict, metrics: list[
 
 def get_metrics_from_task(task: dict) -> list[Metric]:
     task_id = task["status"]["taskId"]
+
     logger.info(f"Retrieving artifacts from evaluation task {task_id}")
+
     metrics = []
     for artifact in queue.listLatestArtifacts(task_id)["artifacts"]:
         if not artifact["name"].endswith(".metrics"):
             continue
+
         log, _ = downloadArtifactToBuf(
             taskId=task_id,
             name=artifact["name"],
@@ -96,13 +105,186 @@ def get_metrics_from_task(task: dict) -> list[Metric]:
         # Remove eventual slashes (e.g. <task_tag>-1/2) that cannot be written to the filesystem
         tag = MULTIPLE_TRAIN_SUFFIX.sub("", tag)
 
-        with tempfile.TemporaryDirectory() as d:
-            file = Path(d) / f"{tag}.txt"
-            with file.open("wb") as f:
-                f.write(log.tobytes())
-                f.flush()
-                metrics.append(Metric.from_file(Path(f.name), sep="-"))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file = Path(temp_dir) / f"{tag}.txt"
+            with file.open("wb") as log_file:
+                log_file.write(log.tobytes())
+                log_file.flush()
+                metrics.append(Metric.from_file(Path(log_file.name), sep="-"))
+
     return metrics
+
+
+def filter_task(task: dict) -> tuple[str, dict] | tuple[None, None]:
+    if task["status"]["state"] == "completed" and "vocab" not in task["task"]["tags"]["kind"]:    
+        name = task["task"]["tags"]["kind"]
+        prefix = name.split("-")[0]
+        if prefix == "train":
+            # Remove "train-" prefix from training task only to avoid duplicates
+            name = name[6:]
+
+        # Teacher training may run multiple times (e.g. "-1/2" prefix)
+        suffix = ""
+        label = task["task"]["tags"].get("label")
+        if label and (re_match := MULTIPLE_TRAIN_SUFFIX.search(label)):
+            (suffix,) = re_match.groups()
+
+        task["name"] = name + suffix
+        return prefix, task
+    
+    return None, None
+
+
+def get_training_tasks(group_id: str, grouped_tasks: dict[str, list[dict]]) -> list[list[dict]]:
+    training_tasks = sum(
+        [tasks for key, tasks in grouped_tasks.items() if key in KIND_TAG_TARGET], start=[]
+    )
+
+    if not training_tasks:
+        logger.warning(f"No completed training task found for group {group_id}")
+    else:
+        logger.info(f"Found {len(training_tasks)} completed training tasks")
+
+    return training_tasks
+
+
+def get_metrics_tasks(group_id: str, grouped_tasks: dict[str, list[dict]]) -> list[dict[str, dict]]:
+    metrics_tasks = {task["status"]["taskId"]: task for task in grouped_tasks["evaluate"]}
+
+    if not metrics_tasks:
+        logger.warning(f"No completed metrics task found for group {group_id}")
+    else:
+        logger.info(f"Found {len(metrics_tasks)} completed metrics tasks")
+
+    return metrics_tasks
+
+
+def list_completed_tasks(group_id: str) -> dict[str, list[dict]]:
+    logger.info(f"Listing completed tasks from group {group_id}")
+
+    response = queue.listTaskGroup(group_id)
+    tasks = response["tasks"]
+    continuation_token = response.get("continuationToken")
+    while continuation_token:
+        # Results may be returned in multiple pages
+        # https://docs.taskcluster.net/docs/reference/platform/queue/api#listTaskGroup
+        response = queue.listTaskGroup(group_id, {"continuationToken": continuation_token})
+        tasks.extend(response["tasks"])
+        continuation_token = response.get("continuationToken")
+
+    # Map tasks by categories
+    grouped_tasks = defaultdict(list)
+    for task in tasks:
+        # Exclude non completed or vocab tasks
+        prefix, filtered_task = filter_task(task)
+        if filtered_task:
+            grouped_tasks[prefix].append(filtered_task)
+
+    return grouped_tasks
+
+
+def publish_task_group(group_id: str) -> None:
+    logger.info(f"Retrieving task group {group_id}")
+
+    # Ensure task group is readable
+    queue.getTaskGroup(group_id)
+
+    # Read project and experiment name from task group configuration
+    task_group = queue.task(group_id)
+    config = task_group.get("extra", {}).get("action", {}).get("context", {}).get("input")
+
+    # If the task group does not have a training configuration, we can skip its publication
+    if config is None:
+        logger.warning(f"Task group {group_id} cannot be published to WandB")
+        return
+
+    experiment = config["experiment"]
+    project_name = f'{experiment["src"]}-{experiment["trg"]}'
+    group_name = f'{experiment["name"]}_{group_id}'
+
+    grouped_tasks = list_completed_tasks(group_id)
+    metrics_tasks = get_metrics_tasks(group_id, grouped_tasks)
+
+    # Publish training tasks as runs
+    for training_task in get_training_tasks(group_id, grouped_tasks):
+        # Associate metrics to each runs (evaluate tasks that depends on the training task)
+        dependent_tasks = []
+        for eval_id, eval_task in metrics_tasks.items():
+            eval_label = eval_task["task"]["tags"].get("label", "")
+
+            try:
+                model_name, _, _ = extract_dataset_from_tag(eval_label, sep="-")
+            except ValueError:
+                continue
+
+            if eval_label and (re_match := MULTIPLE_TRAIN_SUFFIX.search(eval_label)):
+                (suffix,) = re_match.groups()
+                model_name += suffix
+
+            # Evaluation tasks may be named finetuned instead of finetune
+            model_name = model_name.replace("finetuned", "finetune")
+
+            # Evaluation tasks must be a dependency of the run and match its name
+            if (
+                training_task["status"]["taskId"] in eval_task["task"]["dependencies"]
+                and model_name == training_task["name"]
+            ):
+                dependent_tasks.append(eval_id)
+
+        metrics = sum(
+            [get_metrics_from_task(metrics_tasks.pop(dependent_task_id)) for dependent_task_id in dependent_tasks],
+            start=[],
+        )
+
+        publish_task(
+            project=project_name,
+            group=group_name,
+            name=training_task["name"],
+            task=training_task,
+            metrics=metrics,
+        )
+
+    # Group and publish remaining metrics tasks via the logs publication
+    with tempfile.TemporaryDirectory() as temp_dir:
+        logs_folder = Path(temp_dir) / "logs"
+        eval_folder = logs_folder / project_name / group_name / "eval"
+        eval_folder.mkdir(parents=True, exist_ok=True)
+
+        for metrics_task in metrics_tasks.values():
+            filename = metrics_task["task"]["tags"]["label"]
+            # evaluate-teacher-flores-flores_aug-typos_devtest-lt-en-1/2
+            with (eval_folder / f"{filename}.log").open("wb") as log_file:
+                downloadArtifactToFile(
+                    log_file,
+                    taskId=metrics_task["status"]["taskId"],
+                    name="public/logs/live.log",
+                    queueService=queue,
+                )
+
+        # Dump experiment config so it is published on group_logs
+        config_path = Path(temp_dir) / "experiments" / project_name / group_name / "config.yml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with config_path.open("w") as config_file:
+            yaml.dump(config, config_file)
+
+        parents = str(logs_folder.resolve()).strip().split("/")
+        WandB.publish_group_logs(parents, project_name, group_name, existing_runs=[], tag_sep="-")
+
+
+def list_dependent_group_ids(task_id: str, known: set[str]):
+    task = queue.task(task_id)
+
+    # Browse task dependencies
+    for dependent_task_id in task['dependencies']:
+        dependent_status = queue.status(dependent_task_id)
+
+        group_id = dependent_status["status"]["taskGroupId"]
+        if group_id in known:
+            continue
+
+        known.add(group_id)
+        list_dependent_group_ids(dependent_task_id, known)
 
 
 def main() -> None:
@@ -111,110 +293,18 @@ def main() -> None:
     if args.loglevel:
         logger.setLevel(args.loglevel)
 
-    logger.info(f"Retrieving task group {args.group_id}")
-    # Ensure task group is readable
-    queue.getTaskGroup(args.group_id)
-    # Read project and experiment name
-    task_group = queue.task(args.group_id)
-    config = task_group["extra"]["action"]["context"]["input"]
-    experiment = config["experiment"]
-    project = f"{experiment['src']}-{experiment['trg']}"
-    group_name = f"{experiment['name']}_{args.group_id}"
+    groups_ids = {args.group_id}
+    if not args.no_recursive_lookup:
+        logger.info(f"Retrieving related groups from {args.group_id} training tasks dependencies")
 
-    logger.info(f"Listing completed tasks from group {args.group_id}")
-    resp = queue.listTaskGroup(args.group_id)
-    tasks = resp["tasks"]
-    continuation_token = resp.get("continuationToken")
-    while continuation_token:
-        # Results may be returned in multiple pages
-        # https://docs.taskcluster.net/docs/reference/platform/queue/api#listTaskGroup
-        resp = queue.listTaskGroup(args.group_id, {"continuationToken": continuation_token})
-        tasks.extend(resp["tasks"])
-        continuation_token = resp.get("continuationToken")
-    # Map tasks by categories
-    tasks_groups = defaultdict(list)
-    for task in tasks:
-        # Exclude non completed or vocab tasks
-        if task["status"]["state"] == "completed" and "vocab" not in task["task"]["tags"]["kind"]:
-            name = task["task"]["tags"]["kind"]
-            prefix = name.split("-")[0]
-            if prefix == "train":
-                # Remove "train-" prefix from training task only to avoid duplicates
-                name = name[6:]
-            # Teacher training may run multiple times (e.g. "-1/2" prefix)
-            suffix = ""
-            label = task["task"]["tags"].get("label")
-            if label and (re_match := MULTIPLE_TRAIN_SUFFIX.search(label)):
-                (suffix,) = re_match.groups()
-            task["name"] = name + suffix
-            tasks_groups[prefix].append(task)
+        completed_tasks = list_completed_tasks(args.group_id)
+        training_tasks = get_training_tasks(args.group_id, completed_tasks)
+        for training_task in training_tasks:
+            list_dependent_group_ids(training_task["status"]["taskId"], groups_ids)
 
-    train_tasks = sum(
-        [tasks for key, tasks in tasks_groups.items() if key in KIND_TAG_TARGET], start=[]
-    )
-
-    if not train_tasks:
-        logger.warning(f"No completed training task found for group {args.group_id}")
+        logger.info(f"Found {len(groups_ids) - 1} additional groups to browse for WandB publication")
     else:
-        logger.info(f"Found {len(train_tasks)} completed training tasks")
+        logger.info("--no-recursive-lookup option is set, only the provided group will be browsed for WandB publication")
 
-    metrics_tasks = {task["status"]["taskId"]: task for task in tasks_groups["evaluate"]}
-
-    for task in train_tasks:
-        # Associate metrics to each runs (evaluate tasks that depends on the training task)
-        dependent_tasks = []
-        for eval_id, eval_task in metrics_tasks.items():
-            label = eval_task["task"]["tags"].get("label", "")
-            try:
-                model_name, _, _ = extract_dataset_from_tag(label, sep="-")
-            except ValueError:
-                continue
-            if label and (re_match := MULTIPLE_TRAIN_SUFFIX.search(label)):
-                (suffix,) = re_match.groups()
-                model_name += suffix
-            # Evaluation tasks may be named finetuned instead of finetune
-            model_name = model_name.replace("finetuned", "finetune")
-
-            # Evaluation tasks must be a dependency of the run and match its name
-            if (
-                task["status"]["taskId"] in eval_task["task"]["dependencies"]
-                and model_name == task["name"]
-            ):
-                dependent_tasks.append(eval_id)
-        metrics = sum(
-            [get_metrics_from_task(metrics_tasks.pop(task_id)) for task_id in dependent_tasks],
-            start=[],
-        )
-
-        run = task["name"]
-        publish_task(
-            project=project,
-            group=group_name,
-            name=run,
-            task=task,
-            metrics=metrics,
-        )
-
-    # Group and publish missing runs with metrics via the logs publication
-    with tempfile.TemporaryDirectory() as d:
-        logs_folder = Path(d) / "logs"
-        eval_folder = logs_folder / project / group_name / "eval"
-        eval_folder.mkdir(parents=True, exist_ok=True)
-        for task in metrics_tasks.values():
-            filename = task["task"]["tags"]["label"]
-            # evaluate-teacher-flores-flores_aug-typos_devtest-lt-en-1/2
-            with (eval_folder / f"{filename}.log").open("wb") as f:
-                downloadArtifactToFile(
-                    f,
-                    taskId=task["status"]["taskId"],
-                    name="public/logs/live.log",
-                    queueService=queue,
-                )
-        # Dump experiment config so it is published on group_logs
-        config_path = Path(d) / "experiments" / project / group_name / "config.yml"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        with config_path.open("w") as f:
-            yaml.dump(config, f)
-
-        parents = str(logs_folder.resolve()).strip().split("/")
-        WandB.publish_group_logs(parents, project, group_name, existing_runs=[], tag_sep="-")
+    for group_id in groups_ids:
+        publish_task_group(group_id)


### PR DESCRIPTION
Closes #448 

I've added a `--no-recursive-lookup` command option to @vrigal's implementation from #406. 

I've produced results with and without group traversal using the same top level task group ID `aY25-4fXTcuJNuMcWXUYtQ`:
-  `parse_tc_group aY25-4fXTcuJNuMcWXUYtQ` => **WandB** results are available [here](https://wandb.ai/teklia/en-hu-PR-461-recursive-lookup-enabled).
- `parse_tc_group aY25-4fXTcuJNuMcWXUYtQ --no-recursive-lookup` => **WandB** results are available [here](https://wandb.ai/teklia/en-hu-PR-461-recursive-lookup-disabled).