### PR TITLE
Add a taskcluster downloader for models

### DIFF
--- a/pipeline/common/downloads.py
+++ b/pipeline/common/downloads.py
@@ -21,8 +21,8 @@ def stream_download_to_file(url: str, destination: str) -> None:
     if not response.ok:
         raise Exception(f"Unable to download file from {url}")
     with open(destination, "wb") as f:
-        logger.info("Streaming downloading: {url}")
-        logger.info("To: {destination}")
+        logger.info(f"Streaming downloading: {url}")
+        logger.info(f"To: {destination}")
         # Stream to disk in 1 megabyte chunks.
         for chunk in response.iter_content(chunk_size=1024 * 1024):
             f.write(chunk)

--- a/utils/taskcluster_downloader.py
+++ b/utils/taskcluster_downloader.py
@@ -14,6 +14,8 @@ import taskcluster
 from taskcluster.download import downloadArtifactToBuf
 
 TC_MOZILLA = "https://firefox-ci-tc.services.mozilla.com"
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.abspath(os.path.join(CURRENT_DIR, "../data"))
 
 # to parse evaluation task tag
 # examples:
@@ -152,20 +154,36 @@ def donwload_evals(group_id, output):
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--output", metavar="OUTPUT", type=str, help="Output directory to save logs"
+        "--output",
+        metavar="OUTPUT",
+        type=str,
+        help="Output directory to save logs. Defaults to the data directory.",
     )
     parser.add_argument(
-        "--task-group-id", metavar="TASK_GROUP_ID", type=str, help="ID of a Taskcluster task group"
+        "--task-group-id",
+        metavar="TASK_GROUP_ID",
+        required=True,
+        type=str,
+        help="ID of a Taskcluster task group",
     )
-
     parser.add_argument(
-        "--mode", metavar="MODE", type=Mode, help="Downloading mode: logs or evals"
+        "--mode",
+        metavar="MODE",
+        type=Mode,
+        choices=Mode,
+        required=True,
+        help="What to download: " + ", ".join([m.name for m in Mode]),
     )
 
     args = parser.parse_args()
-    output = args.output
-    group_id = args.task_group_id
-    mode = args.mode
+    group_id: str = args.task_group_id
+    mode: Mode = args.mode
+
+    output: str
+    if args.output:
+        output = args.output
+    else:
+        output = os.path.join(DATA_DIR, f"taskcluster-{mode.value}")
 
     if mode == Mode.logs:
         donwload_logs(group_id, output)


### PR DESCRIPTION
This adds a little utility for downloading models. I wrote this for the en-ca model. I included a commit for some small changes to the existing script including a default output path, and listing all of the download modes.

You may have feedback on part of the patch, but I'm using the download utilities from the pipeline scripts, as I wanted a nice download function here.