### PR TITLE
Add a dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.ruff_cache
+.venv
+venv
+.git


### PR DESCRIPTION
I keep my venvs relative to the project I'm working in, and this was causing Docker to fail locally for me.

I added some other dot files I don't think need to be in the Dockerfile either.