### PR TITLE
Adjust pretraining

### DIFF
--- a/pipeline/train/configs/opustrainer/teacher.yml
+++ b/pipeline/train/configs/opustrainer/teacher.yml
@@ -6,11 +6,11 @@ stages:
   - pretrain
   - finetune
 
-# Back-translated corpus can vary a lot in size, so we can try using original one to count epochs
+# Train until the model sees two epochs of back-translated corpus
 pretrain:
   - original 0.6
   - backtranslated 0.4
-  - until original 2
+  - until backtranslated 2
 
 # Fine-tuning only on original clean corpus until the early stopping
 finetune:


### PR DESCRIPTION
Switch to training until 2 back-translated epochs. Sometimes we want to use less back-translated data and then if we use "original" as a stopping criterion the model might train on the back-translated corpus for too many iterations. 

The idea of pretraining is for the model to see the back-translated data several times. It can be noisy, so we mix it with the original parallel corpus.

So the process should be to check the size of both the original parallel corpus and monolingual corpus and decide on how many back-translations we want to add. The model will see those 2 times during the pertaining stage. If we take too many back-translations pertaining can take a while.

We'll fine-tune this process while training more languages.