### PR TITLE
Set TERM for docker worker images

### DIFF
--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -qq \
                           htop \
                           vim \
                           nano \
+                          ncurses-term \
                           zstd \
                           screen \
                           curl \
@@ -44,7 +45,8 @@ RUN pip install zstandard
 
 ENV SHELL=/bin/bash \
     HOME=/builds/worker \
-    PATH="/builds/worker/.local/bin:$PATH"
+    PATH="/builds/worker/.local/bin:$PATH" \
+    TERM=hterm-256color
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.cache


### PR DESCRIPTION
This is to improve issues on docker worker interactive tasks where curses applications don't work correctly.

This is not quite perfect - but it's an improvement. There's seems to be a UI issue in Taskcluster still, where it mixes up x and y size for docker-worker sessions, which leads to a wrongly sized vim window and weird wrapping. I intend to fix that, but that's outside of the scope of this repo.