### PR TITLE
add 1tb cpu only workers

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -69,6 +69,13 @@ workers:
             implementation: docker-worker
             os: linux
             worker-type: 'b-linux-large-gcp-300gb'
+        # Use for tasks that don't require GPUs, but need immense amounts of disk space
+        # eg: alignments
+        b-cpu-xlargedisk:
+            provisioner: '{trust-domain}-{level}'
+            implementation: docker-worker
+            os: linux
+            worker-type: 'b-linux-large-gcp-1tb'
         # Use for quick tasks that need a GPU, eg: evaluate
         b-gpu:
             provisioner: '{trust-domain}-{level}'


### PR DESCRIPTION
Requires https://phabricator.services.mozilla.com/D203537 to be landed and deployed before these will work.