### PR TITLE
Taskcluster publication

### DIFF
--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -108,7 +108,7 @@ if ! command -v parse_tc_logs &> /dev/null
 then
   echo "### Weight & Biases publication script is not available."
   PARSER=cat
-elif ! -z "$TEST_ARTIFACTS"
+elif [ ! -z ${TEST_ARTIFACTS+x} ];
 then
   echo "### Weight & Biases publication is disabled for unit tests."
   PARSER=cat

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -102,6 +102,16 @@ if [[ -z ${USE_CPU+x} ]]; then
   extra_params+=('local')
 fi
 
+# Enable log & metrics publication only when the tracking script is available
+if ! command -v parse_tc_logs &> /dev/null
+then
+  echo "### Weight & Biases publication is disabled."
+  PARSER=tee
+else
+  echo "### Weight & Biases publication is enabled."
+  PARSER="parse_tc_logs --from-stream --wandb-project=moz-translations"
+fi
+
 echo "### Training ${model_dir}"
 # OpusTrainer reads the datasets, shuffles, augments them and feeds to stdin of Marian
 opustrainer-train \
@@ -129,7 +139,7 @@ opustrainer-train \
     --keep-best \
     --tsv \
     --seed ${seed} \
-    "${extra_params[@]}"
+    "${extra_params[@]}" | $PARSER
 
 cp "${model_dir}/model.npz.best-${best_model_metric}.npz" "${model_dir}/final.model.npz.best-${best_model_metric}.npz"
 cp "${model_dir}/model.npz.best-${best_model_metric}.npz.decoder.yml" "${model_dir}/final.model.npz.best-${best_model_metric}.npz.decoder.yml"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -109,7 +109,7 @@ then
   PARSER=tee
 else
   echo "### Weight & Biases publication is enabled."
-  PARSER="parse_tc_logs --from-stream --wandb-project=moz-translations"
+  PARSER="parse_tc_logs --from-stream --wandb-project=moz-translations -v"
 fi
 
 echo "### Training ${model_dir}"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -106,10 +106,10 @@ fi
 if ! command -v parse_tc_logs &> /dev/null
 then
   echo "### Weight & Biases publication is disabled."
-  PARSER=tee
+  PARSER=cat
 else
   echo "### Weight & Biases publication is enabled."
-  PARSER="parse_tc_logs --from-stream -v"
+  PARSER="parse_tc_logs --from-stream -v --wandb-project=${src}-${trg}"
 fi
 
 echo "### Training ${model_dir}"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -104,7 +104,8 @@ fi
 
 # Enable log & metrics publication only when the tracking script is available
 # and we are not running unit tests
-if [[ ! $(command -v parse_tc_logs &> /dev/null) || ! -z "$TEST_ARTIFACTS" ]];
+# and it's not actively disabled through training configuration
+if [[ ! $(command -v parse_tc_logs &> /dev/null) || ! -z "$TEST_ARTIFACTS" || "${WANDB_PUBLICATION,,}" == "false" ]];
 then
   echo "### Weight & Biases publication is disabled."
   PARSER=cat

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -109,7 +109,7 @@ then
   PARSER=tee
 else
   echo "### Weight & Biases publication is enabled."
-  PARSER="parse_tc_logs --from-stream --wandb-project=moz-translations -v"
+  PARSER="parse_tc_logs --from-stream -v"
 fi
 
 echo "### Training ${model_dir}"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -114,7 +114,7 @@ then
   PARSER=cat
 else
   echo "### Weight & Biases publication is available."
-  PARSER="parse_tc_logs --from-stream -v --wandb-project=${src}-${trg} --wandb-group ${model_type}.${training_type} --wandb-run-name $TASK_ID"
+  PARSER="parse_tc_logs --from-stream -v"
 fi
 
 echo "### Training ${model_dir}"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -103,7 +103,8 @@ if [[ -z ${USE_CPU+x} ]]; then
 fi
 
 # Enable log & metrics publication only when the tracking script is available
-if ! command -v parse_tc_logs &> /dev/null
+# and we are not running unit tests
+if [[ ! $(command -v parse_tc_logs &> /dev/null) || ! -z "$TEST_ARTIFACTS" ]];
 then
   echo "### Weight & Biases publication is disabled."
   PARSER=cat

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -139,7 +139,7 @@ opustrainer-train \
     --keep-best \
     --tsv \
     --seed ${seed} \
-    "${extra_params[@]}" | $PARSER
+    "${extra_params[@]}" 2>&1 | $PARSER
 
 cp "${model_dir}/model.npz.best-${best_model_metric}.npz" "${model_dir}/final.model.npz.best-${best_model_metric}.npz"
 cp "${model_dir}/model.npz.best-${best_model_metric}.npz.decoder.yml" "${model_dir}/final.model.npz.best-${best_model_metric}.npz.decoder.yml"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -109,7 +109,7 @@ then
   PARSER=cat
 else
   echo "### Weight & Biases publication is enabled."
-  PARSER="parse_tc_logs --from-stream -v --wandb-project=${src}-${trg}"
+  PARSER="parse_tc_logs --from-stream -v --wandb-project=${src}-${trg} --wandb-group ${model_type}.${training_type} --wandb-run-name $TASK_ID"
 fi
 
 echo "### Training ${model_dir}"

--- a/pipeline/train/train.sh
+++ b/pipeline/train/train.sh
@@ -103,14 +103,17 @@ if [[ -z ${USE_CPU+x} ]]; then
 fi
 
 # Enable log & metrics publication only when the tracking script is available
-# and we are not running unit tests
-# and it's not actively disabled through training configuration
-if [[ ! $(command -v parse_tc_logs &> /dev/null) || ! -z "$TEST_ARTIFACTS" || "${WANDB_PUBLICATION,,}" == "false" ]];
+# and not running in unit tests
+if ! command -v parse_tc_logs &> /dev/null
 then
-  echo "### Weight & Biases publication is disabled."
+  echo "### Weight & Biases publication script is not available."
+  PARSER=cat
+elif ! -z "$TEST_ARTIFACTS"
+then
+  echo "### Weight & Biases publication is disabled for unit tests."
   PARSER=cat
 else
-  echo "### Weight & Biases publication is enabled."
+  echo "### Weight & Biases publication is available."
   PARSER="parse_tc_logs --from-stream -v --wandb-project=${src}-${trg} --wandb-group ${model_type}.${training_type} --wandb-run-name $TASK_ID"
 fi
 

--- a/taskcluster/kinds/finetune-student/kind.yml
+++ b/taskcluster/kinds/finetune-student/kind.yml
@@ -60,10 +60,20 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
             artifacts:
                 - name: public/build
                   path: artifacts
                   type: directory
+
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
 
         marian-args:
             from-parameters: training_config.marian-args.training-student-finetuned
@@ -75,6 +85,7 @@ tasks:
                 - >-
                     pip3 install --upgrade pip setuptools &&
                     pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    pip3 install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/taskcluster/scripts/pipeline/train-taskcluster.sh

--- a/taskcluster/kinds/train-backwards/kind.yml
+++ b/taskcluster/kinds/train-backwards/kind.yml
@@ -61,10 +61,20 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
             artifacts:
                 - name: public/build
                   path: artifacts
                   type: directory
+
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
 
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
@@ -80,6 +90,7 @@ tasks:
                 - >-
                     pip3 install --upgrade pip setuptools &&
                     pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    pip3 install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/taskcluster/scripts/pipeline/train-taskcluster.sh

--- a/taskcluster/kinds/train-backwards/kind.yml
+++ b/taskcluster/kinds/train-backwards/kind.yml
@@ -45,6 +45,7 @@ tasks:
                 trg_locale: training_config.experiment.trg
                 pretrained_backward_mode: training_config.experiment.pretrained-models.train-backwards.mode
                 pretrained_backward_type: training_config.experiment.pretrained-models.train-backwards.type
+                wandb_publication: training_config.wandb-publication
             substitution-fields:
                 - description
                 - name
@@ -52,6 +53,7 @@ tasks:
                 - dependencies
                 - attributes
                 - run.command
+                - worker.env
         worker-type:
             by-tasks-for:
                 github-pull-request: b-largegpu
@@ -61,6 +63,9 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases trigger
+                WANDB_PUBLICATION: "{wandb_publication}"
 
                 # Weight & Biases publication token is stored in that secret
                 TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases

--- a/taskcluster/kinds/train-student/kind.yml
+++ b/taskcluster/kinds/train-student/kind.yml
@@ -58,10 +58,20 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
             artifacts:
                 - name: public/build
                   path: artifacts
                   type: directory
+
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
 
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
@@ -76,6 +86,7 @@ tasks:
                 - >-
                     pip3 install --upgrade pip setuptools &&
                     pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    pip3 install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/taskcluster/scripts/pipeline/train-taskcluster.sh

--- a/taskcluster/kinds/train-student/kind.yml
+++ b/taskcluster/kinds/train-student/kind.yml
@@ -29,6 +29,7 @@ tasks:
                 best_model: training_config.experiment.best-model
                 src_locale: training_config.experiment.src
                 trg_locale: training_config.experiment.trg
+                wandb_publication: training_config.wandb-publication
             substitution-fields:
                 - description
                 - name
@@ -36,6 +37,7 @@ tasks:
                 - dependencies
                 - run.command
                 - attributes
+                - worker.env
         attributes:
             stage: train-student
             src_locale: "{src_locale}"
@@ -58,6 +60,9 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases trigger
+                WANDB_PUBLICATION: "{wandb_publication}"
 
                 # Weight & Biases publication token is stored in that secret
                 TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases

--- a/taskcluster/kinds/train-teacher/kind.yml
+++ b/taskcluster/kinds/train-teacher/kind.yml
@@ -82,13 +82,20 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
             artifacts:
                 - name: public/build
                   path: artifacts
                   type: directory
 
-        # Use a secret to publish logs on weights and biases
-        use-secret: project/translations/level-1/weights-and-biases
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
 
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []

--- a/taskcluster/kinds/train-teacher/kind.yml
+++ b/taskcluster/kinds/train-teacher/kind.yml
@@ -48,6 +48,7 @@ tasks:
                 teacher_ensemble: training_config.experiment.teacher-ensemble
                 pretrained_teacher_mode: training_config.experiment.pretrained-models.train-teacher.mode
                 pretrained_teacher_type: training_config.experiment.pretrained-models.train-teacher.type
+                wandb_publication: training_config.wandb-publication
             substitution-fields:
                 - description
                 - name
@@ -56,6 +57,7 @@ tasks:
                 - run.command
                 - attributes
                 - chunk.total-chunks
+                - worker.env
         attributes:
             stage: train-teacher
             src_locale: "{src_locale}"
@@ -82,6 +84,9 @@ tasks:
             env:
                 ARTIFACT_EXT: zst
                 COMPRESSION_CMD: zstdmt
+
+                # Weight & Biases trigger
+                WANDB_PUBLICATION: "{wandb_publication}"
 
                 # Weight & Biases publication token is stored in that secret
                 TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases

--- a/taskcluster/kinds/train-teacher/kind.yml
+++ b/taskcluster/kinds/train-teacher/kind.yml
@@ -87,6 +87,9 @@ tasks:
                   path: artifacts
                   type: directory
 
+        # Use a secret to publish logs on weights and biases
+        use-secret: project/translations/level-1/weights-and-biases
+
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
 
@@ -101,6 +104,7 @@ tasks:
                 - >-
                     pip3 install --upgrade pip setuptools &&
                     pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    pip3 install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/taskcluster/scripts/pipeline/train-taskcluster.sh

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -99,6 +99,8 @@ def get_defaults(_):
             "taskcluster": {
                 "split-chunks": 2,
             },
+            # Disable Weight & Biases publication on CI
+            "wandb-publication": False,
         },
     }
 
@@ -151,6 +153,7 @@ extend_parameters_schema(
             Optional("taskcluster"): {
                 Optional("split-chunks"): int,
             },
+            Optional("wandb-publication"): bool,
         },
     },
     defaults_fn=get_defaults,

--- a/taskcluster/translations_taskgraph/transforms/worker_env.py
+++ b/taskcluster/translations_taskgraph/transforms/worker_env.py
@@ -8,9 +8,18 @@
 # runtime, or adjust in kinds when changing worker types.
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.schema import resolve_keyed_by
+from taskgraph.util.schema import Schema, resolve_keyed_by
+from voluptuous import Optional, ALLOW_EXTRA
+
+SCHEMA = Schema(
+    {
+        Optional("use-secret"): str,
+    },
+    extra=ALLOW_EXTRA,
+)
 
 transforms = TransformSequence()
+transforms.add_validate(SCHEMA)
 
 
 @transforms.add
@@ -50,5 +59,25 @@ def inject_worker_env(config, jobs):
             )
 
         job["worker"]["env"].update(worker_env)
+
+        yield job
+
+
+@transforms.add
+def inject_secret(config, jobs):
+    for job in jobs:
+        secret_name = job.pop("use-secret", None)
+
+        # Secret access & configuration through proxy
+        if secret_name is not None:
+            job["worker"]["env"].update(
+                {
+                    "TASKCLUSTER_SECRET": secret_name,
+                }
+            )
+            job["worker"]["taskcluster-proxy"] = True
+            if "scopes" not in job:
+                job["scopes"] = []
+            job["scopes"] += [f"secrets:get:{secret_name}"]
 
         yield job

--- a/tests/data/experiments_wandb_calls_1_12.json
+++ b/tests/data/experiments_wandb_calls_1_12.json
@@ -1,1 +1,30752 @@
-[{"step": 1, "data": {"epoch": 1}}, {"step": 1, "data": {"sen": 7760}}, {"step": 1, "data": {"cost": 10.09652901}}, {"step": 1, "data": {"time": 244.67}}, {"step": 1, "data": {"rate": 888.05}}, {"step": 1, "data": {"gnorm": 5.2392}}, {"step": 2, "data": {"epoch": 1}}, {"step": 2, "data": {"sen": 26992}}, {"step": 2, "data": {"cost": 9.85704613}}, {"step": 2, "data": {"time": 0.49}}, {"step": 2, "data": {"rate": 473332.55}}, {"step": 2, "data": {"gnorm": 5.7787}}, {"step": 3, "data": {"epoch": 1}}, {"step": 3, "data": {"sen": 32864}}, {"step": 3, "data": {"cost": 10.21446133}}, {"step": 3, "data": {"time": 0.39}}, {"step": 3, "data": {"rate": 552223.51}}, {"step": 3, "data": {"gnorm": 5.8445}}, {"step": 4, "data": {"epoch": 1}}, {"step": 4, "data": {"sen": 44064}}, {"step": 4, "data": {"cost": 9.94169617}}, {"step": 4, "data": {"time": 0.4}}, {"step": 4, "data": {"rate": 474925.7}}, {"step": 4, "data": {"gnorm": 5.6558}}, {"step": 5, "data": {"epoch": 1}}, {"step": 5, "data": {"sen": 52619}}, {"step": 5, "data": {"cost": 10.21191692}}, {"step": 5, "data": {"time": 0.42}}, {"step": 5, "data": {"rate": 698787.83}}, {"step": 5, "data": {"gnorm": 5.7659}}, {"step": 6, "data": {"epoch": 1}}, {"step": 6, "data": {"sen": 59323}}, {"step": 6, "data": {"cost": 10.22371006}}, {"step": 6, "data": {"time": 0.41}}, {"step": 6, "data": {"rate": 632149.45}}, {"step": 6, "data": {"gnorm": 5.7923}}, {"step": 7, "data": {"epoch": 1}}, {"step": 7, "data": {"sen": 75999}}, {"step": 7, "data": {"cost": 10.08034992}}, {"step": 7, "data": {"time": 0.43}}, {"step": 7, "data": {"rate": 772682.62}}, {"step": 7, "data": {"gnorm": 5.7947}}, {"step": 8, "data": {"epoch": 1}}, {"step": 8, "data": {"sen": 78799}}, {"step": 8, "data": {"cost": 10.33155155}}, {"step": 8, "data": {"time": 0.46}}, {"step": 8, "data": {"rate": 527948.27}}, {"step": 8, "data": {"gnorm": 5.7238}}, {"step": 9, "data": {"epoch": 1}}, {"step": 9, "data": {"sen": 82047}}, {"step": 9, "data": {"cost": 10.32328033}}, {"step": 9, "data": {"time": 0.48}}, {"step": 9, "data": {"rate": 543979.19}}, {"step": 9, "data": {"gnorm": 5.7177}}, {"step": 10, "data": {"epoch": 1}}, {"step": 10, "data": {"sen": 93247}}, {"step": 10, "data": {"cost": 10.02314568}}, {"step": 10, "data": {"time": 0.4}}, {"step": 10, "data": {"rate": 608849.21}}, {"step": 10, "data": {"gnorm": 5.6175}}, {"step": 1000, "data": {"epoch": 1}}, {"step": 1000, "data": {"sen": 11826448}}, {"step": 1000, "data": {"cost": 8.16687393}}, {"step": 1000, "data": {"time": 418.52}}, {"step": 1000, "data": {"rate": 611107.59}}, {"step": 1000, "data": {"gnorm": 1.498}}, {"step": 2000, "data": {"epoch": 1}}, {"step": 2000, "data": {"sen": 23663821}}, {"step": 2000, "data": {"cost": 6.1054821}}, {"step": 2000, "data": {"time": 423.43}}, {"step": 2000, "data": {"rate": 609109.22}}, {"step": 2000, "data": {"gnorm": 2.3888}}, {"step": 3000, "data": {"epoch": 1}}, {"step": 3000, "data": {"sen": 35442478}}, {"step": 3000, "data": {"cost": 5.21276331}}, {"step": 3000, "data": {"time": 424.45}}, {"step": 3000, "data": {"rate": 606478.69}}, {"step": 3000, "data": {"gnorm": 2.1461}}, {"step": 4000, "data": {"epoch": 1}}, {"step": 4000, "data": {"sen": 47228904}}, {"step": 4000, "data": {"cost": 4.55404186}}, {"step": 4000, "data": {"time": 424.94}}, {"step": 4000, "data": {"rate": 608185.31}}, {"step": 4000, "data": {"gnorm": 2.9981}}, {"step": 5000, "data": {"epoch": 1}}, {"step": 5000, "data": {"sen": 59029081}}, {"step": 5000, "data": {"cost": 3.8885138}}, {"step": 5000, "data": {"time": 421.13}}, {"step": 5000, "data": {"rate": 611362.51}}, {"step": 5000, "data": {"gnorm": 3.4638}}, {"step": 5000, "data": {"epoch": 1}}, {"step": 5000, "data": {"perplexity": 96.4394}}, {"step": 5000, "data": {"chrf": 25.5239}}, {"step": 5000, "data": {"ce_mean_words": 4.56891}}, {"step": 5000, "data": {"bleu_detok": 4.0551}}, {"step": 6000, "data": {"epoch": 1}}, {"step": 6000, "data": {"sen": 70726322}}, {"step": 6000, "data": {"cost": 3.27664042}}, {"step": 6000, "data": {"time": 447.89}}, {"step": 6000, "data": {"rate": 572551.45}}, {"step": 6000, "data": {"gnorm": 4.5978}}, {"step": 7000, "data": {"epoch": 1}}, {"step": 7000, "data": {"sen": 82442979}}, {"step": 7000, "data": {"cost": 2.83908176}}, {"step": 7000, "data": {"time": 425.39}}, {"step": 7000, "data": {"rate": 604265.57}}, {"step": 7000, "data": {"gnorm": 3.2209}}, {"step": 8000, "data": {"epoch": 1}}, {"step": 8000, "data": {"sen": 94250487}}, {"step": 8000, "data": {"cost": 2.44592214}}, {"step": 8000, "data": {"time": 424.54}}, {"step": 8000, "data": {"rate": 603593.46}}, {"step": 8000, "data": {"gnorm": 3.1368}}, {"step": 9000, "data": {"epoch": 1}}, {"step": 9000, "data": {"sen": 106036373}}, {"step": 9000, "data": {"cost": 2.12659574}}, {"step": 9000, "data": {"time": 424.5}}, {"step": 9000, "data": {"rate": 607527.62}}, {"step": 9000, "data": {"gnorm": 2.3815}}, {"step": 10000, "data": {"epoch": 2}}, {"step": 10000, "data": {"sen": 108925}}, {"step": 10000, "data": {"cost": 1.89645851}}, {"step": 10000, "data": {"time": 441.86}}, {"step": 10000, "data": {"rate": 578723.92}}, {"step": 10000, "data": {"gnorm": 2.1298}}, {"step": 10000, "data": {"epoch": 2}}, {"step": 10000, "data": {"perplexity": 24.3228}}, {"step": 10000, "data": {"chrf": 42.5467}}, {"step": 10000, "data": {"ce_mean_words": 3.19141}}, {"step": 10000, "data": {"bleu_detok": 14.6807}}, {"step": 11000, "data": {"epoch": 2}}, {"step": 11000, "data": {"sen": 11862481}}, {"step": 11000, "data": {"cost": 1.71168828}}, {"step": 11000, "data": {"time": 445.05}}, {"step": 11000, "data": {"rate": 577578.95}}, {"step": 11000, "data": {"gnorm": 1.8633}}, {"step": 12000, "data": {"epoch": 2}}, {"step": 12000, "data": {"sen": 23682880}}, {"step": 12000, "data": {"cost": 1.56886828}}, {"step": 12000, "data": {"time": 424.24}}, {"step": 12000, "data": {"rate": 606415.7}}, {"step": 12000, "data": {"gnorm": 1.7238}}, {"step": 13000, "data": {"epoch": 2}}, {"step": 13000, "data": {"sen": 35434587}}, {"step": 13000, "data": {"cost": 1.44796801}}, {"step": 13000, "data": {"time": 426.61}}, {"step": 13000, "data": {"rate": 603455.56}}, {"step": 13000, "data": {"gnorm": 1.4451}}, {"step": 14000, "data": {"epoch": 2}}, {"step": 14000, "data": {"sen": 47203957}}, {"step": 14000, "data": {"cost": 1.35240018}}, {"step": 14000, "data": {"time": 424.42}}, {"step": 14000, "data": {"rate": 606780.48}}, {"step": 14000, "data": {"gnorm": 1.3498}}, {"step": 15000, "data": {"epoch": 2}}, {"step": 15000, "data": {"sen": 58990593}}, {"step": 15000, "data": {"cost": 1.26196682}}, {"step": 15000, "data": {"time": 423.09}}, {"step": 15000, "data": {"rate": 607688.12}}, {"step": 15000, "data": {"gnorm": 1.1876}}, {"step": 15000, "data": {"epoch": 2}}, {"step": 15000, "data": {"perplexity": 15.2351}}, {"step": 15000, "data": {"chrf": 48.354}}, {"step": 15000, "data": {"ce_mean_words": 2.7236}}, {"step": 15000, "data": {"bleu_detok": 19.9078}}, {"step": 16000, "data": {"epoch": 2}}, {"step": 16000, "data": {"sen": 70802100}}, {"step": 16000, "data": {"cost": 1.20254648}}, {"step": 16000, "data": {"time": 447.8}}, {"step": 16000, "data": {"rate": 576659.07}}, {"step": 16000, "data": {"gnorm": 1.1636}}, {"step": 17000, "data": {"epoch": 2}}, {"step": 17000, "data": {"sen": 82582686}}, {"step": 17000, "data": {"cost": 1.12801802}}, {"step": 17000, "data": {"time": 424.34}}, {"step": 17000, "data": {"rate": 605259.46}}, {"step": 17000, "data": {"gnorm": 1.1352}}, {"step": 18000, "data": {"epoch": 2}}, {"step": 18000, "data": {"sen": 94365470}}, {"step": 18000, "data": {"cost": 1.05992734}}, {"step": 18000, "data": {"time": 425.99}}, {"step": 18000, "data": {"rate": 606716.21}}, {"step": 18000, "data": {"gnorm": 1.0415}}, {"step": 19000, "data": {"epoch": 2}}, {"step": 19000, "data": {"sen": 106034961}}, {"step": 19000, "data": {"cost": 1.01547647}}, {"step": 19000, "data": {"time": 421.62}}, {"step": 19000, "data": {"rate": 604856.67}}, {"step": 19000, "data": {"gnorm": 0.9318}}, {"step": 20000, "data": {"epoch": 3}}, {"step": 20000, "data": {"sen": 195198}}, {"step": 20000, "data": {"cost": 0.96424389}}, {"step": 20000, "data": {"time": 445.17}}, {"step": 20000, "data": {"rate": 578743.54}}, {"step": 20000, "data": {"gnorm": 0.7591}}, {"step": 20000, "data": {"epoch": 3}}, {"step": 20000, "data": {"perplexity": 12.4278}}, {"step": 20000, "data": {"chrf": 51.5436}}, {"step": 20000, "data": {"ce_mean_words": 2.51993}}, {"step": 20000, "data": {"bleu_detok": 22.6274}}, {"step": 21000, "data": {"epoch": 3}}, {"step": 21000, "data": {"sen": 11999948}}, {"step": 21000, "data": {"cost": 0.92161202}}, {"step": 21000, "data": {"time": 443.99}}, {"step": 21000, "data": {"rate": 578968.79}}, {"step": 21000, "data": {"gnorm": 0.8806}}, {"step": 22000, "data": {"epoch": 3}}, {"step": 22000, "data": {"sen": 23788560}}, {"step": 22000, "data": {"cost": 0.89308023}}, {"step": 22000, "data": {"time": 427.12}}, {"step": 22000, "data": {"rate": 605079.04}}, {"step": 22000, "data": {"gnorm": 0.783}}, {"step": 23000, "data": {"epoch": 3}}, {"step": 23000, "data": {"sen": 35650909}}, {"step": 23000, "data": {"cost": 0.86150789}}, {"step": 23000, "data": {"time": 425.49}}, {"step": 23000, "data": {"rate": 605090.53}}, {"step": 23000, "data": {"gnorm": 0.7715}}, {"step": 24000, "data": {"epoch": 3}}, {"step": 24000, "data": {"sen": 47365112}}, {"step": 24000, "data": {"cost": 0.83436853}}, {"step": 24000, "data": {"time": 426.91}}, {"step": 24000, "data": {"rate": 604424.26}}, {"step": 24000, "data": {"gnorm": 0.6976}}, {"step": 25000, "data": {"epoch": 3}}, {"step": 25000, "data": {"sen": 59258913}}, {"step": 25000, "data": {"cost": 0.81355709}}, {"step": 25000, "data": {"time": 427.68}}, {"step": 25000, "data": {"rate": 606258.4}}, {"step": 25000, "data": {"gnorm": 0.7049}}, {"step": 25000, "data": {"epoch": 3}}, {"step": 25000, "data": {"perplexity": 11.3686}}, {"step": 25000, "data": {"chrf": 52.6074}}, {"step": 25000, "data": {"ce_mean_words": 2.43086}}, {"step": 25000, "data": {"bleu_detok": 24.4593}}, {"step": 26000, "data": {"epoch": 3}}, {"step": 26000, "data": {"sen": 70999758}}, {"step": 26000, "data": {"cost": 0.78981107}}, {"step": 26000, "data": {"time": 444.5}}, {"step": 26000, "data": {"rate": 576104.54}}, {"step": 26000, "data": {"gnorm": 0.6471}}, {"step": 27000, "data": {"epoch": 3}}, {"step": 27000, "data": {"sen": 82768335}}, {"step": 27000, "data": {"cost": 0.77213115}}, {"step": 27000, "data": {"time": 424.91}}, {"step": 27000, "data": {"rate": 605289.19}}, {"step": 27000, "data": {"gnorm": 0.586}}, {"step": 28000, "data": {"epoch": 3}}, {"step": 28000, "data": {"sen": 94585769}}, {"step": 28000, "data": {"cost": 0.75580764}}, {"step": 28000, "data": {"time": 427.18}}, {"step": 28000, "data": {"rate": 604355.58}}, {"step": 28000, "data": {"gnorm": 0.6501}}, {"step": 29000, "data": {"epoch": 3}}, {"step": 29000, "data": {"sen": 106353570}}, {"step": 29000, "data": {"cost": 0.74278587}}, {"step": 29000, "data": {"time": 425.87}}, {"step": 29000, "data": {"rate": 604879.96}}, {"step": 29000, "data": {"gnorm": 0.8841}}, {"step": 30000, "data": {"epoch": 4}}, {"step": 30000, "data": {"sen": 431389}}, {"step": 30000, "data": {"cost": 0.72724628}}, {"step": 30000, "data": {"time": 440.61}}, {"step": 30000, "data": {"rate": 578771.0}}, {"step": 30000, "data": {"gnorm": 0.6045}}, {"step": 30000, "data": {"epoch": 4}}, {"step": 30000, "data": {"perplexity": 11.3483}}, {"step": 30000, "data": {"chrf": 53.3918}}, {"step": 30000, "data": {"ce_mean_words": 2.42906}}, {"step": 30000, "data": {"bleu_detok": 24.7525}}, {"step": 31000, "data": {"epoch": 4}}, {"step": 31000, "data": {"sen": 12239704}}, {"step": 31000, "data": {"cost": 0.71076536}}, {"step": 31000, "data": {"time": 449.37}}, {"step": 31000, "data": {"rate": 575028.39}}, {"step": 31000, "data": {"gnorm": 0.5714}}, {"step": 32000, "data": {"epoch": 4}}, {"step": 32000, "data": {"sen": 24062221}}, {"step": 32000, "data": {"cost": 0.70075667}}, {"step": 32000, "data": {"time": 424.23}}, {"step": 32000, "data": {"rate": 608654.27}}, {"step": 32000, "data": {"gnorm": 0.6688}}, {"step": 33000, "data": {"epoch": 4}}, {"step": 33000, "data": {"sen": 35843799}}, {"step": 33000, "data": {"cost": 0.69009537}}, {"step": 33000, "data": {"time": 425.02}}, {"step": 33000, "data": {"rate": 603680.37}}, {"step": 33000, "data": {"gnorm": 0.6101}}, {"step": 34000, "data": {"epoch": 4}}, {"step": 34000, "data": {"sen": 47537216}}, {"step": 34000, "data": {"cost": 0.68314195}}, {"step": 34000, "data": {"time": 425.07}}, {"step": 34000, "data": {"rate": 604310.94}}, {"step": 34000, "data": {"gnorm": 0.6816}}, {"step": 35000, "data": {"epoch": 4}}, {"step": 35000, "data": {"sen": 59415851}}, {"step": 35000, "data": {"cost": 0.67175812}}, {"step": 35000, "data": {"time": 426.18}}, {"step": 35000, "data": {"rate": 606709.87}}, {"step": 35000, "data": {"gnorm": 0.5757}}, {"step": 35000, "data": {"epoch": 4}}, {"step": 35000, "data": {"perplexity": 10.3192}}, {"step": 35000, "data": {"chrf": 53.9462}}, {"step": 35000, "data": {"ce_mean_words": 2.334}}, {"step": 35000, "data": {"bleu_detok": 26.2343}}, {"step": 36000, "data": {"epoch": 4}}, {"step": 36000, "data": {"sen": 71205189}}, {"step": 36000, "data": {"cost": 0.66021705}}, {"step": 36000, "data": {"time": 447.07}}, {"step": 36000, "data": {"rate": 577334.84}}, {"step": 36000, "data": {"gnorm": 0.5142}}, {"step": 37000, "data": {"epoch": 4}}, {"step": 37000, "data": {"sen": 82979317}}, {"step": 37000, "data": {"cost": 0.65161037}}, {"step": 37000, "data": {"time": 424.97}}, {"step": 37000, "data": {"rate": 605417.05}}, {"step": 37000, "data": {"gnorm": 0.5538}}, {"step": 38000, "data": {"epoch": 4}}, {"step": 38000, "data": {"sen": 94700080}}, {"step": 38000, "data": {"cost": 0.64473414}}, {"step": 38000, "data": {"time": 424.88}}, {"step": 38000, "data": {"rate": 603667.63}}, {"step": 38000, "data": {"gnorm": 0.5425}}, {"step": 39000, "data": {"epoch": 4}}, {"step": 39000, "data": {"sen": 106508709}}, {"step": 39000, "data": {"cost": 0.63728291}}, {"step": 39000, "data": {"time": 425.01}}, {"step": 39000, "data": {"rate": 605755.13}}, {"step": 39000, "data": {"gnorm": 0.551}}, {"step": 40000, "data": {"epoch": 5}}, {"step": 40000, "data": {"sen": 699516}}, {"step": 40000, "data": {"cost": 0.63142753}}, {"step": 40000, "data": {"time": 445.34}}, {"step": 40000, "data": {"rate": 578601.94}}, {"step": 40000, "data": {"gnorm": 0.5092}}, {"step": 40000, "data": {"epoch": 5}}, {"step": 40000, "data": {"perplexity": 10.1005}}, {"step": 40000, "data": {"chrf": 54.7006}}, {"step": 40000, "data": {"ce_mean_words": 2.31258}}, {"step": 40000, "data": {"bleu_detok": 26.8031}}, {"step": 41000, "data": {"epoch": 5}}, {"step": 41000, "data": {"sen": 12477905}}, {"step": 41000, "data": {"cost": 0.62065649}}, {"step": 41000, "data": {"time": 448.83}}, {"step": 41000, "data": {"rate": 575745.39}}, {"step": 41000, "data": {"gnorm": 0.5133}}, {"step": 42000, "data": {"epoch": 5}}, {"step": 42000, "data": {"sen": 24330451}}, {"step": 42000, "data": {"cost": 0.61697447}}, {"step": 42000, "data": {"time": 426.54}}, {"step": 42000, "data": {"rate": 603950.1}}, {"step": 42000, "data": {"gnorm": 0.4906}}, {"step": 43000, "data": {"epoch": 5}}, {"step": 43000, "data": {"sen": 36161100}}, {"step": 43000, "data": {"cost": 0.61005586}}, {"step": 43000, "data": {"time": 427.45}}, {"step": 43000, "data": {"rate": 606846.02}}, {"step": 43000, "data": {"gnorm": 0.4658}}, {"step": 44000, "data": {"epoch": 5}}, {"step": 44000, "data": {"sen": 47888220}}, {"step": 44000, "data": {"cost": 0.60739821}}, {"step": 44000, "data": {"time": 423.66}}, {"step": 44000, "data": {"rate": 604777.49}}, {"step": 44000, "data": {"gnorm": 0.4906}}, {"step": 45000, "data": {"epoch": 5}}, {"step": 45000, "data": {"sen": 59724043}}, {"step": 45000, "data": {"cost": 0.60197359}}, {"step": 45000, "data": {"time": 426.65}}, {"step": 45000, "data": {"rate": 604227.77}}, {"step": 45000, "data": {"gnorm": 0.4849}}, {"step": 45000, "data": {"epoch": 5}}, {"step": 45000, "data": {"perplexity": 10.0515}}, {"step": 45000, "data": {"chrf": 54.5072}}, {"step": 45000, "data": {"ce_mean_words": 2.30773}}, {"step": 45000, "data": {"bleu_detok": 26.5298}}, {"step": 46000, "data": {"epoch": 5}}, {"step": 46000, "data": {"sen": 71548701}}, {"step": 46000, "data": {"cost": 0.59727478}}, {"step": 46000, "data": {"time": 447.36}}, {"step": 46000, "data": {"rate": 576896.14}}, {"step": 46000, "data": {"gnorm": 0.5168}}, {"step": 47000, "data": {"epoch": 5}}, {"step": 47000, "data": {"sen": 83263499}}, {"step": 47000, "data": {"cost": 0.5932005}}, {"step": 47000, "data": {"time": 426.46}}, {"step": 47000, "data": {"rate": 602768.41}}, {"step": 47000, "data": {"gnorm": 0.4963}}, {"step": 48000, "data": {"epoch": 5}}, {"step": 48000, "data": {"sen": 95064001}}, {"step": 48000, "data": {"cost": 0.58822775}}, {"step": 48000, "data": {"time": 425.89}}, {"step": 48000, "data": {"rate": 605302.56}}, {"step": 48000, "data": {"gnorm": 0.4871}}, {"step": 49000, "data": {"epoch": 5}}, {"step": 49000, "data": {"sen": 106826214}}, {"step": 49000, "data": {"cost": 0.58441615}}, {"step": 49000, "data": {"time": 425.87}}, {"step": 49000, "data": {"rate": 604672.44}}, {"step": 49000, "data": {"gnorm": 0.4458}}, {"step": 50000, "data": {"epoch": 6}}, {"step": 50000, "data": {"sen": 948974}}, {"step": 50000, "data": {"cost": 0.57994843}}, {"step": 50000, "data": {"time": 443.32}}, {"step": 50000, "data": {"rate": 577165.89}}, {"step": 50000, "data": {"gnorm": 0.4568}}, {"step": 50000, "data": {"epoch": 6}}, {"step": 50000, "data": {"perplexity": 9.92745}}, {"step": 50000, "data": {"chrf": 54.6534}}, {"step": 50000, "data": {"ce_mean_words": 2.2953}}, {"step": 50000, "data": {"bleu_detok": 26.8405}}, {"step": 51000, "data": {"epoch": 6}}, {"step": 51000, "data": {"sen": 12690274}}, {"step": 51000, "data": {"cost": 0.5746485}}, {"step": 51000, "data": {"time": 447.53}}, {"step": 51000, "data": {"rate": 574739.97}}, {"step": 51000, "data": {"gnorm": 0.5029}}, {"step": 52000, "data": {"epoch": 6}}, {"step": 52000, "data": {"sen": 24471233}}, {"step": 52000, "data": {"cost": 0.57095617}}, {"step": 52000, "data": {"time": 427.17}}, {"step": 52000, "data": {"rate": 603864.86}}, {"step": 52000, "data": {"gnorm": 0.4198}}, {"step": 53000, "data": {"epoch": 6}}, {"step": 53000, "data": {"sen": 36267253}}, {"step": 53000, "data": {"cost": 0.56824714}}, {"step": 53000, "data": {"time": 425.68}}, {"step": 53000, "data": {"rate": 603203.25}}, {"step": 53000, "data": {"gnorm": 0.4878}}, {"step": 54000, "data": {"epoch": 6}}, {"step": 54000, "data": {"sen": 48011828}}, {"step": 54000, "data": {"cost": 0.56487316}}, {"step": 54000, "data": {"time": 424.15}}, {"step": 54000, "data": {"rate": 606222.51}}, {"step": 54000, "data": {"gnorm": 0.4586}}, {"step": 55000, "data": {"epoch": 6}}, {"step": 55000, "data": {"sen": 59756795}}, {"step": 55000, "data": {"cost": 0.56299537}}, {"step": 55000, "data": {"time": 426.58}}, {"step": 55000, "data": {"rate": 603265.84}}, {"step": 55000, "data": {"gnorm": 0.4485}}, {"step": 55000, "data": {"epoch": 6}}, {"step": 55000, "data": {"perplexity": 9.62396}}, {"step": 55000, "data": {"chrf": 54.936}}, {"step": 55000, "data": {"ce_mean_words": 2.26426}}, {"step": 55000, "data": {"bleu_detok": 27.2262}}, {"step": 56000, "data": {"epoch": 6}}, {"step": 56000, "data": {"sen": 71562845}}, {"step": 56000, "data": {"cost": 0.55916399}}, {"step": 56000, "data": {"time": 449.2}}, {"step": 56000, "data": {"rate": 573929.42}}, {"step": 56000, "data": {"gnorm": 0.4387}}, {"step": 57000, "data": {"epoch": 6}}, {"step": 57000, "data": {"sen": 83402575}}, {"step": 57000, "data": {"cost": 0.55701637}}, {"step": 57000, "data": {"time": 427.43}}, {"step": 57000, "data": {"rate": 603058.35}}, {"step": 57000, "data": {"gnorm": 0.4791}}, {"step": 58000, "data": {"epoch": 6}}, {"step": 58000, "data": {"sen": 95167348}}, {"step": 58000, "data": {"cost": 0.55514681}}, {"step": 58000, "data": {"time": 425.99}}, {"step": 58000, "data": {"rate": 606378.08}}, {"step": 58000, "data": {"gnorm": 0.4131}}, {"step": 59000, "data": {"epoch": 6}}, {"step": 59000, "data": {"sen": 107008835}}, {"step": 59000, "data": {"cost": 0.55203605}}, {"step": 59000, "data": {"time": 426.1}}, {"step": 59000, "data": {"rate": 604750.74}}, {"step": 59000, "data": {"gnorm": 0.4189}}, {"step": 60000, "data": {"epoch": 7}}, {"step": 60000, "data": {"sen": 1160371}}, {"step": 60000, "data": {"cost": 0.54889005}}, {"step": 60000, "data": {"time": 445.96}}, {"step": 60000, "data": {"rate": 575041.55}}, {"step": 60000, "data": {"gnorm": 0.4356}}, {"step": 60000, "data": {"epoch": 7}}, {"step": 60000, "data": {"perplexity": 9.83628}}, {"step": 60000, "data": {"chrf": 55.4446}}, {"step": 60000, "data": {"ce_mean_words": 2.28608}}, {"step": 60000, "data": {"bleu_detok": 27.7837}}, {"step": 61000, "data": {"epoch": 7}}, {"step": 61000, "data": {"sen": 12867204}}, {"step": 61000, "data": {"cost": 0.54493934}}, {"step": 61000, "data": {"time": 444.58}}, {"step": 61000, "data": {"rate": 576627.15}}, {"step": 61000, "data": {"gnorm": 0.4702}}, {"step": 62000, "data": {"epoch": 7}}, {"step": 62000, "data": {"sen": 24646261}}, {"step": 62000, "data": {"cost": 0.54324657}}, {"step": 62000, "data": {"time": 425.87}}, {"step": 62000, "data": {"rate": 603363.55}}, {"step": 62000, "data": {"gnorm": 0.451}}, {"step": 63000, "data": {"epoch": 7}}, {"step": 63000, "data": {"sen": 36361673}}, {"step": 63000, "data": {"cost": 0.54085487}}, {"step": 63000, "data": {"time": 426.99}}, {"step": 63000, "data": {"rate": 604488.8}}, {"step": 63000, "data": {"gnorm": 0.4385}}, {"step": 64000, "data": {"epoch": 7}}, {"step": 64000, "data": {"sen": 48213781}}, {"step": 64000, "data": {"cost": 0.53979135}}, {"step": 64000, "data": {"time": 428.0}}, {"step": 64000, "data": {"rate": 603097.81}}, {"step": 64000, "data": {"gnorm": 0.4162}}, {"step": 65000, "data": {"epoch": 7}}, {"step": 65000, "data": {"sen": 60078170}}, {"step": 65000, "data": {"cost": 0.53684783}}, {"step": 65000, "data": {"time": 428.58}}, {"step": 65000, "data": {"rate": 604686.18}}, {"step": 65000, "data": {"gnorm": 0.4323}}, {"step": 65000, "data": {"epoch": 7}}, {"step": 65000, "data": {"perplexity": 9.63551}}, {"step": 65000, "data": {"chrf": 55.4056}}, {"step": 65000, "data": {"ce_mean_words": 2.26546}}, {"step": 65000, "data": {"bleu_detok": 27.6646}}, {"step": 66000, "data": {"epoch": 7}}, {"step": 66000, "data": {"sen": 71907019}}, {"step": 66000, "data": {"cost": 0.53633779}}, {"step": 66000, "data": {"time": 447.81}}, {"step": 66000, "data": {"rate": 575002.07}}, {"step": 66000, "data": {"gnorm": 0.4572}}, {"step": 67000, "data": {"epoch": 7}}, {"step": 67000, "data": {"sen": 83749327}}, {"step": 67000, "data": {"cost": 0.53310555}}, {"step": 67000, "data": {"time": 427.72}}, {"step": 67000, "data": {"rate": 602626.8}}, {"step": 67000, "data": {"gnorm": 0.3941}}, {"step": 68000, "data": {"epoch": 7}}, {"step": 68000, "data": {"sen": 95483561}}, {"step": 68000, "data": {"cost": 0.53319538}}, {"step": 68000, "data": {"time": 427.42}}, {"step": 68000, "data": {"rate": 602231.99}}, {"step": 68000, "data": {"gnorm": 0.4304}}, {"step": 69000, "data": {"epoch": 7}}, {"step": 69000, "data": {"sen": 107254276}}, {"step": 69000, "data": {"cost": 0.53168845}}, {"step": 69000, "data": {"time": 429.67}}, {"step": 69000, "data": {"rate": 601151.09}}, {"step": 69000, "data": {"gnorm": 0.4127}}, {"step": 70000, "data": {"epoch": 8}}, {"step": 70000, "data": {"sen": 1333257}}, {"step": 70000, "data": {"cost": 0.52841294}}, {"step": 70000, "data": {"time": 443.89}}, {"step": 70000, "data": {"rate": 577829.79}}, {"step": 70000, "data": {"gnorm": 0.4591}}, {"step": 70000, "data": {"epoch": 8}}, {"step": 70000, "data": {"perplexity": 9.60693}}, {"step": 70000, "data": {"chrf": 55.4915}}, {"step": 70000, "data": {"ce_mean_words": 2.26248}}, {"step": 70000, "data": {"bleu_detok": 28.0887}}, {"step": 71000, "data": {"epoch": 8}}, {"step": 71000, "data": {"sen": 13173167}}, {"step": 71000, "data": {"cost": 0.52371109}}, {"step": 71000, "data": {"time": 448.24}}, {"step": 71000, "data": {"rate": 575146.87}}, {"step": 71000, "data": {"gnorm": 0.3987}}, {"step": 72000, "data": {"epoch": 8}}, {"step": 72000, "data": {"sen": 24969408}}, {"step": 72000, "data": {"cost": 0.52350378}}, {"step": 72000, "data": {"time": 424.19}}, {"step": 72000, "data": {"rate": 605515.66}}, {"step": 72000, "data": {"gnorm": 0.4074}}, {"step": 73000, "data": {"epoch": 8}}, {"step": 73000, "data": {"sen": 36700779}}, {"step": 73000, "data": {"cost": 0.52198935}}, {"step": 73000, "data": {"time": 427.21}}, {"step": 73000, "data": {"rate": 603649.23}}, {"step": 73000, "data": {"gnorm": 0.4151}}, {"step": 74000, "data": {"epoch": 8}}, {"step": 74000, "data": {"sen": 48518696}}, {"step": 74000, "data": {"cost": 0.52123535}}, {"step": 74000, "data": {"time": 427.18}}, {"step": 74000, "data": {"rate": 600348.75}}, {"step": 74000, "data": {"gnorm": 0.3951}}, {"step": 75000, "data": {"epoch": 8}}, {"step": 75000, "data": {"sen": 60358594}}, {"step": 75000, "data": {"cost": 0.51979423}}, {"step": 75000, "data": {"time": 428.58}}, {"step": 75000, "data": {"rate": 605294.44}}, {"step": 75000, "data": {"gnorm": 0.4004}}, {"step": 75000, "data": {"epoch": 8}}, {"step": 75000, "data": {"perplexity": 9.59269}}, {"step": 75000, "data": {"chrf": 55.8313}}, {"step": 75000, "data": {"ce_mean_words": 2.261}}, {"step": 75000, "data": {"bleu_detok": 28.0371}}, {"step": 76000, "data": {"epoch": 8}}, {"step": 76000, "data": {"sen": 72161996}}, {"step": 76000, "data": {"cost": 0.51826388}}, {"step": 76000, "data": {"time": 449.93}}, {"step": 76000, "data": {"rate": 574412.66}}, {"step": 76000, "data": {"gnorm": 0.4005}}, {"step": 77000, "data": {"epoch": 8}}, {"step": 77000, "data": {"sen": 83999721}}, {"step": 77000, "data": {"cost": 0.51722735}}, {"step": 77000, "data": {"time": 426.39}}, {"step": 77000, "data": {"rate": 605297.95}}, {"step": 77000, "data": {"gnorm": 0.4031}}, {"step": 78000, "data": {"epoch": 8}}, {"step": 78000, "data": {"sen": 95697384}}, {"step": 78000, "data": {"cost": 0.51598418}}, {"step": 78000, "data": {"time": 425.91}}, {"step": 78000, "data": {"rate": 600277.38}}, {"step": 78000, "data": {"gnorm": 0.4317}}, {"step": 79000, "data": {"epoch": 8}}, {"step": 79000, "data": {"sen": 107475078}}, {"step": 79000, "data": {"cost": 0.51495439}}, {"step": 79000, "data": {"time": 426.82}}, {"step": 79000, "data": {"rate": 602460.19}}, {"step": 79000, "data": {"gnorm": 0.4167}}, {"step": 80000, "data": {"epoch": 9}}, {"step": 80000, "data": {"sen": 1540934}}, {"step": 80000, "data": {"cost": 0.51305491}}, {"step": 80000, "data": {"time": 443.24}}, {"step": 80000, "data": {"rate": 576975.57}}, {"step": 80000, "data": {"gnorm": 0.4195}}, {"step": 80000, "data": {"epoch": 9}}, {"step": 80000, "data": {"perplexity": 9.51115}}, {"step": 80000, "data": {"chrf": 55.8292}}, {"step": 80000, "data": {"ce_mean_words": 2.25247}}, {"step": 80000, "data": {"bleu_detok": 28.2713}}, {"step": 81000, "data": {"epoch": 9}}, {"step": 81000, "data": {"sen": 13439612}}, {"step": 81000, "data": {"cost": 0.50866795}}, {"step": 81000, "data": {"time": 451.24}}, {"step": 81000, "data": {"rate": 574215.36}}, {"step": 81000, "data": {"gnorm": 0.4251}}, {"step": 82000, "data": {"epoch": 9}}, {"step": 82000, "data": {"sen": 25181361}}, {"step": 82000, "data": {"cost": 0.50850552}}, {"step": 82000, "data": {"time": 426.79}}, {"step": 82000, "data": {"rate": 603155.54}}, {"step": 82000, "data": {"gnorm": 0.3954}}, {"step": 83000, "data": {"epoch": 9}}, {"step": 83000, "data": {"sen": 36989411}}, {"step": 83000, "data": {"cost": 0.50816721}}, {"step": 83000, "data": {"time": 426.69}}, {"step": 83000, "data": {"rate": 603828.52}}, {"step": 83000, "data": {"gnorm": 0.4149}}, {"step": 84000, "data": {"epoch": 9}}, {"step": 84000, "data": {"sen": 48825615}}, {"step": 84000, "data": {"cost": 0.50700623}}, {"step": 84000, "data": {"time": 428.11}}, {"step": 84000, "data": {"rate": 603222.74}}, {"step": 84000, "data": {"gnorm": 0.3955}}, {"step": 85000, "data": {"epoch": 9}}, {"step": 85000, "data": {"sen": 60517185}}, {"step": 85000, "data": {"cost": 0.50596708}}, {"step": 85000, "data": {"time": 425.69}}, {"step": 85000, "data": {"rate": 602393.79}}, {"step": 85000, "data": {"gnorm": 0.4157}}, {"step": 85000, "data": {"epoch": 9}}, {"step": 85000, "data": {"perplexity": 9.3582}}, {"step": 85000, "data": {"chrf": 55.9314}}, {"step": 85000, "data": {"ce_mean_words": 2.23625}}, {"step": 85000, "data": {"bleu_detok": 28.3152}}, {"step": 86000, "data": {"epoch": 9}}, {"step": 86000, "data": {"sen": 72249310}}, {"step": 86000, "data": {"cost": 0.50625765}}, {"step": 86000, "data": {"time": 448.79}}, {"step": 86000, "data": {"rate": 571211.11}}, {"step": 86000, "data": {"gnorm": 0.4291}}, {"step": 87000, "data": {"epoch": 9}}, {"step": 87000, "data": {"sen": 84047907}}, {"step": 87000, "data": {"cost": 0.50437939}}, {"step": 87000, "data": {"time": 426.21}}, {"step": 87000, "data": {"rate": 603586.84}}, {"step": 87000, "data": {"gnorm": 0.413}}, {"step": 88000, "data": {"epoch": 9}}, {"step": 88000, "data": {"sen": 95903610}}, {"step": 88000, "data": {"cost": 0.50375932}}, {"step": 88000, "data": {"time": 429.35}}, {"step": 88000, "data": {"rate": 602651.27}}, {"step": 88000, "data": {"gnorm": 0.419}}, {"step": 89000, "data": {"epoch": 9}}, {"step": 89000, "data": {"sen": 107620094}}, {"step": 89000, "data": {"cost": 0.50312281}}, {"step": 89000, "data": {"time": 425.16}}, {"step": 89000, "data": {"rate": 602835.98}}, {"step": 89000, "data": {"gnorm": 0.4167}}, {"step": 90000, "data": {"epoch": 10}}, {"step": 90000, "data": {"sen": 1706191}}, {"step": 90000, "data": {"cost": 0.50137883}}, {"step": 90000, "data": {"time": 445.73}}, {"step": 90000, "data": {"rate": 575837.27}}, {"step": 90000, "data": {"gnorm": 0.4233}}, {"step": 90000, "data": {"epoch": 10}}, {"step": 90000, "data": {"perplexity": 9.39603}}, {"step": 90000, "data": {"chrf": 55.4832}}, {"step": 90000, "data": {"ce_mean_words": 2.24029}}, {"step": 90000, "data": {"bleu_detok": 27.9519}}, {"step": 91000, "data": {"epoch": 10}}, {"step": 91000, "data": {"sen": 13573769}}, {"step": 91000, "data": {"cost": 0.49778035}}, {"step": 91000, "data": {"time": 448.68}}, {"step": 91000, "data": {"rate": 574899.32}}, {"step": 91000, "data": {"gnorm": 0.4055}}, {"step": 92000, "data": {"epoch": 10}}, {"step": 92000, "data": {"sen": 25280588}}, {"step": 92000, "data": {"cost": 0.49746081}}, {"step": 92000, "data": {"time": 426.6}}, {"step": 92000, "data": {"rate": 602170.26}}, {"step": 92000, "data": {"gnorm": 0.3841}}, {"step": 93000, "data": {"epoch": 10}}, {"step": 93000, "data": {"sen": 37106308}}, {"step": 93000, "data": {"cost": 0.49725124}}, {"step": 93000, "data": {"time": 426.44}}, {"step": 93000, "data": {"rate": 603056.65}}, {"step": 93000, "data": {"gnorm": 0.3977}}, {"step": 94000, "data": {"epoch": 10}}, {"step": 94000, "data": {"sen": 48850409}}, {"step": 94000, "data": {"cost": 0.49611723}}, {"step": 94000, "data": {"time": 426.58}}, {"step": 94000, "data": {"rate": 603063.93}}, {"step": 94000, "data": {"gnorm": 0.3958}}, {"step": 95000, "data": {"epoch": 10}}, {"step": 95000, "data": {"sen": 60679806}}, {"step": 95000, "data": {"cost": 0.49574691}}, {"step": 95000, "data": {"time": 429.81}}, {"step": 95000, "data": {"rate": 602486.21}}, {"step": 95000, "data": {"gnorm": 0.3985}}, {"step": 95000, "data": {"epoch": 10}}, {"step": 95000, "data": {"perplexity": 9.45618}}, {"step": 95000, "data": {"chrf": 55.8171}}, {"step": 95000, "data": {"ce_mean_words": 2.24667}}, {"step": 95000, "data": {"bleu_detok": 28.2061}}, {"step": 96000, "data": {"epoch": 10}}, {"step": 96000, "data": {"sen": 72462607}}, {"step": 96000, "data": {"cost": 0.4946883}}, {"step": 96000, "data": {"time": 448.97}}, {"step": 96000, "data": {"rate": 572779.58}}, {"step": 96000, "data": {"gnorm": 0.4166}}, {"step": 97000, "data": {"epoch": 10}}, {"step": 97000, "data": {"sen": 84311203}}, {"step": 97000, "data": {"cost": 0.49431637}}, {"step": 97000, "data": {"time": 430.18}}, {"step": 97000, "data": {"rate": 601358.32}}, {"step": 97000, "data": {"gnorm": 0.3868}}, {"step": 98000, "data": {"epoch": 10}}, {"step": 98000, "data": {"sen": 96017723}}, {"step": 98000, "data": {"cost": 0.49413139}}, {"step": 98000, "data": {"time": 426.86}}, {"step": 98000, "data": {"rate": 600510.08}}, {"step": 98000, "data": {"gnorm": 0.4466}}, {"step": 99000, "data": {"epoch": 10}}, {"step": 99000, "data": {"sen": 107696695}}, {"step": 99000, "data": {"cost": 0.49291834}}, {"step": 99000, "data": {"time": 426.86}}, {"step": 99000, "data": {"rate": 599037.43}}, {"step": 99000, "data": {"gnorm": 0.3921}}, {"step": 100000, "data": {"epoch": 11}}, {"step": 100000, "data": {"sen": 1812109}}, {"step": 100000, "data": {"cost": 0.49154162}}, {"step": 100000, "data": {"time": 445.65}}, {"step": 100000, "data": {"rate": 574131.95}}, {"step": 100000, "data": {"gnorm": 0.3789}}, {"step": 100000, "data": {"epoch": 11}}, {"step": 100000, "data": {"perplexity": 9.4911}}, {"step": 100000, "data": {"chrf": 56.0034}}, {"step": 100000, "data": {"ce_mean_words": 2.25035}}, {"step": 100000, "data": {"bleu_detok": 28.5268}}, {"step": 101000, "data": {"epoch": 11}}, {"step": 101000, "data": {"sen": 13594218}}, {"step": 101000, "data": {"cost": 0.48933458}}, {"step": 101000, "data": {"time": 449.66}}, {"step": 101000, "data": {"rate": 569843.73}}, {"step": 101000, "data": {"gnorm": 0.4026}}, {"step": 102000, "data": {"epoch": 11}}, {"step": 102000, "data": {"sen": 25423739}}, {"step": 102000, "data": {"cost": 0.48827583}}, {"step": 102000, "data": {"time": 431.73}}, {"step": 102000, "data": {"rate": 601304.74}}, {"step": 102000, "data": {"gnorm": 0.4241}}, {"step": 103000, "data": {"epoch": 11}}, {"step": 103000, "data": {"sen": 37204596}}, {"step": 103000, "data": {"cost": 0.48820502}}, {"step": 103000, "data": {"time": 428.31}}, {"step": 103000, "data": {"rate": 598942.95}}, {"step": 103000, "data": {"gnorm": 0.3954}}, {"step": 104000, "data": {"epoch": 11}}, {"step": 104000, "data": {"sen": 48955798}}, {"step": 104000, "data": {"cost": 0.48718339}}, {"step": 104000, "data": {"time": 428.08}}, {"step": 104000, "data": {"rate": 601172.75}}, {"step": 104000, "data": {"gnorm": 0.3886}}, {"step": 105000, "data": {"epoch": 11}}, {"step": 105000, "data": {"sen": 60659223}}, {"step": 105000, "data": {"cost": 0.48741946}}, {"step": 105000, "data": {"time": 428.59}}, {"step": 105000, "data": {"rate": 598548.94}}, {"step": 105000, "data": {"gnorm": 0.3828}}, {"step": 105000, "data": {"epoch": 11}}, {"step": 105000, "data": {"perplexity": 9.33579}}, {"step": 105000, "data": {"chrf": 55.8588}}, {"step": 105000, "data": {"ce_mean_words": 2.23386}}, {"step": 105000, "data": {"bleu_detok": 28.3337}}, {"step": 106000, "data": {"epoch": 11}}, {"step": 106000, "data": {"sen": 72414964}}, {"step": 106000, "data": {"cost": 0.48721126}}, {"step": 106000, "data": {"time": 450.8}}, {"step": 106000, "data": {"rate": 568970.67}}, {"step": 106000, "data": {"gnorm": 0.4212}}, {"step": 107000, "data": {"epoch": 11}}, {"step": 107000, "data": {"sen": 84249049}}, {"step": 107000, "data": {"cost": 0.48628062}}, {"step": 107000, "data": {"time": 431.49}}, {"step": 107000, "data": {"rate": 600428.85}}, {"step": 107000, "data": {"gnorm": 0.3898}}, {"step": 108000, "data": {"epoch": 11}}, {"step": 108000, "data": {"sen": 95999677}}, {"step": 108000, "data": {"cost": 0.48547062}}, {"step": 108000, "data": {"time": 426.44}}, {"step": 108000, "data": {"rate": 600307.25}}, {"step": 108000, "data": {"gnorm": 0.3729}}, {"step": 109000, "data": {"epoch": 11}}, {"step": 109000, "data": {"sen": 107819116}}, {"step": 109000, "data": {"cost": 0.4852626}}, {"step": 109000, "data": {"time": 429.88}}, {"step": 109000, "data": {"rate": 599594.31}}, {"step": 109000, "data": {"gnorm": 0.403}}, {"step": 110000, "data": {"epoch": 12}}, {"step": 110000, "data": {"sen": 1884413}}, {"step": 110000, "data": {"cost": 0.48323965}}, {"step": 110000, "data": {"time": 446.65}}, {"step": 110000, "data": {"rate": 573235.1}}, {"step": 110000, "data": {"gnorm": 0.3757}}, {"step": 110000, "data": {"epoch": 12}}, {"step": 110000, "data": {"perplexity": 9.28521}}, {"step": 110000, "data": {"chrf": 55.9104}}, {"step": 110000, "data": {"ce_mean_words": 2.22842}}, {"step": 110000, "data": {"bleu_detok": 28.4369}}, {"step": 111000, "data": {"epoch": 12}}, {"step": 111000, "data": {"sen": 13601494}}, {"step": 111000, "data": {"cost": 0.48019114}}, {"step": 111000, "data": {"time": 449.72}}, {"step": 111000, "data": {"rate": 569326.62}}, {"step": 111000, "data": {"gnorm": 0.364}}, {"step": 112000, "data": {"epoch": 12}}, {"step": 112000, "data": {"sen": 25398943}}, {"step": 112000, "data": {"cost": 0.48115325}}, {"step": 112000, "data": {"time": 430.74}}, {"step": 112000, "data": {"rate": 598712.95}}, {"step": 112000, "data": {"gnorm": 0.376}}, {"step": 113000, "data": {"epoch": 12}}, {"step": 113000, "data": {"sen": 37251908}}, {"step": 113000, "data": {"cost": 0.48136362}}, {"step": 113000, "data": {"time": 431.8}}, {"step": 113000, "data": {"rate": 598226.11}}, {"step": 113000, "data": {"gnorm": 0.4088}}, {"step": 114000, "data": {"epoch": 12}}, {"step": 114000, "data": {"sen": 49055452}}, {"step": 114000, "data": {"cost": 0.48127928}}, {"step": 114000, "data": {"time": 429.98}}, {"step": 114000, "data": {"rate": 599834.87}}, {"step": 114000, "data": {"gnorm": 0.4048}}, {"step": 115000, "data": {"epoch": 12}}, {"step": 115000, "data": {"sen": 60911716}}, {"step": 115000, "data": {"cost": 0.47995147}}, {"step": 115000, "data": {"time": 431.35}}, {"step": 115000, "data": {"rate": 600207.97}}, {"step": 115000, "data": {"gnorm": 0.388}}, {"step": 115000, "data": {"epoch": 12}}, {"step": 115000, "data": {"perplexity": 9.25589}}, {"step": 115000, "data": {"chrf": 56.0285}}, {"step": 115000, "data": {"ce_mean_words": 2.22526}}, {"step": 115000, "data": {"bleu_detok": 28.6539}}, {"step": 116000, "data": {"epoch": 12}}, {"step": 116000, "data": {"sen": 72677338}}, {"step": 116000, "data": {"cost": 0.47926217}}, {"step": 116000, "data": {"time": 453.42}}, {"step": 116000, "data": {"rate": 568946.61}}, {"step": 116000, "data": {"gnorm": 0.3896}}, {"step": 117000, "data": {"epoch": 12}}, {"step": 117000, "data": {"sen": 84443317}}, {"step": 117000, "data": {"cost": 0.47978944}}, {"step": 117000, "data": {"time": 431.36}}, {"step": 117000, "data": {"rate": 597007.88}}, {"step": 117000, "data": {"gnorm": 0.4094}}, {"step": 118000, "data": {"epoch": 12}}, {"step": 118000, "data": {"sen": 96262331}}, {"step": 118000, "data": {"cost": 0.47889182}}, {"step": 118000, "data": {"time": 430.84}}, {"step": 118000, "data": {"rate": 598398.56}}, {"step": 118000, "data": {"gnorm": 0.3829}}, {"step": 119000, "data": {"epoch": 12}}, {"step": 119000, "data": {"sen": 108041613}}, {"step": 119000, "data": {"cost": 0.47837481}}, {"step": 119000, "data": {"time": 428.35}}, {"step": 119000, "data": {"rate": 599693.1}}, {"step": 119000, "data": {"gnorm": 0.4301}}, {"step": 120000, "data": {"epoch": 13}}, {"step": 120000, "data": {"sen": 2145653}}, {"step": 120000, "data": {"cost": 0.47654736}}, {"step": 120000, "data": {"time": 448.34}}, {"step": 120000, "data": {"rate": 571710.68}}, {"step": 120000, "data": {"gnorm": 0.3745}}, {"step": 120000, "data": {"epoch": 13}}, {"step": 120000, "data": {"perplexity": 9.55098}}, {"step": 120000, "data": {"chrf": 56.3126}}, {"step": 120000, "data": {"ce_mean_words": 2.25664}}, {"step": 120000, "data": {"bleu_detok": 28.5648}}, {"step": 121000, "data": {"epoch": 13}}, {"step": 121000, "data": {"sen": 13883043}}, {"step": 121000, "data": {"cost": 0.47427839}}, {"step": 121000, "data": {"time": 451.54}}, {"step": 121000, "data": {"rate": 568362.25}}, {"step": 121000, "data": {"gnorm": 0.3796}}, {"step": 122000, "data": {"epoch": 13}}, {"step": 122000, "data": {"sen": 25707222}}, {"step": 122000, "data": {"cost": 0.47462633}}, {"step": 122000, "data": {"time": 431.72}}, {"step": 122000, "data": {"rate": 598876.82}}, {"step": 122000, "data": {"gnorm": 0.3999}}, {"step": 123000, "data": {"epoch": 13}}, {"step": 123000, "data": {"sen": 37525945}}, {"step": 123000, "data": {"cost": 0.47471222}}, {"step": 123000, "data": {"time": 432.02}}, {"step": 123000, "data": {"rate": 596959.87}}, {"step": 123000, "data": {"gnorm": 0.3748}}, {"step": 124000, "data": {"epoch": 13}}, {"step": 124000, "data": {"sen": 49304166}}, {"step": 124000, "data": {"cost": 0.47414112}}, {"step": 124000, "data": {"time": 429.92}}, {"step": 124000, "data": {"rate": 597655.08}}, {"step": 124000, "data": {"gnorm": 0.3853}}, {"step": 125000, "data": {"epoch": 13}}, {"step": 125000, "data": {"sen": 61142554}}, {"step": 125000, "data": {"cost": 0.474098}}, {"step": 125000, "data": {"time": 432.55}}, {"step": 125000, "data": {"rate": 599497.53}}, {"step": 125000, "data": {"gnorm": 0.3893}}, {"step": 125000, "data": {"epoch": 13}}, {"step": 125000, "data": {"perplexity": 9.56639}}, {"step": 125000, "data": {"chrf": 56.2365}}, {"step": 125000, "data": {"ce_mean_words": 2.25826}}, {"step": 125000, "data": {"bleu_detok": 28.6552}}, {"step": 126000, "data": {"epoch": 13}}, {"step": 126000, "data": {"sen": 72939129}}, {"step": 126000, "data": {"cost": 0.47340956}}, {"step": 126000, "data": {"time": 451.08}}, {"step": 126000, "data": {"rate": 570034.38}}, {"step": 126000, "data": {"gnorm": 0.3862}}, {"step": 127000, "data": {"epoch": 13}}, {"step": 127000, "data": {"sen": 84727392}}, {"step": 127000, "data": {"cost": 0.47368377}}, {"step": 127000, "data": {"time": 432.72}}, {"step": 127000, "data": {"rate": 597376.39}}, {"step": 127000, "data": {"gnorm": 0.4212}}, {"step": 128000, "data": {"epoch": 13}}, {"step": 128000, "data": {"sen": 96603392}}, {"step": 128000, "data": {"cost": 0.47246337}}, {"step": 128000, "data": {"time": 432.16}}, {"step": 128000, "data": {"rate": 598259.75}}, {"step": 128000, "data": {"gnorm": 0.3867}}, {"step": 129000, "data": {"epoch": 13}}, {"step": 129000, "data": {"sen": 108279577}}, {"step": 129000, "data": {"cost": 0.47282624}}, {"step": 129000, "data": {"time": 430.75}}, {"step": 129000, "data": {"rate": 596840.81}}, {"step": 129000, "data": {"gnorm": 0.3707}}, {"step": 130000, "data": {"epoch": 14}}, {"step": 130000, "data": {"sen": 2359467}}, {"step": 130000, "data": {"cost": 0.47152594}}, {"step": 130000, "data": {"time": 447.64}}, {"step": 130000, "data": {"rate": 569861.07}}, {"step": 130000, "data": {"gnorm": 0.3982}}, {"step": 130000, "data": {"epoch": 14}}, {"step": 130000, "data": {"perplexity": 9.59334}}, {"step": 130000, "data": {"chrf": 56.181}}, {"step": 130000, "data": {"ce_mean_words": 2.26107}}, {"step": 130000, "data": {"bleu_detok": 28.662}}, {"step": 131000, "data": {"epoch": 14}}, {"step": 131000, "data": {"sen": 14218304}}, {"step": 131000, "data": {"cost": 0.46889615}}, {"step": 131000, "data": {"time": 452.05}}, {"step": 131000, "data": {"rate": 569532.92}}, {"step": 131000, "data": {"gnorm": 0.3904}}, {"step": 132000, "data": {"epoch": 14}}, {"step": 132000, "data": {"sen": 25956516}}, {"step": 132000, "data": {"cost": 0.46917397}}, {"step": 132000, "data": {"time": 432.25}}, {"step": 132000, "data": {"rate": 595984.97}}, {"step": 132000, "data": {"gnorm": 0.3721}}, {"step": 133000, "data": {"epoch": 14}}, {"step": 133000, "data": {"sen": 37718593}}, {"step": 133000, "data": {"cost": 0.46958303}}, {"step": 133000, "data": {"time": 431.8}}, {"step": 133000, "data": {"rate": 596124.83}}, {"step": 133000, "data": {"gnorm": 0.3977}}, {"step": 134000, "data": {"epoch": 14}}, {"step": 134000, "data": {"sen": 49519580}}, {"step": 134000, "data": {"cost": 0.46965498}}, {"step": 134000, "data": {"time": 432.74}}, {"step": 134000, "data": {"rate": 594250.6}}, {"step": 134000, "data": {"gnorm": 0.3799}}, {"step": 135000, "data": {"epoch": 14}}, {"step": 135000, "data": {"sen": 61314444}}, {"step": 135000, "data": {"cost": 0.46847466}}, {"step": 135000, "data": {"time": 431.5}}, {"step": 135000, "data": {"rate": 597634.5}}, {"step": 135000, "data": {"gnorm": 0.3852}}, {"step": 135000, "data": {"epoch": 14}}, {"step": 135000, "data": {"perplexity": 9.4307}}, {"step": 135000, "data": {"chrf": 56.2072}}, {"step": 135000, "data": {"ce_mean_words": 2.24397}}, {"step": 135000, "data": {"bleu_detok": 28.822}}, {"step": 136000, "data": {"epoch": 14}}, {"step": 136000, "data": {"sen": 73093437}}, {"step": 136000, "data": {"cost": 0.46794567}}, {"step": 136000, "data": {"time": 452.98}}, {"step": 136000, "data": {"rate": 569400.76}}, {"step": 136000, "data": {"gnorm": 0.3585}}, {"step": 137000, "data": {"epoch": 14}}, {"step": 137000, "data": {"sen": 84885325}}, {"step": 137000, "data": {"cost": 0.46773368}}, {"step": 137000, "data": {"time": 431.77}}, {"step": 137000, "data": {"rate": 595638.35}}, {"step": 137000, "data": {"gnorm": 0.3772}}, {"step": 138000, "data": {"epoch": 14}}, {"step": 138000, "data": {"sen": 96615161}}, {"step": 138000, "data": {"cost": 0.46750042}}, {"step": 138000, "data": {"time": 431.52}}, {"step": 138000, "data": {"rate": 597675.77}}, {"step": 138000, "data": {"gnorm": 0.3455}}, {"step": 139000, "data": {"epoch": 14}}, {"step": 139000, "data": {"sen": 108456892}}, {"step": 139000, "data": {"cost": 0.46773955}}, {"step": 139000, "data": {"time": 432.87}}, {"step": 139000, "data": {"rate": 593440.33}}, {"step": 139000, "data": {"gnorm": 0.4057}}, {"step": 140000, "data": {"epoch": 15}}, {"step": 140000, "data": {"sen": 2626249}}, {"step": 140000, "data": {"cost": 0.46589574}}, {"step": 140000, "data": {"time": 450.63}}, {"step": 140000, "data": {"rate": 571058.8}}, {"step": 140000, "data": {"gnorm": 0.3704}}, {"step": 140000, "data": {"epoch": 15}}, {"step": 140000, "data": {"perplexity": 9.46642}}, {"step": 140000, "data": {"chrf": 56.353}}, {"step": 140000, "data": {"ce_mean_words": 2.24775}}, {"step": 140000, "data": {"bleu_detok": 28.9422}}, {"step": 141000, "data": {"epoch": 15}}, {"step": 141000, "data": {"sen": 14392346}}, {"step": 141000, "data": {"cost": 0.46500969}}, {"step": 141000, "data": {"time": 455.73}}, {"step": 141000, "data": {"rate": 567607.84}}, {"step": 141000, "data": {"gnorm": 0.353}}, {"step": 142000, "data": {"epoch": 15}}, {"step": 142000, "data": {"sen": 26217731}}, {"step": 142000, "data": {"cost": 0.46453327}}, {"step": 142000, "data": {"time": 431.47}}, {"step": 142000, "data": {"rate": 597581.2}}, {"step": 142000, "data": {"gnorm": 0.3791}}, {"step": 143000, "data": {"epoch": 15}}, {"step": 143000, "data": {"sen": 38094755}}, {"step": 143000, "data": {"cost": 0.4641732}}, {"step": 143000, "data": {"time": 433.56}}, {"step": 143000, "data": {"rate": 596442.24}}, {"step": 143000, "data": {"gnorm": 0.3836}}, {"step": 144000, "data": {"epoch": 15}}, {"step": 144000, "data": {"sen": 49822577}}, {"step": 144000, "data": {"cost": 0.46423176}}, {"step": 144000, "data": {"time": 432.85}}, {"step": 144000, "data": {"rate": 595073.98}}, {"step": 144000, "data": {"gnorm": 0.3539}}, {"step": 145000, "data": {"epoch": 15}}, {"step": 145000, "data": {"sen": 61614291}}, {"step": 145000, "data": {"cost": 0.46501788}}, {"step": 145000, "data": {"time": 430.37}}, {"step": 145000, "data": {"rate": 595369.52}}, {"step": 145000, "data": {"gnorm": 0.3955}}, {"step": 145000, "data": {"epoch": 15}}, {"step": 145000, "data": {"perplexity": 9.32185}}, {"step": 145000, "data": {"chrf": 56.0107}}, {"step": 145000, "data": {"ce_mean_words": 2.23236}}, {"step": 145000, "data": {"bleu_detok": 28.4816}}, {"step": 146000, "data": {"epoch": 15}}, {"step": 146000, "data": {"sen": 73298661}}, {"step": 146000, "data": {"cost": 0.46428731}}, {"step": 146000, "data": {"time": 452.1}}, {"step": 146000, "data": {"rate": 567770.85}}, {"step": 146000, "data": {"gnorm": 0.3685}}, {"step": 147000, "data": {"epoch": 15}}, {"step": 147000, "data": {"sen": 85095100}}, {"step": 147000, "data": {"cost": 0.46374959}}, {"step": 147000, "data": {"time": 434.45}}, {"step": 147000, "data": {"rate": 591787.64}}, {"step": 147000, "data": {"gnorm": 0.3695}}, {"step": 148000, "data": {"epoch": 15}}, {"step": 148000, "data": {"sen": 96799184}}, {"step": 148000, "data": {"cost": 0.46422428}}, {"step": 148000, "data": {"time": 431.81}}, {"step": 148000, "data": {"rate": 592741.93}}, {"step": 148000, "data": {"gnorm": 0.4317}}, {"step": 149000, "data": {"epoch": 15}}, {"step": 149000, "data": {"sen": 108600682}}, {"step": 149000, "data": {"cost": 0.46367741}}, {"step": 149000, "data": {"time": 433.12}}, {"step": 149000, "data": {"rate": 593267.96}}, {"step": 149000, "data": {"gnorm": 0.3718}}, {"step": 150000, "data": {"epoch": 16}}, {"step": 150000, "data": {"sen": 2666946}}, {"step": 150000, "data": {"cost": 0.46222976}}, {"step": 150000, "data": {"time": 452.27}}, {"step": 150000, "data": {"rate": 565094.03}}, {"step": 150000, "data": {"gnorm": 0.391}}, {"step": 150000, "data": {"epoch": 16}}, {"step": 150000, "data": {"perplexity": 9.41566}}, {"step": 150000, "data": {"chrf": 56.2021}}, {"step": 150000, "data": {"ce_mean_words": 2.24237}}, {"step": 150000, "data": {"bleu_detok": 28.7866}}, {"step": 151000, "data": {"epoch": 16}}, {"step": 151000, "data": {"sen": 14361531}}, {"step": 151000, "data": {"cost": 0.46048635}}, {"step": 151000, "data": {"time": 454.22}}, {"step": 151000, "data": {"rate": 565671.76}}, {"step": 151000, "data": {"gnorm": 0.3628}}, {"step": 152000, "data": {"epoch": 16}}, {"step": 152000, "data": {"sen": 26150599}}, {"step": 152000, "data": {"cost": 0.45991597}}, {"step": 152000, "data": {"time": 431.03}}, {"step": 152000, "data": {"rate": 593568.93}}, {"step": 152000, "data": {"gnorm": 0.3702}}, {"step": 153000, "data": {"epoch": 16}}, {"step": 153000, "data": {"sen": 37898046}}, {"step": 153000, "data": {"cost": 0.4611145}}, {"step": 153000, "data": {"time": 434.02}}, {"step": 153000, "data": {"rate": 592465.23}}, {"step": 153000, "data": {"gnorm": 0.4066}}, {"step": 154000, "data": {"epoch": 16}}, {"step": 154000, "data": {"sen": 49630879}}, {"step": 154000, "data": {"cost": 0.4604539}}, {"step": 154000, "data": {"time": 434.12}}, {"step": 154000, "data": {"rate": 590939.05}}, {"step": 154000, "data": {"gnorm": 0.3811}}, {"step": 155000, "data": {"epoch": 16}}, {"step": 155000, "data": {"sen": 61471390}}, {"step": 155000, "data": {"cost": 0.46033168}}, {"step": 155000, "data": {"time": 436.71}}, {"step": 155000, "data": {"rate": 592979.06}}, {"step": 155000, "data": {"gnorm": 0.3468}}, {"step": 155000, "data": {"epoch": 16}}, {"step": 155000, "data": {"perplexity": 9.38266}}, {"step": 155000, "data": {"chrf": 56.2884}}, {"step": 155000, "data": {"ce_mean_words": 2.23886}}, {"step": 155000, "data": {"bleu_detok": 28.7536}}, {"step": 156000, "data": {"epoch": 16}}, {"step": 156000, "data": {"sen": 73286426}}, {"step": 156000, "data": {"cost": 0.46055719}}, {"step": 156000, "data": {"time": 455.14}}, {"step": 156000, "data": {"rate": 565341.13}}, {"step": 156000, "data": {"gnorm": 0.3819}}, {"step": 157000, "data": {"epoch": 16}}, {"step": 157000, "data": {"sen": 84990728}}, {"step": 157000, "data": {"cost": 0.46030071}}, {"step": 157000, "data": {"time": 433.42}}, {"step": 157000, "data": {"rate": 591693.53}}, {"step": 157000, "data": {"gnorm": 0.3935}}, {"step": 158000, "data": {"epoch": 16}}, {"step": 158000, "data": {"sen": 96763954}}, {"step": 158000, "data": {"cost": 0.46006843}}, {"step": 158000, "data": {"time": 434.58}}, {"step": 158000, "data": {"rate": 591797.96}}, {"step": 158000, "data": {"gnorm": 0.3687}}, {"step": 159000, "data": {"epoch": 16}}, {"step": 159000, "data": {"sen": 108569407}}, {"step": 159000, "data": {"cost": 0.45938495}}, {"step": 159000, "data": {"time": 437.14}}, {"step": 159000, "data": {"rate": 592444.35}}, {"step": 159000, "data": {"gnorm": 0.3824}}, {"step": 160000, "data": {"epoch": 17}}, {"step": 160000, "data": {"sen": 2655672}}, {"step": 160000, "data": {"cost": 0.45810917}}, {"step": 160000, "data": {"time": 453.05}}, {"step": 160000, "data": {"rate": 565382.63}}, {"step": 160000, "data": {"gnorm": 0.3771}}, {"step": 160000, "data": {"epoch": 17}}, {"step": 160000, "data": {"perplexity": 9.38606}}, {"step": 160000, "data": {"chrf": 56.2319}}, {"step": 160000, "data": {"ce_mean_words": 2.23923}}, {"step": 160000, "data": {"bleu_detok": 28.8452}}, {"step": 161000, "data": {"epoch": 17}}, {"step": 161000, "data": {"sen": 14650564}}, {"step": 161000, "data": {"cost": 0.45642519}}, {"step": 161000, "data": {"time": 459.13}}, {"step": 161000, "data": {"rate": 564502.23}}, {"step": 161000, "data": {"gnorm": 0.3718}}, {"step": 162000, "data": {"epoch": 17}}, {"step": 162000, "data": {"sen": 26438889}}, {"step": 162000, "data": {"cost": 0.45680916}}, {"step": 162000, "data": {"time": 437.33}}, {"step": 162000, "data": {"rate": 589944.85}}, {"step": 162000, "data": {"gnorm": 0.3816}}, {"step": 163000, "data": {"epoch": 17}}, {"step": 163000, "data": {"sen": 38102428}}, {"step": 163000, "data": {"cost": 0.45749706}}, {"step": 163000, "data": {"time": 435.9}}, {"step": 163000, "data": {"rate": 590246.85}}, {"step": 163000, "data": {"gnorm": 0.3749}}, {"step": 164000, "data": {"epoch": 17}}, {"step": 164000, "data": {"sen": 49955922}}, {"step": 164000, "data": {"cost": 0.45631835}}, {"step": 164000, "data": {"time": 435.5}}, {"step": 164000, "data": {"rate": 591496.47}}, {"step": 164000, "data": {"gnorm": 0.3878}}, {"step": 165000, "data": {"epoch": 17}}, {"step": 165000, "data": {"sen": 61634217}}, {"step": 165000, "data": {"cost": 0.45699695}}, {"step": 165000, "data": {"time": 433.62}}, {"step": 165000, "data": {"rate": 590482.02}}, {"step": 165000, "data": {"gnorm": 0.3936}}, {"step": 165000, "data": {"epoch": 17}}, {"step": 165000, "data": {"perplexity": 9.26861}}, {"step": 165000, "data": {"chrf": 56.1556}}, {"step": 165000, "data": {"ce_mean_words": 2.22663}}, {"step": 165000, "data": {"bleu_detok": 28.8576}}, {"step": 166000, "data": {"epoch": 17}}, {"step": 166000, "data": {"sen": 73463669}}, {"step": 166000, "data": {"cost": 0.45690277}}, {"step": 166000, "data": {"time": 456.69}}, {"step": 166000, "data": {"rate": 566703.11}}, {"step": 166000, "data": {"gnorm": 0.3503}}, {"step": 167000, "data": {"epoch": 17}}, {"step": 167000, "data": {"sen": 85213899}}, {"step": 167000, "data": {"cost": 0.45712119}}, {"step": 167000, "data": {"time": 433.23}}, {"step": 167000, "data": {"rate": 588901.35}}, {"step": 167000, "data": {"gnorm": 0.4}}, {"step": 168000, "data": {"epoch": 17}}, {"step": 168000, "data": {"sen": 96963530}}, {"step": 168000, "data": {"cost": 0.45645934}}, {"step": 168000, "data": {"time": 435.19}}, {"step": 168000, "data": {"rate": 591524.42}}, {"step": 168000, "data": {"gnorm": 0.3691}}, {"step": 169000, "data": {"epoch": 17}}, {"step": 169000, "data": {"sen": 108635373}}, {"step": 169000, "data": {"cost": 0.4561255}}, {"step": 169000, "data": {"time": 433.88}}, {"step": 169000, "data": {"rate": 591375.95}}, {"step": 169000, "data": {"gnorm": 0.3911}}, {"step": 170000, "data": {"epoch": 18}}, {"step": 170000, "data": {"sen": 2833043}}, {"step": 170000, "data": {"cost": 0.45509434}}, {"step": 170000, "data": {"time": 453.42}}, {"step": 170000, "data": {"rate": 565122.81}}, {"step": 170000, "data": {"gnorm": 0.3784}}, {"step": 170000, "data": {"epoch": 18}}, {"step": 170000, "data": {"perplexity": 9.22607}}, {"step": 170000, "data": {"chrf": 56.1352}}, {"step": 170000, "data": {"ce_mean_words": 2.22203}}, {"step": 170000, "data": {"bleu_detok": 28.6235}}, {"step": 171000, "data": {"epoch": 18}}, {"step": 171000, "data": {"sen": 14580566}}, {"step": 171000, "data": {"cost": 0.45330366}}, {"step": 171000, "data": {"time": 457.25}}, {"step": 171000, "data": {"rate": 563187.27}}, {"step": 171000, "data": {"gnorm": 0.362}}, {"step": 172000, "data": {"epoch": 18}}, {"step": 172000, "data": {"sen": 26346048}}, {"step": 172000, "data": {"cost": 0.45379007}}, {"step": 172000, "data": {"time": 433.03}}, {"step": 172000, "data": {"rate": 591421.65}}, {"step": 172000, "data": {"gnorm": 0.3727}}, {"step": 173000, "data": {"epoch": 18}}, {"step": 173000, "data": {"sen": 38180349}}, {"step": 173000, "data": {"cost": 0.45368966}}, {"step": 173000, "data": {"time": 438.43}}, {"step": 173000, "data": {"rate": 592053.63}}, {"step": 173000, "data": {"gnorm": 0.3707}}, {"step": 174000, "data": {"epoch": 18}}, {"step": 174000, "data": {"sen": 49955553}}, {"step": 174000, "data": {"cost": 0.45357865}}, {"step": 174000, "data": {"time": 434.36}}, {"step": 174000, "data": {"rate": 591075.21}}, {"step": 174000, "data": {"gnorm": 0.3776}}, {"step": 175000, "data": {"epoch": 18}}, {"step": 175000, "data": {"sen": 61637835}}, {"step": 175000, "data": {"cost": 0.45371526}}, {"step": 175000, "data": {"time": 433.08}}, {"step": 175000, "data": {"rate": 590468.92}}, {"step": 175000, "data": {"gnorm": 0.3769}}, {"step": 175000, "data": {"epoch": 18}}, {"step": 175000, "data": {"perplexity": 9.46701}}, {"step": 175000, "data": {"chrf": 56.3345}}, {"step": 175000, "data": {"ce_mean_words": 2.24781}}, {"step": 175000, "data": {"bleu_detok": 28.7349}}, {"step": 176000, "data": {"epoch": 18}}, {"step": 176000, "data": {"sen": 73484556}}, {"step": 176000, "data": {"cost": 0.45314974}}, {"step": 176000, "data": {"time": 459.85}}, {"step": 176000, "data": {"rate": 561668.63}}, {"step": 176000, "data": {"gnorm": 0.3658}}, {"step": 177000, "data": {"epoch": 18}}, {"step": 177000, "data": {"sen": 85286542}}, {"step": 177000, "data": {"cost": 0.45406091}}, {"step": 177000, "data": {"time": 438.53}}, {"step": 177000, "data": {"rate": 590028.52}}, {"step": 177000, "data": {"gnorm": 0.3754}}, {"step": 178000, "data": {"epoch": 18}}, {"step": 178000, "data": {"sen": 97163786}}, {"step": 178000, "data": {"cost": 0.45338452}}, {"step": 178000, "data": {"time": 438.26}}, {"step": 178000, "data": {"rate": 590944.83}}, {"step": 178000, "data": {"gnorm": 0.3685}}, {"step": 179000, "data": {"epoch": 18}}, {"step": 179000, "data": {"sen": 108913175}}, {"step": 179000, "data": {"cost": 0.45368055}}, {"step": 179000, "data": {"time": 436.22}}, {"step": 179000, "data": {"rate": 590888.31}}, {"step": 179000, "data": {"gnorm": 0.3913}}, {"step": 180000, "data": {"epoch": 19}}, {"step": 180000, "data": {"sen": 3119343}}, {"step": 180000, "data": {"cost": 0.45204258}}, {"step": 180000, "data": {"time": 456.96}}, {"step": 180000, "data": {"rate": 562674.6}}, {"step": 180000, "data": {"gnorm": 0.3758}}, {"step": 180000, "data": {"epoch": 19}}, {"step": 180000, "data": {"perplexity": 9.59316}}, {"step": 180000, "data": {"chrf": 56.3672}}, {"step": 180000, "data": {"ce_mean_words": 2.26105}}, {"step": 180000, "data": {"bleu_detok": 28.9025}}, {"step": 181000, "data": {"epoch": 19}}, {"step": 181000, "data": {"sen": 14908010}}, {"step": 181000, "data": {"cost": 0.44966587}}, {"step": 181000, "data": {"time": 461.34}}, {"step": 181000, "data": {"rate": 559030.41}}, {"step": 181000, "data": {"gnorm": 0.3674}}, {"step": 182000, "data": {"epoch": 19}}, {"step": 182000, "data": {"sen": 26611622}}, {"step": 182000, "data": {"cost": 0.45041338}}, {"step": 182000, "data": {"time": 436.28}}, {"step": 182000, "data": {"rate": 587334.43}}, {"step": 182000, "data": {"gnorm": 0.3684}}, {"step": 183000, "data": {"epoch": 19}}, {"step": 183000, "data": {"sen": 38402012}}, {"step": 183000, "data": {"cost": 0.45100725}}, {"step": 183000, "data": {"time": 437.86}}, {"step": 183000, "data": {"rate": 588172.49}}, {"step": 183000, "data": {"gnorm": 0.3774}}, {"step": 184000, "data": {"epoch": 19}}, {"step": 184000, "data": {"sen": 50182233}}, {"step": 184000, "data": {"cost": 0.45046315}}, {"step": 184000, "data": {"time": 438.52}}, {"step": 184000, "data": {"rate": 587374.11}}, {"step": 184000, "data": {"gnorm": 0.3685}}, {"step": 185000, "data": {"epoch": 19}}, {"step": 185000, "data": {"sen": 61988589}}, {"step": 185000, "data": {"cost": 0.45078316}}, {"step": 185000, "data": {"time": 437.73}}, {"step": 185000, "data": {"rate": 588969.37}}, {"step": 185000, "data": {"gnorm": 0.3776}}, {"step": 185000, "data": {"epoch": 19}}, {"step": 185000, "data": {"perplexity": 9.26849}}, {"step": 185000, "data": {"chrf": 56.25}}, {"step": 185000, "data": {"ce_mean_words": 2.22662}}, {"step": 185000, "data": {"bleu_detok": 28.9145}}, {"step": 186000, "data": {"epoch": 19}}, {"step": 186000, "data": {"sen": 73739542}}, {"step": 186000, "data": {"cost": 0.45082703}}, {"step": 186000, "data": {"time": 459.85}}, {"step": 186000, "data": {"rate": 559354.71}}, {"step": 186000, "data": {"gnorm": 0.3587}}, {"step": 187000, "data": {"epoch": 19}}, {"step": 187000, "data": {"sen": 85516353}}, {"step": 187000, "data": {"cost": 0.45025146}}, {"step": 187000, "data": {"time": 439.43}}, {"step": 187000, "data": {"rate": 586953.96}}, {"step": 187000, "data": {"gnorm": 0.3727}}, {"step": 188000, "data": {"epoch": 19}}, {"step": 188000, "data": {"sen": 97366084}}, {"step": 188000, "data": {"cost": 0.45009664}}, {"step": 188000, "data": {"time": 438.15}}, {"step": 188000, "data": {"rate": 588498.97}}, {"step": 188000, "data": {"gnorm": 0.3655}}, {"step": 189000, "data": {"epoch": 19}}, {"step": 189000, "data": {"sen": 109214881}}, {"step": 189000, "data": {"cost": 0.4509193}}, {"step": 189000, "data": {"time": 438.72}}, {"step": 189000, "data": {"rate": 586556.55}}, {"step": 189000, "data": {"gnorm": 0.4806}}, {"step": 190000, "data": {"epoch": 20}}, {"step": 190000, "data": {"sen": 3243603}}, {"step": 190000, "data": {"cost": 0.44915855}}, {"step": 190000, "data": {"time": 459.73}}, {"step": 190000, "data": {"rate": 557490.94}}, {"step": 190000, "data": {"gnorm": 0.3582}}, {"step": 190000, "data": {"epoch": 20}}, {"step": 190000, "data": {"perplexity": 9.25491}}, {"step": 190000, "data": {"chrf": 56.1698}}, {"step": 190000, "data": {"ce_mean_words": 2.22515}}, {"step": 190000, "data": {"bleu_detok": 28.8545}}, {"step": 191000, "data": {"epoch": 20}}, {"step": 191000, "data": {"sen": 15047039}}, {"step": 191000, "data": {"cost": 0.44777152}}, {"step": 191000, "data": {"time": 460.42}}, {"step": 191000, "data": {"rate": 559465.78}}, {"step": 191000, "data": {"gnorm": 0.3769}}, {"step": 192000, "data": {"epoch": 20}}, {"step": 192000, "data": {"sen": 26906896}}, {"step": 192000, "data": {"cost": 0.44720948}}, {"step": 192000, "data": {"time": 441.37}}, {"step": 192000, "data": {"rate": 586939.05}}, {"step": 192000, "data": {"gnorm": 0.3755}}, {"step": 193000, "data": {"epoch": 20}}, {"step": 193000, "data": {"sen": 38710308}}, {"step": 193000, "data": {"cost": 0.44795078}}, {"step": 193000, "data": {"time": 440.15}}, {"step": 193000, "data": {"rate": 586988.57}}, {"step": 193000, "data": {"gnorm": 0.3646}}, {"step": 194000, "data": {"epoch": 20}}, {"step": 194000, "data": {"sen": 50478455}}, {"step": 194000, "data": {"cost": 0.44791254}}, {"step": 194000, "data": {"time": 436.98}}, {"step": 194000, "data": {"rate": 587616.93}}, {"step": 194000, "data": {"gnorm": 0.3581}}, {"step": 195000, "data": {"epoch": 20}}, {"step": 195000, "data": {"sen": 62310191}}, {"step": 195000, "data": {"cost": 0.44817236}}, {"step": 195000, "data": {"time": 439.54}}, {"step": 195000, "data": {"rate": 586492.13}}, {"step": 195000, "data": {"gnorm": 0.3809}}, {"step": 195000, "data": {"epoch": 20}}, {"step": 195000, "data": {"perplexity": 9.2688}}, {"step": 195000, "data": {"chrf": 56.3689}}, {"step": 195000, "data": {"ce_mean_words": 2.22665}}, {"step": 195000, "data": {"bleu_detok": 29.068}}, {"step": 196000, "data": {"epoch": 20}}, {"step": 196000, "data": {"sen": 74081476}}, {"step": 196000, "data": {"cost": 0.44821185}}, {"step": 196000, "data": {"time": 463.95}}, {"step": 196000, "data": {"rate": 557280.46}}, {"step": 196000, "data": {"gnorm": 0.379}}, {"step": 197000, "data": {"epoch": 20}}, {"step": 197000, "data": {"sen": 85874959}}, {"step": 197000, "data": {"cost": 0.44817808}}, {"step": 197000, "data": {"time": 441.18}}, {"step": 197000, "data": {"rate": 585258.33}}, {"step": 197000, "data": {"gnorm": 0.3738}}, {"step": 198000, "data": {"epoch": 20}}, {"step": 198000, "data": {"sen": 97699938}}, {"step": 198000, "data": {"cost": 0.44812799}}, {"step": 198000, "data": {"time": 441.58}}, {"step": 198000, "data": {"rate": 583960.49}}, {"step": 198000, "data": {"gnorm": 0.3888}}, {"step": 199000, "data": {"epoch": 20}}, {"step": 199000, "data": {"sen": 109615073}}, {"step": 199000, "data": {"cost": 0.44742417}}, {"step": 199000, "data": {"time": 443.05}}, {"step": 199000, "data": {"rate": 583237.02}}, {"step": 199000, "data": {"gnorm": 0.3879}}, {"step": 200000, "data": {"epoch": 21}}, {"step": 200000, "data": {"sen": 3664252}}, {"step": 200000, "data": {"cost": 0.44631025}}, {"step": 200000, "data": {"time": 463.24}}, {"step": 200000, "data": {"rate": 552376.84}}, {"step": 200000, "data": {"gnorm": 0.3514}}, {"step": 200000, "data": {"epoch": 21}}, {"step": 200000, "data": {"perplexity": 9.46171}}, {"step": 200000, "data": {"chrf": 56.3911}}, {"step": 200000, "data": {"ce_mean_words": 2.24725}}, {"step": 200000, "data": {"bleu_detok": 29.1056}}, {"step": 201000, "data": {"epoch": 21}}, {"step": 201000, "data": {"sen": 15413089}}, {"step": 201000, "data": {"cost": 0.44541192}}, {"step": 201000, "data": {"time": 461.88}}, {"step": 201000, "data": {"rate": 557418.49}}, {"step": 201000, "data": {"gnorm": 0.3657}}, {"step": 202000, "data": {"epoch": 21}}, {"step": 202000, "data": {"sen": 27207391}}, {"step": 202000, "data": {"cost": 0.44550568}}, {"step": 202000, "data": {"time": 440.55}}, {"step": 202000, "data": {"rate": 584804.3}}, {"step": 202000, "data": {"gnorm": 0.3593}}, {"step": 203000, "data": {"epoch": 21}}, {"step": 203000, "data": {"sen": 39005095}}, {"step": 203000, "data": {"cost": 0.44585809}}, {"step": 203000, "data": {"time": 440.26}}, {"step": 203000, "data": {"rate": 585382.49}}, {"step": 203000, "data": {"gnorm": 0.3681}}, {"step": 204000, "data": {"epoch": 21}}, {"step": 204000, "data": {"sen": 50834531}}, {"step": 204000, "data": {"cost": 0.4450379}}, {"step": 204000, "data": {"time": 440.78}}, {"step": 204000, "data": {"rate": 585618.8}}, {"step": 204000, "data": {"gnorm": 0.3685}}, {"step": 205000, "data": {"epoch": 21}}, {"step": 205000, "data": {"sen": 62539326}}, {"step": 205000, "data": {"cost": 0.44587755}}, {"step": 205000, "data": {"time": 440.66}}, {"step": 205000, "data": {"rate": 582137.67}}, {"step": 205000, "data": {"gnorm": 0.5461}}, {"step": 205000, "data": {"epoch": 21}}, {"step": 205000, "data": {"perplexity": 9.27423}}, {"step": 205000, "data": {"chrf": 56.3655}}, {"step": 205000, "data": {"ce_mean_words": 2.22724}}, {"step": 205000, "data": {"bleu_detok": 29.1131}}, {"step": 206000, "data": {"epoch": 21}}, {"step": 206000, "data": {"sen": 74332640}}, {"step": 206000, "data": {"cost": 0.44581839}}, {"step": 206000, "data": {"time": 461.12}}, {"step": 206000, "data": {"rate": 558274.54}}, {"step": 206000, "data": {"gnorm": 0.3715}}, {"step": 207000, "data": {"epoch": 21}}, {"step": 207000, "data": {"sen": 86151961}}, {"step": 207000, "data": {"cost": 0.44576955}}, {"step": 207000, "data": {"time": 440.05}}, {"step": 207000, "data": {"rate": 584645.87}}, {"step": 207000, "data": {"gnorm": 0.3646}}, {"step": 208000, "data": {"epoch": 21}}, {"step": 208000, "data": {"sen": 97928126}}, {"step": 208000, "data": {"cost": 0.44510272}}, {"step": 208000, "data": {"time": 441.96}}, {"step": 208000, "data": {"rate": 585809.14}}, {"step": 208000, "data": {"gnorm": 0.4152}}, {"step": 209000, "data": {"epoch": 21}}, {"step": 209000, "data": {"sen": 109774150}}, {"step": 209000, "data": {"cost": 0.44603771}}, {"step": 209000, "data": {"time": 442.41}}, {"step": 209000, "data": {"rate": 583062.17}}, {"step": 209000, "data": {"gnorm": 0.4135}}, {"step": 210000, "data": {"epoch": 22}}, {"step": 210000, "data": {"sen": 3864530}}, {"step": 210000, "data": {"cost": 0.44470102}}, {"step": 210000, "data": {"time": 464.54}}, {"step": 210000, "data": {"rate": 551293.98}}, {"step": 210000, "data": {"gnorm": 0.3914}}, {"step": 210000, "data": {"epoch": 22}}, {"step": 210000, "data": {"perplexity": 9.40695}}, {"step": 210000, "data": {"chrf": 56.3888}}, {"step": 210000, "data": {"ce_mean_words": 2.24145}}, {"step": 210000, "data": {"bleu_detok": 29.0923}}, {"step": 211000, "data": {"epoch": 22}}, {"step": 211000, "data": {"sen": 15692928}}, {"step": 211000, "data": {"cost": 0.44195884}}, {"step": 211000, "data": {"time": 460.68}}, {"step": 211000, "data": {"rate": 559008.31}}, {"step": 211000, "data": {"gnorm": 0.3722}}, {"step": 212000, "data": {"epoch": 22}}, {"step": 212000, "data": {"sen": 27515604}}, {"step": 212000, "data": {"cost": 0.44305474}}, {"step": 212000, "data": {"time": 443.38}}, {"step": 212000, "data": {"rate": 583944.77}}, {"step": 212000, "data": {"gnorm": 0.3709}}, {"step": 213000, "data": {"epoch": 22}}, {"step": 213000, "data": {"sen": 39256353}}, {"step": 213000, "data": {"cost": 0.44371077}}, {"step": 213000, "data": {"time": 438.47}}, {"step": 213000, "data": {"rate": 583726.95}}, {"step": 213000, "data": {"gnorm": 0.3761}}, {"step": 214000, "data": {"epoch": 22}}, {"step": 214000, "data": {"sen": 50970542}}, {"step": 214000, "data": {"cost": 0.4435164}}, {"step": 214000, "data": {"time": 440.71}}, {"step": 214000, "data": {"rate": 583470.73}}, {"step": 214000, "data": {"gnorm": 0.3652}}, {"step": 215000, "data": {"epoch": 22}}, {"step": 215000, "data": {"sen": 62826980}}, {"step": 215000, "data": {"cost": 0.44330567}}, {"step": 215000, "data": {"time": 442.13}}, {"step": 215000, "data": {"rate": 584738.87}}, {"step": 215000, "data": {"gnorm": 0.3631}}, {"step": 215000, "data": {"epoch": 22}}, {"step": 215000, "data": {"perplexity": 9.48446}}, {"step": 215000, "data": {"chrf": 56.5076}}, {"step": 215000, "data": {"ce_mean_words": 2.24965}}, {"step": 215000, "data": {"bleu_detok": 28.9888}}, {"step": 216000, "data": {"epoch": 22}}, {"step": 216000, "data": {"sen": 74588793}}, {"step": 216000, "data": {"cost": 0.44342333}}, {"step": 216000, "data": {"time": 460.87}}, {"step": 216000, "data": {"rate": 556670.17}}, {"step": 216000, "data": {"gnorm": 0.3869}}, {"step": 217000, "data": {"epoch": 22}}, {"step": 217000, "data": {"sen": 86282526}}, {"step": 217000, "data": {"cost": 0.44287375}}, {"step": 217000, "data": {"time": 440.36}}, {"step": 217000, "data": {"rate": 583021.6}}, {"step": 217000, "data": {"gnorm": 0.3782}}, {"step": 218000, "data": {"epoch": 22}}, {"step": 218000, "data": {"sen": 98116696}}, {"step": 218000, "data": {"cost": 0.44278762}}, {"step": 218000, "data": {"time": 442.99}}, {"step": 218000, "data": {"rate": 583037.79}}, {"step": 218000, "data": {"gnorm": 0.3573}}, {"step": 219000, "data": {"epoch": 22}}, {"step": 219000, "data": {"sen": 109904726}}, {"step": 219000, "data": {"cost": 0.44348368}}, {"step": 219000, "data": {"time": 442.33}}, {"step": 219000, "data": {"rate": 581640.71}}, {"step": 219000, "data": {"gnorm": 0.3644}}, {"step": 220000, "data": {"epoch": 23}}, {"step": 220000, "data": {"sen": 3924291}}, {"step": 220000, "data": {"cost": 0.44229835}}, {"step": 220000, "data": {"time": 464.2}}, {"step": 220000, "data": {"rate": 548037.8}}, {"step": 220000, "data": {"gnorm": 0.3884}}, {"step": 220000, "data": {"epoch": 23}}, {"step": 220000, "data": {"perplexity": 9.49362}}, {"step": 220000, "data": {"chrf": 56.5687}}, {"step": 220000, "data": {"ce_mean_words": 2.25062}}, {"step": 220000, "data": {"bleu_detok": 29.1362}}, {"step": 221000, "data": {"epoch": 23}}, {"step": 221000, "data": {"sen": 15639136}}, {"step": 221000, "data": {"cost": 0.44064739}}, {"step": 221000, "data": {"time": 462.97}}, {"step": 221000, "data": {"rate": 552476.6}}, {"step": 221000, "data": {"gnorm": 0.37}}, {"step": 222000, "data": {"epoch": 23}}, {"step": 222000, "data": {"sen": 27482789}}, {"step": 222000, "data": {"cost": 0.44081715}}, {"step": 222000, "data": {"time": 444.32}}, {"step": 222000, "data": {"rate": 582694.88}}, {"step": 222000, "data": {"gnorm": 0.3547}}, {"step": 223000, "data": {"epoch": 23}}, {"step": 223000, "data": {"sen": 39239547}}, {"step": 223000, "data": {"cost": 0.44143939}}, {"step": 223000, "data": {"time": 442.4}}, {"step": 223000, "data": {"rate": 582051.12}}, {"step": 223000, "data": {"gnorm": 0.3563}}, {"step": 224000, "data": {"epoch": 23}}, {"step": 224000, "data": {"sen": 51070599}}, {"step": 224000, "data": {"cost": 0.44150719}}, {"step": 224000, "data": {"time": 443.73}}, {"step": 224000, "data": {"rate": 582277.44}}, {"step": 224000, "data": {"gnorm": 0.3559}}, {"step": 225000, "data": {"epoch": 23}}, {"step": 225000, "data": {"sen": 62922818}}, {"step": 225000, "data": {"cost": 0.44120145}}, {"step": 225000, "data": {"time": 443.37}}, {"step": 225000, "data": {"rate": 582883.64}}, {"step": 225000, "data": {"gnorm": 0.3448}}, {"step": 225000, "data": {"epoch": 23}}, {"step": 225000, "data": {"perplexity": 9.47606}}, {"step": 225000, "data": {"chrf": 56.4264}}, {"step": 225000, "data": {"ce_mean_words": 2.24877}}, {"step": 225000, "data": {"bleu_detok": 29.091}}, {"step": 226000, "data": {"epoch": 23}}, {"step": 226000, "data": {"sen": 74769932}}, {"step": 226000, "data": {"cost": 0.441136}}, {"step": 226000, "data": {"time": 465.99}}, {"step": 226000, "data": {"rate": 554714.51}}, {"step": 226000, "data": {"gnorm": 0.3702}}, {"step": 227000, "data": {"epoch": 23}}, {"step": 227000, "data": {"sen": 86553276}}, {"step": 227000, "data": {"cost": 0.44135451}}, {"step": 227000, "data": {"time": 443.27}}, {"step": 227000, "data": {"rate": 582456.14}}, {"step": 227000, "data": {"gnorm": 0.3667}}, {"step": 228000, "data": {"epoch": 23}}, {"step": 228000, "data": {"sen": 98302120}}, {"step": 228000, "data": {"cost": 0.44117048}}, {"step": 228000, "data": {"time": 441.9}}, {"step": 228000, "data": {"rate": 580587.43}}, {"step": 228000, "data": {"gnorm": 0.3592}}, {"step": 229000, "data": {"epoch": 23}}, {"step": 229000, "data": {"sen": 110104332}}, {"step": 229000, "data": {"cost": 0.44181234}}, {"step": 229000, "data": {"time": 443.06}}, {"step": 229000, "data": {"rate": 582519.86}}, {"step": 229000, "data": {"gnorm": 0.3674}}, {"step": 230000, "data": {"epoch": 24}}, {"step": 230000, "data": {"sen": 4235877}}, {"step": 230000, "data": {"cost": 0.44055501}}, {"step": 230000, "data": {"time": 468.47}}, {"step": 230000, "data": {"rate": 546440.2}}, {"step": 230000, "data": {"gnorm": 0.3784}}, {"step": 230000, "data": {"epoch": 24}}, {"step": 230000, "data": {"perplexity": 9.45005}}, {"step": 230000, "data": {"chrf": 56.452}}, {"step": 230000, "data": {"ce_mean_words": 2.24602}}, {"step": 230000, "data": {"bleu_detok": 29.1292}}, {"step": 231000, "data": {"epoch": 24}}, {"step": 231000, "data": {"sen": 15999938}}, {"step": 231000, "data": {"cost": 0.43854019}}, {"step": 231000, "data": {"time": 468.14}}, {"step": 231000, "data": {"rate": 550634.82}}, {"step": 231000, "data": {"gnorm": 0.3564}}, {"step": 232000, "data": {"epoch": 24}}, {"step": 232000, "data": {"sen": 27793978}}, {"step": 232000, "data": {"cost": 0.4391906}}, {"step": 232000, "data": {"time": 443.76}}, {"step": 232000, "data": {"rate": 579508.05}}, {"step": 232000, "data": {"gnorm": 0.3903}}, {"step": 233000, "data": {"epoch": 24}}, {"step": 233000, "data": {"sen": 39475069}}, {"step": 233000, "data": {"cost": 0.43898764}}, {"step": 233000, "data": {"time": 442.08}}, {"step": 233000, "data": {"rate": 581847.24}}, {"step": 233000, "data": {"gnorm": 0.365}}, {"step": 234000, "data": {"epoch": 24}}, {"step": 234000, "data": {"sen": 51355934}}, {"step": 234000, "data": {"cost": 0.43921655}}, {"step": 234000, "data": {"time": 446.13}}, {"step": 234000, "data": {"rate": 580067.05}}, {"step": 234000, "data": {"gnorm": 0.3419}}, {"step": 235000, "data": {"epoch": 24}}, {"step": 235000, "data": {"sen": 63169733}}, {"step": 235000, "data": {"cost": 0.439834}}, {"step": 235000, "data": {"time": 444.89}}, {"step": 235000, "data": {"rate": 579706.15}}, {"step": 235000, "data": {"gnorm": 0.4048}}, {"step": 235000, "data": {"epoch": 24}}, {"step": 235000, "data": {"perplexity": 9.18762}}, {"step": 235000, "data": {"chrf": 56.3695}}, {"step": 235000, "data": {"ce_mean_words": 2.21786}}, {"step": 235000, "data": {"bleu_detok": 29.0076}}, {"step": 236000, "data": {"epoch": 24}}, {"step": 236000, "data": {"sen": 74946160}}, {"step": 236000, "data": {"cost": 0.43989334}}, {"step": 236000, "data": {"time": 468.08}}, {"step": 236000, "data": {"rate": 549143.53}}, {"step": 236000, "data": {"gnorm": 0.3879}}, {"step": 237000, "data": {"epoch": 24}}, {"step": 237000, "data": {"sen": 86799248}}, {"step": 237000, "data": {"cost": 0.43984589}}, {"step": 237000, "data": {"time": 445.51}}, {"step": 237000, "data": {"rate": 580123.87}}, {"step": 237000, "data": {"gnorm": 0.3775}}, {"step": 238000, "data": {"epoch": 24}}, {"step": 238000, "data": {"sen": 98557043}}, {"step": 238000, "data": {"cost": 0.43930057}}, {"step": 238000, "data": {"time": 444.6}}, {"step": 238000, "data": {"rate": 579224.02}}, {"step": 238000, "data": {"gnorm": 0.3639}}, {"step": 239000, "data": {"epoch": 24}}, {"step": 239000, "data": {"sen": 110379971}}, {"step": 239000, "data": {"cost": 0.43950388}}, {"step": 239000, "data": {"time": 446.2}}, {"step": 239000, "data": {"rate": 579443.32}}, {"step": 239000, "data": {"gnorm": 0.3504}}, {"step": 240000, "data": {"epoch": 25}}, {"step": 240000, "data": {"sen": 4517893}}, {"step": 240000, "data": {"cost": 0.43805051}}, {"step": 240000, "data": {"time": 469.58}}, {"step": 240000, "data": {"rate": 546513.6}}, {"step": 240000, "data": {"gnorm": 0.3644}}, {"step": 240000, "data": {"epoch": 25}}, {"step": 240000, "data": {"perplexity": 9.31448}}, {"step": 240000, "data": {"chrf": 56.372}}, {"step": 240000, "data": {"ce_mean_words": 2.23157}}, {"step": 240000, "data": {"bleu_detok": 29.1039}}, {"step": 241000, "data": {"epoch": 25}}, {"step": 241000, "data": {"sen": 16251314}}, {"step": 241000, "data": {"cost": 0.43656027}}, {"step": 241000, "data": {"time": 464.63}}, {"step": 241000, "data": {"rate": 552753.62}}, {"step": 241000, "data": {"gnorm": 0.3688}}, {"step": 242000, "data": {"epoch": 25}}, {"step": 242000, "data": {"sen": 28104273}}, {"step": 242000, "data": {"cost": 0.43687513}}, {"step": 242000, "data": {"time": 444.16}}, {"step": 242000, "data": {"rate": 580945.05}}, {"step": 242000, "data": {"gnorm": 0.3669}}, {"step": 243000, "data": {"epoch": 25}}, {"step": 243000, "data": {"sen": 39839136}}, {"step": 243000, "data": {"cost": 0.43714023}}, {"step": 243000, "data": {"time": 442.8}}, {"step": 243000, "data": {"rate": 578811.59}}, {"step": 243000, "data": {"gnorm": 0.3671}}, {"step": 244000, "data": {"epoch": 25}}, {"step": 244000, "data": {"sen": 51528098}}, {"step": 244000, "data": {"cost": 0.43764248}}, {"step": 244000, "data": {"time": 443.87}}, {"step": 244000, "data": {"rate": 577747.58}}, {"step": 244000, "data": {"gnorm": 0.3815}}, {"step": 245000, "data": {"epoch": 25}}, {"step": 245000, "data": {"sen": 63361767}}, {"step": 245000, "data": {"cost": 0.43762565}}, {"step": 245000, "data": {"time": 445.96}}, {"step": 245000, "data": {"rate": 579996.89}}, {"step": 245000, "data": {"gnorm": 0.3711}}, {"step": 245000, "data": {"epoch": 25}}, {"step": 245000, "data": {"perplexity": 9.25262}}, {"step": 245000, "data": {"chrf": 56.5864}}, {"step": 245000, "data": {"ce_mean_words": 2.22491}}, {"step": 245000, "data": {"bleu_detok": 29.2153}}, {"step": 246000, "data": {"epoch": 25}}, {"step": 246000, "data": {"sen": 75175866}}, {"step": 246000, "data": {"cost": 0.43792155}}, {"step": 246000, "data": {"time": 469.51}}, {"step": 246000, "data": {"rate": 549265.72}}, {"step": 246000, "data": {"gnorm": 0.3553}}, {"step": 247000, "data": {"epoch": 25}}, {"step": 247000, "data": {"sen": 86940594}}, {"step": 247000, "data": {"cost": 0.43772209}}, {"step": 247000, "data": {"time": 444.44}}, {"step": 247000, "data": {"rate": 576614.5}}, {"step": 247000, "data": {"gnorm": 0.3577}}, {"step": 248000, "data": {"epoch": 25}}, {"step": 248000, "data": {"sen": 98588441}}, {"step": 248000, "data": {"cost": 0.43818143}}, {"step": 248000, "data": {"time": 443.79}}, {"step": 248000, "data": {"rate": 577381.03}}, {"step": 248000, "data": {"gnorm": 0.372}}, {"step": 249000, "data": {"epoch": 25}}, {"step": 249000, "data": {"sen": 110518320}}, {"step": 249000, "data": {"cost": 0.43761593}}, {"step": 249000, "data": {"time": 446.87}}, {"step": 249000, "data": {"rate": 579812.49}}, {"step": 249000, "data": {"gnorm": 0.3513}}, {"step": 250000, "data": {"epoch": 26}}, {"step": 250000, "data": {"sen": 4638969}}, {"step": 250000, "data": {"cost": 0.43637943}}, {"step": 250000, "data": {"time": 473.1}}, {"step": 250000, "data": {"rate": 543312.03}}, {"step": 250000, "data": {"gnorm": 0.3605}}, {"step": 250000, "data": {"epoch": 26}}, {"step": 250000, "data": {"perplexity": 9.24702}}, {"step": 250000, "data": {"chrf": 56.4923}}, {"step": 250000, "data": {"ce_mean_words": 2.2243}}, {"step": 250000, "data": {"bleu_detok": 29.0982}}, {"step": 251000, "data": {"epoch": 26}}, {"step": 251000, "data": {"sen": 16418784}}, {"step": 251000, "data": {"cost": 0.43534884}}, {"step": 251000, "data": {"time": 465.58}}, {"step": 251000, "data": {"rate": 552307.99}}, {"step": 251000, "data": {"gnorm": 0.3783}}, {"step": 252000, "data": {"epoch": 26}}, {"step": 252000, "data": {"sen": 28287322}}, {"step": 252000, "data": {"cost": 0.43536708}}, {"step": 252000, "data": {"time": 447.9}}, {"step": 252000, "data": {"rate": 579347.45}}, {"step": 252000, "data": {"gnorm": 0.3466}}, {"step": 253000, "data": {"epoch": 26}}, {"step": 253000, "data": {"sen": 40040099}}, {"step": 253000, "data": {"cost": 0.43610796}}, {"step": 253000, "data": {"time": 444.7}}, {"step": 253000, "data": {"rate": 579016.33}}, {"step": 253000, "data": {"gnorm": 0.3608}}, {"step": 254000, "data": {"epoch": 26}}, {"step": 254000, "data": {"sen": 51777886}}, {"step": 254000, "data": {"cost": 0.43596169}}, {"step": 254000, "data": {"time": 443.98}}, {"step": 254000, "data": {"rate": 577030.6}}, {"step": 254000, "data": {"gnorm": 0.3614}}, {"step": 255000, "data": {"epoch": 26}}, {"step": 255000, "data": {"sen": 63512352}}, {"step": 255000, "data": {"cost": 0.43589422}}, {"step": 255000, "data": {"time": 445.27}}, {"step": 255000, "data": {"rate": 577831.69}}, {"step": 255000, "data": {"gnorm": 0.3705}}, {"step": 255000, "data": {"epoch": 26}}, {"step": 255000, "data": {"perplexity": 9.24564}}, {"step": 255000, "data": {"chrf": 56.5104}}, {"step": 255000, "data": {"ce_mean_words": 2.22415}}, {"step": 255000, "data": {"bleu_detok": 29.16}}, {"step": 256000, "data": {"epoch": 26}}, {"step": 256000, "data": {"sen": 75370681}}, {"step": 256000, "data": {"cost": 0.43613812}}, {"step": 256000, "data": {"time": 468.09}}, {"step": 256000, "data": {"rate": 550292.87}}, {"step": 256000, "data": {"gnorm": 0.3399}}, {"step": 257000, "data": {"epoch": 26}}, {"step": 257000, "data": {"sen": 87140182}}, {"step": 257000, "data": {"cost": 0.43605602}}, {"step": 257000, "data": {"time": 444.9}}, {"step": 257000, "data": {"rate": 579090.45}}, {"step": 257000, "data": {"gnorm": 0.3589}}, {"step": 258000, "data": {"epoch": 26}}, {"step": 258000, "data": {"sen": 98870839}}, {"step": 258000, "data": {"cost": 0.4361105}}, {"step": 258000, "data": {"time": 445.54}}, {"step": 258000, "data": {"rate": 577282.07}}, {"step": 258000, "data": {"gnorm": 0.3784}}, {"step": 259000, "data": {"epoch": 26}}, {"step": 259000, "data": {"sen": 110744655}}, {"step": 259000, "data": {"cost": 0.43640849}}, {"step": 259000, "data": {"time": 446.87}}, {"step": 259000, "data": {"rate": 575647.99}}, {"step": 259000, "data": {"gnorm": 0.3665}}, {"step": 260000, "data": {"epoch": 27}}, {"step": 260000, "data": {"sen": 4751200}}, {"step": 260000, "data": {"cost": 0.43441543}}, {"step": 260000, "data": {"time": 472.45}}, {"step": 260000, "data": {"rate": 542106.56}}, {"step": 260000, "data": {"gnorm": 0.3771}}, {"step": 260000, "data": {"epoch": 27}}, {"step": 260000, "data": {"perplexity": 9.56998}}, {"step": 260000, "data": {"chrf": 56.6339}}, {"step": 260000, "data": {"ce_mean_words": 2.25863}}, {"step": 260000, "data": {"bleu_detok": 29.117}}, {"step": 261000, "data": {"epoch": 27}}, {"step": 261000, "data": {"sen": 16542169}}, {"step": 261000, "data": {"cost": 0.43353}}, {"step": 261000, "data": {"time": 467.84}}, {"step": 261000, "data": {"rate": 547956.95}}, {"step": 261000, "data": {"gnorm": 0.3793}}, {"step": 262000, "data": {"epoch": 27}}, {"step": 262000, "data": {"sen": 28371847}}, {"step": 262000, "data": {"cost": 0.43384069}}, {"step": 262000, "data": {"time": 447.45}}, {"step": 262000, "data": {"rate": 576437.96}}, {"step": 262000, "data": {"gnorm": 0.3761}}, {"step": 263000, "data": {"epoch": 27}}, {"step": 263000, "data": {"sen": 40122068}}, {"step": 263000, "data": {"cost": 0.4338806}}, {"step": 263000, "data": {"time": 446.02}}, {"step": 263000, "data": {"rate": 578640.14}}, {"step": 263000, "data": {"gnorm": 0.3758}}, {"step": 264000, "data": {"epoch": 27}}, {"step": 264000, "data": {"sen": 51960463}}, {"step": 264000, "data": {"cost": 0.43449128}}, {"step": 264000, "data": {"time": 447.87}}, {"step": 264000, "data": {"rate": 575789.87}}, {"step": 264000, "data": {"gnorm": 0.399}}, {"step": 265000, "data": {"epoch": 27}}, {"step": 265000, "data": {"sen": 63650219}}, {"step": 265000, "data": {"cost": 0.43423343}}, {"step": 265000, "data": {"time": 445.65}}, {"step": 265000, "data": {"rate": 575900.88}}, {"step": 265000, "data": {"gnorm": 0.3605}}, {"step": 265000, "data": {"epoch": 27}}, {"step": 265000, "data": {"perplexity": 9.22466}}, {"step": 265000, "data": {"chrf": 56.2178}}, {"step": 265000, "data": {"ce_mean_words": 2.22188}}, {"step": 265000, "data": {"bleu_detok": 28.866}}, {"step": 266000, "data": {"epoch": 27}}, {"step": 266000, "data": {"sen": 75455073}}, {"step": 266000, "data": {"cost": 0.43440267}}, {"step": 266000, "data": {"time": 467.3}}, {"step": 266000, "data": {"rate": 551145.86}}, {"step": 266000, "data": {"gnorm": 0.3569}}, {"step": 267000, "data": {"epoch": 27}}, {"step": 267000, "data": {"sen": 87280933}}, {"step": 267000, "data": {"cost": 0.43432069}}, {"step": 267000, "data": {"time": 446.57}}, {"step": 267000, "data": {"rate": 576969.89}}, {"step": 267000, "data": {"gnorm": 0.3419}}, {"step": 268000, "data": {"epoch": 27}}, {"step": 268000, "data": {"sen": 99100484}}, {"step": 268000, "data": {"cost": 0.43452659}}, {"step": 268000, "data": {"time": 448.32}}, {"step": 268000, "data": {"rate": 576952.4}}, {"step": 268000, "data": {"gnorm": 0.3617}}, {"step": 269000, "data": {"epoch": 27}}, {"step": 269000, "data": {"sen": 110931962}}, {"step": 269000, "data": {"cost": 0.43484607}}, {"step": 269000, "data": {"time": 448.81}}, {"step": 269000, "data": {"rate": 575879.27}}, {"step": 269000, "data": {"gnorm": 0.3853}}, {"step": 270000, "data": {"epoch": 28}}, {"step": 270000, "data": {"sen": 4999993}}, {"step": 270000, "data": {"cost": 0.43333212}}, {"step": 270000, "data": {"time": 472.54}}, {"step": 270000, "data": {"rate": 540814.96}}, {"step": 270000, "data": {"gnorm": 0.3806}}, {"step": 270000, "data": {"epoch": 28}}, {"step": 270000, "data": {"perplexity": 9.20763}}, {"step": 270000, "data": {"chrf": 56.5498}}, {"step": 270000, "data": {"ce_mean_words": 2.22003}}, {"step": 270000, "data": {"bleu_detok": 29.199}}, {"step": 271000, "data": {"epoch": 28}}, {"step": 271000, "data": {"sen": 16843442}}, {"step": 271000, "data": {"cost": 0.43181854}}, {"step": 271000, "data": {"time": 468.56}}, {"step": 271000, "data": {"rate": 549236.05}}, {"step": 271000, "data": {"gnorm": 0.3793}}, {"step": 272000, "data": {"epoch": 28}}, {"step": 272000, "data": {"sen": 28621276}}, {"step": 272000, "data": {"cost": 0.43263769}}, {"step": 272000, "data": {"time": 447.09}}, {"step": 272000, "data": {"rate": 578085.3}}, {"step": 272000, "data": {"gnorm": 0.3658}}, {"step": 273000, "data": {"epoch": 28}}, {"step": 273000, "data": {"sen": 40383370}}, {"step": 273000, "data": {"cost": 0.43260631}}, {"step": 273000, "data": {"time": 446.42}}, {"step": 273000, "data": {"rate": 578381.71}}, {"step": 273000, "data": {"gnorm": 0.3496}}, {"step": 274000, "data": {"epoch": 28}}, {"step": 274000, "data": {"sen": 52195736}}, {"step": 274000, "data": {"cost": 0.43312678}}, {"step": 274000, "data": {"time": 448.27}}, {"step": 274000, "data": {"rate": 575502.13}}, {"step": 274000, "data": {"gnorm": 0.3452}}, {"step": 275000, "data": {"epoch": 28}}, {"step": 275000, "data": {"sen": 63975505}}, {"step": 275000, "data": {"cost": 0.43313354}}, {"step": 275000, "data": {"time": 445.63}}, {"step": 275000, "data": {"rate": 575680.26}}, {"step": 275000, "data": {"gnorm": 0.3681}}, {"step": 275000, "data": {"epoch": 28}}, {"step": 275000, "data": {"perplexity": 9.46031}}, {"step": 275000, "data": {"chrf": 56.5346}}, {"step": 275000, "data": {"ce_mean_words": 2.2471}}, {"step": 275000, "data": {"bleu_detok": 28.91}}, {"step": 276000, "data": {"epoch": 28}}, {"step": 276000, "data": {"sen": 75737612}}, {"step": 276000, "data": {"cost": 0.43315428}}, {"step": 276000, "data": {"time": 468.1}}, {"step": 276000, "data": {"rate": 549935.16}}, {"step": 276000, "data": {"gnorm": 0.3375}}, {"step": 277000, "data": {"epoch": 28}}, {"step": 277000, "data": {"sen": 87529871}}, {"step": 277000, "data": {"cost": 0.4335297}}, {"step": 277000, "data": {"time": 446.44}}, {"step": 277000, "data": {"rate": 576992.65}}, {"step": 277000, "data": {"gnorm": 0.3603}}, {"step": 278000, "data": {"epoch": 28}}, {"step": 278000, "data": {"sen": 99369099}}, {"step": 278000, "data": {"cost": 0.43320602}}, {"step": 278000, "data": {"time": 447.83}}, {"step": 278000, "data": {"rate": 577485.32}}, {"step": 278000, "data": {"gnorm": 0.3668}}, {"step": 279000, "data": {"epoch": 28}}, {"step": 279000, "data": {"sen": 111208774}}, {"step": 279000, "data": {"cost": 0.43340576}}, {"step": 279000, "data": {"time": 446.88}}, {"step": 279000, "data": {"rate": 576031.99}}, {"step": 279000, "data": {"gnorm": 0.3721}}, {"step": 280000, "data": {"epoch": 29}}, {"step": 280000, "data": {"sen": 5320405}}, {"step": 280000, "data": {"cost": 0.43155792}}, {"step": 280000, "data": {"time": 472.77}}, {"step": 280000, "data": {"rate": 541450.83}}, {"step": 280000, "data": {"gnorm": 0.3848}}, {"step": 280000, "data": {"epoch": 29}}, {"step": 280000, "data": {"perplexity": 9.53538}}, {"step": 280000, "data": {"chrf": 56.5685}}, {"step": 280000, "data": {"ce_mean_words": 2.25501}}, {"step": 280000, "data": {"bleu_detok": 29.0928}}, {"step": 281000, "data": {"epoch": 29}}, {"step": 281000, "data": {"sen": 17018921}}, {"step": 281000, "data": {"cost": 0.43104631}}, {"step": 281000, "data": {"time": 471.84}}, {"step": 281000, "data": {"rate": 545314.94}}, {"step": 281000, "data": {"gnorm": 0.3787}}, {"step": 282000, "data": {"epoch": 29}}, {"step": 282000, "data": {"sen": 28826556}}, {"step": 282000, "data": {"cost": 0.43086576}}, {"step": 282000, "data": {"time": 446.84}}, {"step": 282000, "data": {"rate": 577821.66}}, {"step": 282000, "data": {"gnorm": 0.3503}}, {"step": 283000, "data": {"epoch": 29}}, {"step": 283000, "data": {"sen": 40676243}}, {"step": 283000, "data": {"cost": 0.43109739}}, {"step": 283000, "data": {"time": 448.51}}, {"step": 283000, "data": {"rate": 577169.36}}, {"step": 283000, "data": {"gnorm": 0.3529}}, {"step": 284000, "data": {"epoch": 29}}, {"step": 284000, "data": {"sen": 52398047}}, {"step": 284000, "data": {"cost": 0.43122756}}, {"step": 284000, "data": {"time": 445.18}}, {"step": 284000, "data": {"rate": 576531.72}}, {"step": 284000, "data": {"gnorm": 0.3502}}, {"step": 285000, "data": {"epoch": 29}}, {"step": 285000, "data": {"sen": 64168999}}, {"step": 285000, "data": {"cost": 0.43178615}}, {"step": 285000, "data": {"time": 446.8}}, {"step": 285000, "data": {"rate": 575987.76}}, {"step": 285000, "data": {"gnorm": 0.3642}}, {"step": 285000, "data": {"epoch": 29}}, {"step": 285000, "data": {"perplexity": 9.50138}}, {"step": 285000, "data": {"chrf": 56.5379}}, {"step": 285000, "data": {"ce_mean_words": 2.25144}}, {"step": 285000, "data": {"bleu_detok": 29.1774}}, {"step": 286000, "data": {"epoch": 29}}, {"step": 286000, "data": {"sen": 76046918}}, {"step": 286000, "data": {"cost": 0.43129116}}, {"step": 286000, "data": {"time": 475.3}}, {"step": 286000, "data": {"rate": 546390.35}}, {"step": 286000, "data": {"gnorm": 0.3743}}, {"step": 287000, "data": {"epoch": 29}}, {"step": 287000, "data": {"sen": 87867837}}, {"step": 287000, "data": {"cost": 0.43163234}}, {"step": 287000, "data": {"time": 447.05}}, {"step": 287000, "data": {"rate": 575955.96}}, {"step": 287000, "data": {"gnorm": 0.3778}}, {"step": 288000, "data": {"epoch": 29}}, {"step": 288000, "data": {"sen": 99680043}}, {"step": 288000, "data": {"cost": 0.43207401}}, {"step": 288000, "data": {"time": 447.17}}, {"step": 288000, "data": {"rate": 575954.22}}, {"step": 288000, "data": {"gnorm": 0.3831}}, {"step": 289000, "data": {"epoch": 29}}, {"step": 289000, "data": {"sen": 111495571}}, {"step": 289000, "data": {"cost": 0.431321}}, {"step": 289000, "data": {"time": 447.49}}, {"step": 289000, "data": {"rate": 577890.74}}, {"step": 289000, "data": {"gnorm": 0.3636}}, {"step": 290000, "data": {"epoch": 30}}, {"step": 290000, "data": {"sen": 5639986}}, {"step": 290000, "data": {"cost": 0.43085283}}, {"step": 290000, "data": {"time": 474.65}}, {"step": 290000, "data": {"rate": 539658.35}}, {"step": 290000, "data": {"gnorm": 0.3625}}, {"step": 290000, "data": {"epoch": 30}}, {"step": 290000, "data": {"perplexity": 9.16953}}, {"step": 290000, "data": {"chrf": 56.0941}}, {"step": 290000, "data": {"ce_mean_words": 2.21589}}, {"step": 290000, "data": {"bleu_detok": 28.723}}, {"step": 291000, "data": {"epoch": 30}}, {"step": 291000, "data": {"sen": 17413967}}, {"step": 291000, "data": {"cost": 0.42911133}}, {"step": 291000, "data": {"time": 470.8}}, {"step": 291000, "data": {"rate": 547544.84}}, {"step": 291000, "data": {"gnorm": 0.3706}}, {"step": 292000, "data": {"epoch": 30}}, {"step": 292000, "data": {"sen": 29212161}}, {"step": 292000, "data": {"cost": 0.42959651}}, {"step": 292000, "data": {"time": 447.19}}, {"step": 292000, "data": {"rate": 577917.74}}, {"step": 292000, "data": {"gnorm": 0.3632}}, {"step": 293000, "data": {"epoch": 30}}, {"step": 293000, "data": {"sen": 41041580}}, {"step": 293000, "data": {"cost": 0.43033442}}, {"step": 293000, "data": {"time": 446.7}}, {"step": 293000, "data": {"rate": 577493.83}}, {"step": 293000, "data": {"gnorm": 0.482}}, {"step": 294000, "data": {"epoch": 30}}, {"step": 294000, "data": {"sen": 52810914}}, {"step": 294000, "data": {"cost": 0.43031818}}, {"step": 294000, "data": {"time": 447.13}}, {"step": 294000, "data": {"rate": 576876.83}}, {"step": 294000, "data": {"gnorm": 0.3522}}, {"step": 295000, "data": {"epoch": 30}}, {"step": 295000, "data": {"sen": 64618578}}, {"step": 295000, "data": {"cost": 0.43026277}}, {"step": 295000, "data": {"time": 446.71}}, {"step": 295000, "data": {"rate": 575671.21}}, {"step": 295000, "data": {"gnorm": 0.3904}}, {"step": 295000, "data": {"epoch": 30}}, {"step": 295000, "data": {"perplexity": 9.01395}}, {"step": 295000, "data": {"chrf": 56.3707}}, {"step": 295000, "data": {"ce_mean_words": 2.19877}}, {"step": 295000, "data": {"bleu_detok": 29.0869}}, {"step": 296000, "data": {"epoch": 30}}, {"step": 296000, "data": {"sen": 76438646}}, {"step": 296000, "data": {"cost": 0.43032601}}, {"step": 296000, "data": {"time": 469.71}}, {"step": 296000, "data": {"rate": 549699.02}}, {"step": 296000, "data": {"gnorm": 0.3679}}, {"step": 297000, "data": {"epoch": 30}}, {"step": 297000, "data": {"sen": 88190458}}, {"step": 297000, "data": {"cost": 0.43040115}}, {"step": 297000, "data": {"time": 445.36}}, {"step": 297000, "data": {"rate": 577917.33}}, {"step": 297000, "data": {"gnorm": 0.3568}}, {"step": 298000, "data": {"epoch": 30}}, {"step": 298000, "data": {"sen": 99914767}}, {"step": 298000, "data": {"cost": 0.43061516}}, {"step": 298000, "data": {"time": 444.6}}, {"step": 298000, "data": {"rate": 576013.51}}, {"step": 298000, "data": {"gnorm": 0.3531}}, {"step": 299000, "data": {"epoch": 30}}, {"step": 299000, "data": {"sen": 111657624}}, {"step": 299000, "data": {"cost": 0.43104616}}, {"step": 299000, "data": {"time": 446.54}}, {"step": 299000, "data": {"rate": 577072.31}}, {"step": 299000, "data": {"gnorm": 0.3763}}, {"step": 300000, "data": {"epoch": 31}}, {"step": 300000, "data": {"sen": 5864819}}, {"step": 300000, "data": {"cost": 0.4288303}}, {"step": 300000, "data": {"time": 474.14}}, {"step": 300000, "data": {"rate": 543258.19}}, {"step": 300000, "data": {"gnorm": 0.372}}, {"step": 300000, "data": {"epoch": 31}}, {"step": 300000, "data": {"perplexity": 9.31968}}, {"step": 300000, "data": {"chrf": 56.4823}}, {"step": 300000, "data": {"ce_mean_words": 2.23213}}, {"step": 300000, "data": {"bleu_detok": 29.092}}, {"step": 301000, "data": {"epoch": 31}}, {"step": 301000, "data": {"sen": 17600634}}, {"step": 301000, "data": {"cost": 0.42809597}}, {"step": 301000, "data": {"time": 466.03}}, {"step": 301000, "data": {"rate": 548922.69}}, {"step": 301000, "data": {"gnorm": 0.3723}}, {"step": 302000, "data": {"epoch": 31}}, {"step": 302000, "data": {"sen": 29359476}}, {"step": 302000, "data": {"cost": 0.42879906}}, {"step": 302000, "data": {"time": 447.34}}, {"step": 302000, "data": {"rate": 578324.23}}, {"step": 302000, "data": {"gnorm": 0.3757}}, {"step": 303000, "data": {"epoch": 31}}, {"step": 303000, "data": {"sen": 41165195}}, {"step": 303000, "data": {"cost": 0.42915285}}, {"step": 303000, "data": {"time": 445.35}}, {"step": 303000, "data": {"rate": 576495.29}}, {"step": 303000, "data": {"gnorm": 0.3719}}, {"step": 304000, "data": {"epoch": 31}}, {"step": 304000, "data": {"sen": 52980572}}, {"step": 304000, "data": {"cost": 0.42915481}}, {"step": 304000, "data": {"time": 447.78}}, {"step": 304000, "data": {"rate": 576994.4}}, {"step": 304000, "data": {"gnorm": 0.3637}}, {"step": 305000, "data": {"epoch": 31}}, {"step": 305000, "data": {"sen": 64711381}}, {"step": 305000, "data": {"cost": 0.42935294}}, {"step": 305000, "data": {"time": 446.05}}, {"step": 305000, "data": {"rate": 574329.67}}, {"step": 305000, "data": {"gnorm": 0.3596}}, {"step": 305000, "data": {"epoch": 31}}, {"step": 305000, "data": {"perplexity": 9.13743}}, {"step": 305000, "data": {"chrf": 56.6732}}, {"step": 305000, "data": {"ce_mean_words": 2.21238}}, {"step": 305000, "data": {"bleu_detok": 29.4477}}, {"step": 306000, "data": {"epoch": 31}}, {"step": 306000, "data": {"sen": 76582390}}, {"step": 306000, "data": {"cost": 0.42957613}}, {"step": 306000, "data": {"time": 469.71}}, {"step": 306000, "data": {"rate": 551135.61}}, {"step": 306000, "data": {"gnorm": 0.3766}}, {"step": 307000, "data": {"epoch": 31}}, {"step": 307000, "data": {"sen": 88348540}}, {"step": 307000, "data": {"cost": 0.42923048}}, {"step": 307000, "data": {"time": 446.81}}, {"step": 307000, "data": {"rate": 576784.4}}, {"step": 307000, "data": {"gnorm": 0.3789}}, {"step": 308000, "data": {"epoch": 31}}, {"step": 308000, "data": {"sen": 100139188}}, {"step": 308000, "data": {"cost": 0.42923689}}, {"step": 308000, "data": {"time": 447.4}}, {"step": 308000, "data": {"rate": 576820.31}}, {"step": 308000, "data": {"gnorm": 0.3615}}, {"step": 309000, "data": {"epoch": 31}}, {"step": 309000, "data": {"sen": 111972400}}, {"step": 309000, "data": {"cost": 0.42955807}}, {"step": 309000, "data": {"time": 447.09}}, {"step": 309000, "data": {"rate": 577301.37}}, {"step": 309000, "data": {"gnorm": 0.3781}}, {"step": 310000, "data": {"epoch": 32}}, {"step": 310000, "data": {"sen": 6196974}}, {"step": 310000, "data": {"cost": 0.4276827}}, {"step": 310000, "data": {"time": 475.65}}, {"step": 310000, "data": {"rate": 541005.82}}, {"step": 310000, "data": {"gnorm": 0.396}}, {"step": 310000, "data": {"epoch": 32}}, {"step": 310000, "data": {"perplexity": 9.38267}}, {"step": 310000, "data": {"chrf": 56.5889}}, {"step": 310000, "data": {"ce_mean_words": 2.23886}}, {"step": 310000, "data": {"bleu_detok": 29.2612}}, {"step": 311000, "data": {"epoch": 32}}, {"step": 311000, "data": {"sen": 17894088}}, {"step": 311000, "data": {"cost": 0.42720792}}, {"step": 311000, "data": {"time": 473.11}}, {"step": 311000, "data": {"rate": 544137.48}}, {"step": 311000, "data": {"gnorm": 0.3563}}, {"step": 312000, "data": {"epoch": 32}}, {"step": 312000, "data": {"sen": 29728573}}, {"step": 312000, "data": {"cost": 0.42738834}}, {"step": 312000, "data": {"time": 448.56}}, {"step": 312000, "data": {"rate": 576353.69}}, {"step": 312000, "data": {"gnorm": 0.3476}}, {"step": 313000, "data": {"epoch": 32}}, {"step": 313000, "data": {"sen": 41617989}}, {"step": 313000, "data": {"cost": 0.42749053}}, {"step": 313000, "data": {"time": 448.37}}, {"step": 313000, "data": {"rate": 577892.45}}, {"step": 313000, "data": {"gnorm": 0.3611}}, {"step": 314000, "data": {"epoch": 32}}, {"step": 314000, "data": {"sen": 53354358}}, {"step": 314000, "data": {"cost": 0.42760217}}, {"step": 314000, "data": {"time": 444.28}}, {"step": 314000, "data": {"rate": 577997.65}}, {"step": 314000, "data": {"gnorm": 0.3784}}, {"step": 315000, "data": {"epoch": 32}}, {"step": 315000, "data": {"sen": 65135680}}, {"step": 315000, "data": {"cost": 0.42803776}}, {"step": 315000, "data": {"time": 445.78}}, {"step": 315000, "data": {"rate": 577339.89}}, {"step": 315000, "data": {"gnorm": 0.3776}}, {"step": 315000, "data": {"epoch": 32}}, {"step": 315000, "data": {"perplexity": 9.26654}}, {"step": 315000, "data": {"chrf": 56.5164}}, {"step": 315000, "data": {"ce_mean_words": 2.22641}}, {"step": 315000, "data": {"bleu_detok": 29.255}}, {"step": 316000, "data": {"epoch": 32}}, {"step": 316000, "data": {"sen": 76973315}}, {"step": 316000, "data": {"cost": 0.4280864}}, {"step": 316000, "data": {"time": 475.23}}, {"step": 316000, "data": {"rate": 544422.49}}, {"step": 316000, "data": {"gnorm": 0.367}}, {"step": 317000, "data": {"epoch": 32}}, {"step": 317000, "data": {"sen": 88776638}}, {"step": 317000, "data": {"cost": 0.42793134}}, {"step": 317000, "data": {"time": 445.62}}, {"step": 317000, "data": {"rate": 577957.67}}, {"step": 317000, "data": {"gnorm": 0.3693}}, {"step": 318000, "data": {"epoch": 32}}, {"step": 318000, "data": {"sen": 100591782}}, {"step": 318000, "data": {"cost": 0.42817906}}, {"step": 318000, "data": {"time": 446.11}}, {"step": 318000, "data": {"rate": 577823.14}}, {"step": 318000, "data": {"gnorm": 0.3854}}, {"step": 319000, "data": {"epoch": 32}}, {"step": 319000, "data": {"sen": 112350138}}, {"step": 319000, "data": {"cost": 0.42830694}}, {"step": 319000, "data": {"time": 446.58}}, {"step": 319000, "data": {"rate": 575196.29}}, {"step": 319000, "data": {"gnorm": 0.3904}}, {"step": 320000, "data": {"epoch": 33}}, {"step": 320000, "data": {"sen": 6513271}}, {"step": 320000, "data": {"cost": 0.42616892}}, {"step": 320000, "data": {"time": 474.48}}, {"step": 320000, "data": {"rate": 542619.65}}, {"step": 320000, "data": {"gnorm": 0.3726}}, {"step": 320000, "data": {"epoch": 33}}, {"step": 320000, "data": {"perplexity": 9.27182}}, {"step": 320000, "data": {"chrf": 56.5815}}, {"step": 320000, "data": {"ce_mean_words": 2.22698}}, {"step": 320000, "data": {"bleu_detok": 29.2738}}, {"step": 321000, "data": {"epoch": 33}}, {"step": 321000, "data": {"sen": 18334107}}, {"step": 321000, "data": {"cost": 0.42632654}}, {"step": 321000, "data": {"time": 472.61}}, {"step": 321000, "data": {"rate": 546867.15}}, {"step": 321000, "data": {"gnorm": 0.371}}, {"step": 322000, "data": {"epoch": 33}}, {"step": 322000, "data": {"sen": 30112839}}, {"step": 322000, "data": {"cost": 0.42652088}}, {"step": 322000, "data": {"time": 446.72}}, {"step": 322000, "data": {"rate": 577362.66}}, {"step": 322000, "data": {"gnorm": 0.3773}}, {"step": 323000, "data": {"epoch": 33}}, {"step": 323000, "data": {"sen": 41899375}}, {"step": 323000, "data": {"cost": 0.42698514}}, {"step": 323000, "data": {"time": 447.6}}, {"step": 323000, "data": {"rate": 575460.9}}, {"step": 323000, "data": {"gnorm": 0.369}}, {"step": 324000, "data": {"epoch": 33}}, {"step": 324000, "data": {"sen": 53644087}}, {"step": 324000, "data": {"cost": 0.42709965}}, {"step": 324000, "data": {"time": 446.85}}, {"step": 324000, "data": {"rate": 574453.29}}, {"step": 324000, "data": {"gnorm": 0.3935}}, {"step": 325000, "data": {"epoch": 33}}, {"step": 325000, "data": {"sen": 65392024}}, {"step": 325000, "data": {"cost": 0.4271175}}, {"step": 325000, "data": {"time": 446.4}}, {"step": 325000, "data": {"rate": 577477.74}}, {"step": 325000, "data": {"gnorm": 0.3558}}, {"step": 325000, "data": {"epoch": 33}}, {"step": 325000, "data": {"perplexity": 9.20456}}, {"step": 325000, "data": {"chrf": 56.478}}, {"step": 325000, "data": {"ce_mean_words": 2.2197}}, {"step": 325000, "data": {"bleu_detok": 29.1451}}, {"step": 326000, "data": {"epoch": 33}}, {"step": 326000, "data": {"sen": 77264815}}, {"step": 326000, "data": {"cost": 0.42709443}}, {"step": 326000, "data": {"time": 470.94}}, {"step": 326000, "data": {"rate": 548365.73}}, {"step": 326000, "data": {"gnorm": 0.386}}, {"step": 327000, "data": {"epoch": 33}}, {"step": 327000, "data": {"sen": 88993675}}, {"step": 327000, "data": {"cost": 0.42676288}}, {"step": 327000, "data": {"time": 444.08}}, {"step": 327000, "data": {"rate": 577256.96}}, {"step": 327000, "data": {"gnorm": 0.3719}}, {"step": 328000, "data": {"epoch": 33}}, {"step": 328000, "data": {"sen": 100783060}}, {"step": 328000, "data": {"cost": 0.42708147}}, {"step": 328000, "data": {"time": 446.51}}, {"step": 328000, "data": {"rate": 577129.01}}, {"step": 328000, "data": {"gnorm": 0.3756}}, {"step": 329000, "data": {"epoch": 33}}, {"step": 329000, "data": {"sen": 112623519}}, {"step": 329000, "data": {"cost": 0.42670077}}, {"step": 329000, "data": {"time": 448.53}}, {"step": 329000, "data": {"rate": 576014.27}}, {"step": 329000, "data": {"gnorm": 0.3722}}, {"step": 330000, "data": {"epoch": 34}}, {"step": 330000, "data": {"sen": 6741071}}, {"step": 330000, "data": {"cost": 0.42518342}}, {"step": 330000, "data": {"time": 474.28}}, {"step": 330000, "data": {"rate": 542425.03}}, {"step": 330000, "data": {"gnorm": 0.3702}}, {"step": 330000, "data": {"epoch": 34}}, {"step": 330000, "data": {"perplexity": 9.60103}}, {"step": 330000, "data": {"chrf": 56.6786}}, {"step": 330000, "data": {"ce_mean_words": 2.26187}}, {"step": 330000, "data": {"bleu_detok": 29.2372}}, {"step": 331000, "data": {"epoch": 34}}, {"step": 331000, "data": {"sen": 18482803}}, {"step": 331000, "data": {"cost": 0.42507765}}, {"step": 331000, "data": {"time": 467.55}}, {"step": 331000, "data": {"rate": 547183.86}}, {"step": 331000, "data": {"gnorm": 0.3715}}, {"step": 332000, "data": {"epoch": 34}}, {"step": 332000, "data": {"sen": 30256788}}, {"step": 332000, "data": {"cost": 0.42525265}}, {"step": 332000, "data": {"time": 446.13}}, {"step": 332000, "data": {"rate": 577962.04}}, {"step": 332000, "data": {"gnorm": 0.3733}}, {"step": 333000, "data": {"epoch": 34}}, {"step": 333000, "data": {"sen": 42073350}}, {"step": 333000, "data": {"cost": 0.4257713}}, {"step": 333000, "data": {"time": 446.39}}, {"step": 333000, "data": {"rate": 577583.5}}, {"step": 333000, "data": {"gnorm": 0.368}}, {"step": 334000, "data": {"epoch": 34}}, {"step": 334000, "data": {"sen": 53898682}}, {"step": 334000, "data": {"cost": 0.42556387}}, {"step": 334000, "data": {"time": 447.04}}, {"step": 334000, "data": {"rate": 576291.86}}, {"step": 334000, "data": {"gnorm": 0.389}}, {"step": 335000, "data": {"epoch": 34}}, {"step": 335000, "data": {"sen": 65624079}}, {"step": 335000, "data": {"cost": 0.42552322}}, {"step": 335000, "data": {"time": 446.0}}, {"step": 335000, "data": {"rate": 575282.46}}, {"step": 335000, "data": {"gnorm": 0.3747}}, {"step": 335000, "data": {"epoch": 34}}, {"step": 335000, "data": {"perplexity": 9.23171}}, {"step": 335000, "data": {"chrf": 56.5903}}, {"step": 335000, "data": {"ce_mean_words": 2.22264}}, {"step": 335000, "data": {"bleu_detok": 29.3104}}, {"step": 336000, "data": {"epoch": 34}}, {"step": 336000, "data": {"sen": 77444474}}, {"step": 336000, "data": {"cost": 0.42606494}}, {"step": 336000, "data": {"time": 469.25}}, {"step": 336000, "data": {"rate": 550088.54}}, {"step": 336000, "data": {"gnorm": 0.3598}}, {"step": 337000, "data": {"epoch": 34}}, {"step": 337000, "data": {"sen": 89170016}}, {"step": 337000, "data": {"cost": 0.42636302}}, {"step": 337000, "data": {"time": 444.82}}, {"step": 337000, "data": {"rate": 577119.32}}, {"step": 337000, "data": {"gnorm": 0.3902}}, {"step": 338000, "data": {"epoch": 34}}, {"step": 338000, "data": {"sen": 100962165}}, {"step": 338000, "data": {"cost": 0.42625621}}, {"step": 338000, "data": {"time": 447.75}}, {"step": 338000, "data": {"rate": 575164.38}}, {"step": 338000, "data": {"gnorm": 0.3751}}, {"step": 339000, "data": {"epoch": 34}}, {"step": 339000, "data": {"sen": 112777429}}, {"step": 339000, "data": {"cost": 0.42610222}}, {"step": 339000, "data": {"time": 447.35}}, {"step": 339000, "data": {"rate": 577276.01}}, {"step": 339000, "data": {"gnorm": 0.3912}}, {"step": 340000, "data": {"epoch": 35}}, {"step": 340000, "data": {"sen": 6818269}}, {"step": 340000, "data": {"cost": 0.42467371}}, {"step": 340000, "data": {"time": 473.85}}, {"step": 340000, "data": {"rate": 539039.25}}, {"step": 340000, "data": {"gnorm": 0.367}}, {"step": 340000, "data": {"epoch": 35}}, {"step": 340000, "data": {"perplexity": 9.23632}}, {"step": 340000, "data": {"chrf": 56.6415}}, {"step": 340000, "data": {"ce_mean_words": 2.22314}}, {"step": 340000, "data": {"bleu_detok": 29.3083}}, {"step": 341000, "data": {"epoch": 35}}, {"step": 341000, "data": {"sen": 18612510}}, {"step": 341000, "data": {"cost": 0.42355597}}, {"step": 341000, "data": {"time": 470.46}}, {"step": 341000, "data": {"rate": 548459.31}}, {"step": 341000, "data": {"gnorm": 0.3626}}, {"step": 342000, "data": {"epoch": 35}}, {"step": 342000, "data": {"sen": 30497808}}, {"step": 342000, "data": {"cost": 0.42442226}}, {"step": 342000, "data": {"time": 447.76}}, {"step": 342000, "data": {"rate": 576816.45}}, {"step": 342000, "data": {"gnorm": 0.3768}}, {"step": 343000, "data": {"epoch": 35}}, {"step": 343000, "data": {"sen": 42271140}}, {"step": 343000, "data": {"cost": 0.42478597}}, {"step": 343000, "data": {"time": 446.55}}, {"step": 343000, "data": {"rate": 575701.73}}, {"step": 343000, "data": {"gnorm": 0.3778}}, {"step": 344000, "data": {"epoch": 35}}, {"step": 344000, "data": {"sen": 54039446}}, {"step": 344000, "data": {"cost": 0.42444637}}, {"step": 344000, "data": {"time": 447.6}}, {"step": 344000, "data": {"rate": 578046.16}}, {"step": 344000, "data": {"gnorm": 0.3718}}, {"step": 345000, "data": {"epoch": 35}}, {"step": 345000, "data": {"sen": 65913929}}, {"step": 345000, "data": {"cost": 0.4246963}}, {"step": 345000, "data": {"time": 448.32}}, {"step": 345000, "data": {"rate": 577001.73}}, {"step": 345000, "data": {"gnorm": 0.3387}}, {"step": 345000, "data": {"epoch": 35}}, {"step": 345000, "data": {"perplexity": 9.28554}}, {"step": 345000, "data": {"chrf": 56.653}}, {"step": 345000, "data": {"ce_mean_words": 2.22846}}, {"step": 345000, "data": {"bleu_detok": 29.313}}, {"step": 346000, "data": {"epoch": 35}}, {"step": 346000, "data": {"sen": 77642610}}, {"step": 346000, "data": {"cost": 0.4251903}}, {"step": 346000, "data": {"time": 468.93}}, {"step": 346000, "data": {"rate": 548974.63}}, {"step": 346000, "data": {"gnorm": 0.3779}}, {"step": 347000, "data": {"epoch": 35}}, {"step": 347000, "data": {"sen": 89457379}}, {"step": 347000, "data": {"cost": 0.42521256}}, {"step": 347000, "data": {"time": 445.85}}, {"step": 347000, "data": {"rate": 576707.05}}, {"step": 347000, "data": {"gnorm": 0.3746}}, {"step": 348000, "data": {"epoch": 35}}, {"step": 348000, "data": {"sen": 101291418}}, {"step": 348000, "data": {"cost": 0.42481172}}, {"step": 348000, "data": {"time": 446.52}}, {"step": 348000, "data": {"rate": 576888.21}}, {"step": 348000, "data": {"gnorm": 0.385}}, {"step": 349000, "data": {"epoch": 35}}, {"step": 349000, "data": {"sen": 113041544}}, {"step": 349000, "data": {"cost": 0.42521274}}, {"step": 349000, "data": {"time": 444.88}}, {"step": 349000, "data": {"rate": 580165.28}}, {"step": 349000, "data": {"gnorm": 0.3889}}, {"step": 350000, "data": {"epoch": 36}}, {"step": 350000, "data": {"sen": 7126278}}, {"step": 350000, "data": {"cost": 0.42340738}}, {"step": 350000, "data": {"time": 472.42}}, {"step": 350000, "data": {"rate": 540093.44}}, {"step": 350000, "data": {"gnorm": 0.3567}}, {"step": 350000, "data": {"epoch": 36}}, {"step": 350000, "data": {"perplexity": 9.29532}}, {"step": 350000, "data": {"chrf": 56.5983}}, {"step": 350000, "data": {"ce_mean_words": 2.22951}}, {"step": 350000, "data": {"bleu_detok": 29.3574}}, {"step": 351000, "data": {"epoch": 36}}, {"step": 351000, "data": {"sen": 18841942}}, {"step": 351000, "data": {"cost": 0.42268735}}, {"step": 351000, "data": {"time": 471.36}}, {"step": 351000, "data": {"rate": 544694.31}}, {"step": 351000, "data": {"gnorm": 0.3772}}, {"step": 352000, "data": {"epoch": 36}}, {"step": 352000, "data": {"sen": 30694707}}, {"step": 352000, "data": {"cost": 0.42332387}}, {"step": 352000, "data": {"time": 447.26}}, {"step": 352000, "data": {"rate": 575120.19}}, {"step": 352000, "data": {"gnorm": 0.3621}}, {"step": 353000, "data": {"epoch": 36}}, {"step": 353000, "data": {"sen": 42498993}}, {"step": 353000, "data": {"cost": 0.4235788}}, {"step": 353000, "data": {"time": 447.51}}, {"step": 353000, "data": {"rate": 578966.59}}, {"step": 353000, "data": {"gnorm": 0.359}}, {"step": 354000, "data": {"epoch": 36}}, {"step": 354000, "data": {"sen": 54303926}}, {"step": 354000, "data": {"cost": 0.42345852}}, {"step": 354000, "data": {"time": 447.31}}, {"step": 354000, "data": {"rate": 578731.39}}, {"step": 354000, "data": {"gnorm": 0.3423}}, {"step": 355000, "data": {"epoch": 36}}, {"step": 355000, "data": {"sen": 66105017}}, {"step": 355000, "data": {"cost": 0.42404088}}, {"step": 355000, "data": {"time": 447.8}}, {"step": 355000, "data": {"rate": 575797.44}}, {"step": 355000, "data": {"gnorm": 0.3673}}, {"step": 355000, "data": {"epoch": 36}}, {"step": 355000, "data": {"perplexity": 9.27531}}, {"step": 355000, "data": {"chrf": 56.7085}}, {"step": 355000, "data": {"ce_mean_words": 2.22736}}, {"step": 355000, "data": {"bleu_detok": 29.3785}}, {"step": 356000, "data": {"epoch": 36}}, {"step": 356000, "data": {"sen": 77838995}}, {"step": 356000, "data": {"cost": 0.42379859}}, {"step": 356000, "data": {"time": 470.91}}, {"step": 356000, "data": {"rate": 541659.35}}, {"step": 356000, "data": {"gnorm": 0.3661}}, {"step": 357000, "data": {"epoch": 36}}, {"step": 357000, "data": {"sen": 89639610}}, {"step": 357000, "data": {"cost": 0.42431182}}, {"step": 357000, "data": {"time": 449.29}}, {"step": 357000, "data": {"rate": 576665.43}}, {"step": 357000, "data": {"gnorm": 0.3466}}, {"step": 358000, "data": {"epoch": 36}}, {"step": 358000, "data": {"sen": 101466763}}, {"step": 358000, "data": {"cost": 0.42413855}}, {"step": 358000, "data": {"time": 447.11}}, {"step": 358000, "data": {"rate": 576333.92}}, {"step": 358000, "data": {"gnorm": 0.3673}}, {"step": 359000, "data": {"epoch": 36}}, {"step": 359000, "data": {"sen": 113274974}}, {"step": 359000, "data": {"cost": 0.42411876}}, {"step": 359000, "data": {"time": 447.41}}, {"step": 359000, "data": {"rate": 576601.08}}, {"step": 359000, "data": {"gnorm": 0.3722}}, {"step": 360000, "data": {"epoch": 37}}, {"step": 360000, "data": {"sen": 7363031}}, {"step": 360000, "data": {"cost": 0.42273402}}, {"step": 360000, "data": {"time": 472.9}}, {"step": 360000, "data": {"rate": 540706.34}}, {"step": 360000, "data": {"gnorm": 0.3654}}, {"step": 360000, "data": {"epoch": 37}}, {"step": 360000, "data": {"perplexity": 9.36541}}, {"step": 360000, "data": {"chrf": 56.5368}}, {"step": 360000, "data": {"ce_mean_words": 2.23702}}, {"step": 360000, "data": {"bleu_detok": 29.2741}}, {"step": 361000, "data": {"epoch": 37}}, {"step": 361000, "data": {"sen": 19100723}}, {"step": 361000, "data": {"cost": 0.42225498}}, {"step": 361000, "data": {"time": 470.19}}, {"step": 361000, "data": {"rate": 547825.99}}, {"step": 361000, "data": {"gnorm": 0.3723}}, {"step": 362000, "data": {"epoch": 37}}, {"step": 362000, "data": {"sen": 30951129}}, {"step": 362000, "data": {"cost": 0.42232558}}, {"step": 362000, "data": {"time": 446.66}}, {"step": 362000, "data": {"rate": 577273.68}}, {"step": 362000, "data": {"gnorm": 0.3764}}, {"step": 363000, "data": {"epoch": 37}}, {"step": 363000, "data": {"sen": 42724684}}, {"step": 363000, "data": {"cost": 0.42280048}}, {"step": 363000, "data": {"time": 446.74}}, {"step": 363000, "data": {"rate": 576703.73}}, {"step": 363000, "data": {"gnorm": 0.3734}}, {"step": 364000, "data": {"epoch": 37}}, {"step": 364000, "data": {"sen": 54661299}}, {"step": 364000, "data": {"cost": 0.42276621}}, {"step": 364000, "data": {"time": 451.17}}, {"step": 364000, "data": {"rate": 578131.15}}, {"step": 364000, "data": {"gnorm": 0.3645}}, {"step": 365000, "data": {"epoch": 37}}, {"step": 365000, "data": {"sen": 66439137}}, {"step": 365000, "data": {"cost": 0.42285624}}, {"step": 365000, "data": {"time": 447.11}}, {"step": 365000, "data": {"rate": 576636.14}}, {"step": 365000, "data": {"gnorm": 0.3809}}, {"step": 365000, "data": {"epoch": 37}}, {"step": 365000, "data": {"perplexity": 9.2531}}, {"step": 365000, "data": {"chrf": 56.6618}}, {"step": 365000, "data": {"ce_mean_words": 2.22496}}, {"step": 365000, "data": {"bleu_detok": 29.3497}}, {"step": 366000, "data": {"epoch": 37}}, {"step": 366000, "data": {"sen": 78211870}}, {"step": 366000, "data": {"cost": 0.42318329}}, {"step": 366000, "data": {"time": 468.98}}, {"step": 366000, "data": {"rate": 545490.11}}, {"step": 366000, "data": {"gnorm": 0.3702}}, {"step": 367000, "data": {"epoch": 37}}, {"step": 367000, "data": {"sen": 89984536}}, {"step": 367000, "data": {"cost": 0.42337519}}, {"step": 367000, "data": {"time": 447.03}}, {"step": 367000, "data": {"rate": 576565.54}}, {"step": 367000, "data": {"gnorm": 0.357}}, {"step": 368000, "data": {"epoch": 37}}, {"step": 368000, "data": {"sen": 101665619}}, {"step": 368000, "data": {"cost": 0.42365173}}, {"step": 368000, "data": {"time": 444.91}}, {"step": 368000, "data": {"rate": 576330.21}}, {"step": 368000, "data": {"gnorm": 0.3686}}, {"step": 369000, "data": {"epoch": 37}}, {"step": 369000, "data": {"sen": 113544568}}, {"step": 369000, "data": {"cost": 0.42301959}}, {"step": 369000, "data": {"time": 448.82}}, {"step": 369000, "data": {"rate": 577190.15}}, {"step": 369000, "data": {"gnorm": 0.3601}}, {"step": 370000, "data": {"epoch": 38}}, {"step": 370000, "data": {"sen": 7642815}}, {"step": 370000, "data": {"cost": 0.42135236}}, {"step": 370000, "data": {"time": 471.68}}, {"step": 370000, "data": {"rate": 539957.95}}, {"step": 370000, "data": {"gnorm": 0.3866}}, {"step": 370000, "data": {"epoch": 38}}, {"step": 370000, "data": {"perplexity": 9.1401}}, {"step": 370000, "data": {"chrf": 56.4225}}, {"step": 370000, "data": {"ce_mean_words": 2.21267}}, {"step": 370000, "data": {"bleu_detok": 29.1088}}, {"step": 371000, "data": {"epoch": 38}}, {"step": 371000, "data": {"sen": 19333079}}, {"step": 371000, "data": {"cost": 0.42108682}}, {"step": 371000, "data": {"time": 466.3}}, {"step": 371000, "data": {"rate": 550930.3}}, {"step": 371000, "data": {"gnorm": 0.363}}, {"step": 372000, "data": {"epoch": 38}}, {"step": 372000, "data": {"sen": 31276471}}, {"step": 372000, "data": {"cost": 0.42146933}}, {"step": 372000, "data": {"time": 450.23}}, {"step": 372000, "data": {"rate": 577874.43}}, {"step": 372000, "data": {"gnorm": 0.3521}}, {"step": 373000, "data": {"epoch": 38}}, {"step": 373000, "data": {"sen": 43019473}}, {"step": 373000, "data": {"cost": 0.42136693}}, {"step": 373000, "data": {"time": 445.67}}, {"step": 373000, "data": {"rate": 577292.37}}, {"step": 373000, "data": {"gnorm": 0.3614}}, {"step": 374000, "data": {"epoch": 38}}, {"step": 374000, "data": {"sen": 54924730}}, {"step": 374000, "data": {"cost": 0.42143333}}, {"step": 374000, "data": {"time": 449.69}}, {"step": 374000, "data": {"rate": 577615.22}}, {"step": 374000, "data": {"gnorm": 0.3539}}, {"step": 375000, "data": {"epoch": 38}}, {"step": 375000, "data": {"sen": 66698217}}, {"step": 375000, "data": {"cost": 0.42232859}}, {"step": 375000, "data": {"time": 447.58}}, {"step": 375000, "data": {"rate": 575903.15}}, {"step": 375000, "data": {"gnorm": 0.3784}}, {"step": 375000, "data": {"epoch": 38}}, {"step": 375000, "data": {"perplexity": 9.28391}}, {"step": 375000, "data": {"chrf": 56.5913}}, {"step": 375000, "data": {"ce_mean_words": 2.22828}}, {"step": 375000, "data": {"bleu_detok": 29.2885}}, {"step": 376000, "data": {"epoch": 38}}, {"step": 376000, "data": {"sen": 78484260}}, {"step": 376000, "data": {"cost": 0.42247868}}, {"step": 376000, "data": {"time": 468.21}}, {"step": 376000, "data": {"rate": 549130.04}}, {"step": 376000, "data": {"gnorm": 0.364}}, {"step": 377000, "data": {"epoch": 38}}, {"step": 377000, "data": {"sen": 90329313}}, {"step": 377000, "data": {"cost": 0.4222962}}, {"step": 377000, "data": {"time": 447.37}}, {"step": 377000, "data": {"rate": 576730.53}}, {"step": 377000, "data": {"gnorm": 0.3721}}, {"step": 378000, "data": {"epoch": 38}}, {"step": 378000, "data": {"sen": 101999641}}, {"step": 378000, "data": {"cost": 0.42243907}}, {"step": 378000, "data": {"time": 444.13}}, {"step": 378000, "data": {"rate": 576400.65}}, {"step": 378000, "data": {"gnorm": 0.3794}}, {"step": 379000, "data": {"epoch": 38}}, {"step": 379000, "data": {"sen": 113859870}}, {"step": 379000, "data": {"cost": 0.42228359}}, {"step": 379000, "data": {"time": 448.65}}, {"step": 379000, "data": {"rate": 576610.29}}, {"step": 379000, "data": {"gnorm": 0.3643}}, {"step": 380000, "data": {"epoch": 39}}, {"step": 380000, "data": {"sen": 7943596}}, {"step": 380000, "data": {"cost": 0.42053586}}, {"step": 380000, "data": {"time": 471.71}}, {"step": 380000, "data": {"rate": 540708.54}}, {"step": 380000, "data": {"gnorm": 0.3839}}, {"step": 380000, "data": {"epoch": 39}}, {"step": 380000, "data": {"perplexity": 9.45316}}, {"step": 380000, "data": {"chrf": 56.6336}}, {"step": 380000, "data": {"ce_mean_words": 2.24635}}, {"step": 380000, "data": {"bleu_detok": 29.3747}}, {"step": 381000, "data": {"epoch": 39}}, {"step": 381000, "data": {"sen": 19632957}}, {"step": 381000, "data": {"cost": 0.42063504}}, {"step": 381000, "data": {"time": 466.94}}, {"step": 381000, "data": {"rate": 549123.89}}, {"step": 381000, "data": {"gnorm": 0.3877}}, {"step": 382000, "data": {"epoch": 39}}, {"step": 382000, "data": {"sen": 31422494}}, {"step": 382000, "data": {"cost": 0.42052266}}, {"step": 382000, "data": {"time": 445.1}}, {"step": 382000, "data": {"rate": 578790.72}}, {"step": 382000, "data": {"gnorm": 0.3867}}, {"step": 383000, "data": {"epoch": 39}}, {"step": 383000, "data": {"sen": 43204330}}, {"step": 383000, "data": {"cost": 0.42111155}}, {"step": 383000, "data": {"time": 445.57}}, {"step": 383000, "data": {"rate": 578451.17}}, {"step": 383000, "data": {"gnorm": 0.3734}}, {"step": 384000, "data": {"epoch": 39}}, {"step": 384000, "data": {"sen": 55022546}}, {"step": 384000, "data": {"cost": 0.42119005}}, {"step": 384000, "data": {"time": 448.04}}, {"step": 384000, "data": {"rate": 576408.55}}, {"step": 384000, "data": {"gnorm": 0.372}}, {"step": 385000, "data": {"epoch": 39}}, {"step": 385000, "data": {"sen": 66882088}}, {"step": 385000, "data": {"cost": 0.4215644}}, {"step": 385000, "data": {"time": 444.93}}, {"step": 385000, "data": {"rate": 579661.15}}, {"step": 385000, "data": {"gnorm": 0.3777}}, {"step": 385000, "data": {"epoch": 39}}, {"step": 385000, "data": {"perplexity": 9.28774}}, {"step": 385000, "data": {"chrf": 56.6508}}, {"step": 385000, "data": {"ce_mean_words": 2.22869}}, {"step": 385000, "data": {"bleu_detok": 29.3221}}, {"step": 386000, "data": {"epoch": 39}}, {"step": 386000, "data": {"sen": 78688231}}, {"step": 386000, "data": {"cost": 0.42125267}}, {"step": 386000, "data": {"time": 471.32}}, {"step": 386000, "data": {"rate": 549894.71}}, {"step": 386000, "data": {"gnorm": 0.3434}}, {"step": 387000, "data": {"epoch": 39}}, {"step": 387000, "data": {"sen": 90426852}}, {"step": 387000, "data": {"cost": 0.42211333}}, {"step": 387000, "data": {"time": 443.13}}, {"step": 387000, "data": {"rate": 577464.99}}, {"step": 387000, "data": {"gnorm": 0.3642}}, {"step": 388000, "data": {"epoch": 39}}, {"step": 388000, "data": {"sen": 102254488}}, {"step": 388000, "data": {"cost": 0.42129838}}, {"step": 388000, "data": {"time": 447.5}}, {"step": 388000, "data": {"rate": 577707.17}}, {"step": 388000, "data": {"gnorm": 0.3899}}, {"step": 389000, "data": {"epoch": 39}}, {"step": 389000, "data": {"sen": 114034552}}, {"step": 389000, "data": {"cost": 0.42163926}}, {"step": 389000, "data": {"time": 447.29}}, {"step": 389000, "data": {"rate": 576858.3}}, {"step": 389000, "data": {"gnorm": 0.3731}}, {"step": 390000, "data": {"epoch": 40}}, {"step": 390000, "data": {"sen": 8193723}}, {"step": 390000, "data": {"cost": 0.42002839}}, {"step": 390000, "data": {"time": 475.24}}, {"step": 390000, "data": {"rate": 540988.85}}, {"step": 390000, "data": {"gnorm": 0.3839}}, {"step": 390000, "data": {"epoch": 40}}, {"step": 390000, "data": {"perplexity": 9.31273}}, {"step": 390000, "data": {"chrf": 56.6093}}, {"step": 390000, "data": {"ce_mean_words": 2.23138}}, {"step": 390000, "data": {"bleu_detok": 29.2654}}, {"step": 391000, "data": {"epoch": 40}}, {"step": 391000, "data": {"sen": 19890711}}, {"step": 391000, "data": {"cost": 0.41947886}}, {"step": 391000, "data": {"time": 469.68}}, {"step": 391000, "data": {"rate": 544909.35}}, {"step": 391000, "data": {"gnorm": 0.3715}}, {"step": 392000, "data": {"epoch": 40}}, {"step": 392000, "data": {"sen": 31657413}}, {"step": 392000, "data": {"cost": 0.41992235}}, {"step": 392000, "data": {"time": 445.82}}, {"step": 392000, "data": {"rate": 576603.3}}, {"step": 392000, "data": {"gnorm": 0.3763}}, {"step": 393000, "data": {"epoch": 40}}, {"step": 393000, "data": {"sen": 43449081}}, {"step": 393000, "data": {"cost": 0.41992283}}, {"step": 393000, "data": {"time": 446.84}}, {"step": 393000, "data": {"rate": 577311.63}}, {"step": 393000, "data": {"gnorm": 0.376}}, {"step": 394000, "data": {"epoch": 40}}, {"step": 394000, "data": {"sen": 55250922}}, {"step": 394000, "data": {"cost": 0.42044222}}, {"step": 394000, "data": {"time": 445.68}}, {"step": 394000, "data": {"rate": 577011.86}}, {"step": 394000, "data": {"gnorm": 0.3665}}, {"step": 395000, "data": {"epoch": 40}}, {"step": 395000, "data": {"sen": 67033428}}, {"step": 395000, "data": {"cost": 0.42075121}}, {"step": 395000, "data": {"time": 445.62}}, {"step": 395000, "data": {"rate": 577684.96}}, {"step": 395000, "data": {"gnorm": 0.3803}}, {"step": 395000, "data": {"epoch": 40}}, {"step": 395000, "data": {"perplexity": 9.21047}}, {"step": 395000, "data": {"chrf": 56.5246}}, {"step": 395000, "data": {"ce_mean_words": 2.22034}}, {"step": 395000, "data": {"bleu_detok": 29.2253}}, {"step": 1, "data": {"epoch": 1}}, {"step": 1, "data": {"sen": 22400}}, {"step": 1, "data": {"cost": 0.42945915}}, {"step": 1, "data": {"time": 242.9}}, {"step": 1, "data": {"rate": 1600.9}}, {"step": 1, "data": {"gnorm": 0.3028}}, {"step": 2, "data": {"epoch": 1}}, {"step": 2, "data": {"sen": 40800}}, {"step": 2, "data": {"cost": 0.43385255}}, {"step": 2, "data": {"time": 0.69}}, {"step": 2, "data": {"rate": 620093.04}}, {"step": 2, "data": {"gnorm": 0.3022}}, {"step": 3, "data": {"epoch": 1}}, {"step": 3, "data": {"sen": 48512}}, {"step": 3, "data": {"cost": 0.44706488}}, {"step": 3, "data": {"time": 0.8}}, {"step": 3, "data": {"rate": 535057.13}}, {"step": 3, "data": {"gnorm": 0.319}}, {"step": 4, "data": {"epoch": 1}}, {"step": 4, "data": {"sen": 70912}}, {"step": 4, "data": {"cost": 0.42464179}}, {"step": 4, "data": {"time": 0.58}}, {"step": 4, "data": {"rate": 582540.8}}, {"step": 4, "data": {"gnorm": 0.3044}}, {"step": 5, "data": {"epoch": 1}}, {"step": 5, "data": {"sen": 109716}}, {"step": 5, "data": {"cost": 0.43045926}}, {"step": 5, "data": {"time": 0.75}}, {"step": 5, "data": {"rate": 672397.58}}, {"step": 5, "data": {"gnorm": 0.3078}}, {"step": 6, "data": {"epoch": 1}}, {"step": 6, "data": {"sen": 132116}}, {"step": 6, "data": {"cost": 0.4244875}}, {"step": 6, "data": {"time": 0.63}}, {"step": 6, "data": {"rate": 640719.38}}, {"step": 6, "data": {"gnorm": 0.2979}}, {"step": 7, "data": {"epoch": 1}}, {"step": 7, "data": {"sen": 143860}}, {"step": 7, "data": {"cost": 0.44767788}}, {"step": 7, "data": {"time": 0.73}}, {"step": 7, "data": {"rate": 627707.66}}, {"step": 7, "data": {"gnorm": 0.3054}}, {"step": 8, "data": {"epoch": 1}}, {"step": 8, "data": {"sen": 149460}}, {"step": 8, "data": {"cost": 0.46901628}}, {"step": 8, "data": {"time": 0.87}}, {"step": 8, "data": {"rate": 538549.45}}, {"step": 8, "data": {"gnorm": 0.3349}}, {"step": 9, "data": {"epoch": 1}}, {"step": 9, "data": {"sen": 161204}}, {"step": 9, "data": {"cost": 0.45137054}}, {"step": 9, "data": {"time": 0.73}}, {"step": 9, "data": {"rate": 653297.11}}, {"step": 9, "data": {"gnorm": 0.3298}}, {"step": 10, "data": {"epoch": 1}}, {"step": 10, "data": {"sen": 176724}}, {"step": 10, "data": {"cost": 0.43862325}}, {"step": 10, "data": {"time": 0.67}}, {"step": 10, "data": {"rate": 704617.37}}, {"step": 10, "data": {"gnorm": 0.3267}}, {"step": 100, "data": {"epoch": 1}}, {"step": 100, "data": {"sen": 1988245}}, {"step": 100, "data": {"cost": 0.44293833}}, {"step": 100, "data": {"time": 62.12}}, {"step": 100, "data": {"rate": 624799.04}}, {"step": 100, "data": {"gnorm": 0.3432}}, {"step": 200, "data": {"epoch": 1}}, {"step": 200, "data": {"sen": 4044783}}, {"step": 200, "data": {"cost": 0.44180658}}, {"step": 200, "data": {"time": 73.8}}, {"step": 200, "data": {"rate": 609363.67}}, {"step": 200, "data": {"gnorm": 0.3064}}, {"step": 300, "data": {"epoch": 1}}, {"step": 300, "data": {"sen": 6040776}}, {"step": 300, "data": {"cost": 0.44082555}}, {"step": 300, "data": {"time": 71.74}}, {"step": 300, "data": {"rate": 610456.94}}, {"step": 300, "data": {"gnorm": 0.3112}}, {"step": 400, "data": {"epoch": 1}}, {"step": 400, "data": {"sen": 8026819}}, {"step": 400, "data": {"cost": 0.43916216}}, {"step": 400, "data": {"time": 72.22}}, {"step": 400, "data": {"rate": 606176.23}}, {"step": 400, "data": {"gnorm": 0.2604}}, {"step": 500, "data": {"epoch": 1}}, {"step": 500, "data": {"sen": 10037885}}, {"step": 500, "data": {"cost": 0.43592939}}, {"step": 500, "data": {"time": 72.29}}, {"step": 500, "data": {"rate": 605841.35}}, {"step": 500, "data": {"gnorm": 0.2231}}, {"step": 500, "data": {"epoch": 1}}, {"step": 500, "data": {"perplexity": 9.44136}}, {"step": 500, "data": {"chrf": 56.4569}}, {"step": 500, "data": {"ce_mean_words": 2.2451}}, {"step": 500, "data": {"bleu_detok": 29.1717}}, {"step": 600, "data": {"epoch": 1}}, {"step": 600, "data": {"sen": 12096400}}, {"step": 600, "data": {"cost": 0.43422392}}, {"step": 600, "data": {"time": 100.64}}, {"step": 600, "data": {"rate": 437122.89}}, {"step": 600, "data": {"gnorm": 0.2136}}, {"step": 700, "data": {"epoch": 1}}, {"step": 700, "data": {"sen": 14054254}}, {"step": 700, "data": {"cost": 0.43195471}}, {"step": 700, "data": {"time": 73.16}}, {"step": 700, "data": {"rate": 605920.87}}, {"step": 700, "data": {"gnorm": 0.2129}}, {"step": 800, "data": {"epoch": 1}}, {"step": 800, "data": {"sen": 16156263}}, {"step": 800, "data": {"cost": 0.42985243}}, {"step": 800, "data": {"time": 74.14}}, {"step": 800, "data": {"rate": 604111.59}}, {"step": 800, "data": {"gnorm": 0.1995}}, {"step": 900, "data": {"epoch": 1}}, {"step": 900, "data": {"sen": 18175872}}, {"step": 900, "data": {"cost": 0.42936045}}, {"step": 900, "data": {"time": 73.83}}, {"step": 900, "data": {"rate": 604887.29}}, {"step": 900, "data": {"gnorm": 0.1995}}, {"step": 1000, "data": {"epoch": 1}}, {"step": 1000, "data": {"sen": 20312610}}, {"step": 1000, "data": {"cost": 0.42563558}}, {"step": 1000, "data": {"time": 74.09}}, {"step": 1000, "data": {"rate": 604047.69}}, {"step": 1000, "data": {"gnorm": 0.2063}}, {"step": 1000, "data": {"epoch": 1}}, {"step": 1000, "data": {"perplexity": 9.39711}}, {"step": 1000, "data": {"chrf": 56.555}}, {"step": 1000, "data": {"ce_mean_words": 2.2404}}, {"step": 1000, "data": {"bleu_detok": 29.2629}}, {"step": 1100, "data": {"epoch": 1}}, {"step": 1100, "data": {"sen": 22232542}}, {"step": 1100, "data": {"cost": 0.4270623}}, {"step": 1100, "data": {"time": 101.16}}, {"step": 1100, "data": {"rate": 437805.26}}, {"step": 1100, "data": {"gnorm": 0.1977}}, {"step": 1200, "data": {"epoch": 1}}, {"step": 1200, "data": {"sen": 24227740}}, {"step": 1200, "data": {"cost": 0.42348987}}, {"step": 1200, "data": {"time": 72.39}}, {"step": 1200, "data": {"rate": 608690.26}}, {"step": 1200, "data": {"gnorm": 0.1981}}, {"step": 1300, "data": {"epoch": 1}}, {"step": 1300, "data": {"sen": 26356719}}, {"step": 1300, "data": {"cost": 0.42560452}}, {"step": 1300, "data": {"time": 73.28}}, {"step": 1300, "data": {"rate": 604304.17}}, {"step": 1300, "data": {"gnorm": 0.2061}}, {"step": 1400, "data": {"epoch": 1}}, {"step": 1400, "data": {"sen": 28394846}}, {"step": 1400, "data": {"cost": 0.42287678}}, {"step": 1400, "data": {"time": 74.43}}, {"step": 1400, "data": {"rate": 609888.13}}, {"step": 1400, "data": {"gnorm": 0.1936}}, {"step": 1500, "data": {"epoch": 1}}, {"step": 1500, "data": {"sen": 30442333}}, {"step": 1500, "data": {"cost": 0.42398295}}, {"step": 1500, "data": {"time": 72.72}}, {"step": 1500, "data": {"rate": 601838.98}}, {"step": 1500, "data": {"gnorm": 0.2061}}, {"step": 1500, "data": {"epoch": 1}}, {"step": 1500, "data": {"perplexity": 9.37062}}, {"step": 1500, "data": {"chrf": 56.5788}}, {"step": 1500, "data": {"ce_mean_words": 2.23758}}, {"step": 1500, "data": {"bleu_detok": 29.3035}}, {"step": 1600, "data": {"epoch": 1}}, {"step": 1600, "data": {"sen": 32372383}}, {"step": 1600, "data": {"cost": 0.42146775}}, {"step": 1600, "data": {"time": 100.41}}, {"step": 1600, "data": {"rate": 442000.34}}, {"step": 1600, "data": {"gnorm": 0.1965}}, {"step": 1700, "data": {"epoch": 1}}, {"step": 1700, "data": {"sen": 34393940}}, {"step": 1700, "data": {"cost": 0.42263454}}, {"step": 1700, "data": {"time": 74.12}}, {"step": 1700, "data": {"rate": 603001.55}}, {"step": 1700, "data": {"gnorm": 0.2015}}, {"step": 1800, "data": {"epoch": 1}}, {"step": 1800, "data": {"sen": 36388353}}, {"step": 1800, "data": {"cost": 0.42409346}}, {"step": 1800, "data": {"time": 74.1}}, {"step": 1800, "data": {"rate": 597651.19}}, {"step": 1800, "data": {"gnorm": 0.2082}}, {"step": 1900, "data": {"epoch": 1}}, {"step": 1900, "data": {"sen": 38429891}}, {"step": 1900, "data": {"cost": 0.42277914}}, {"step": 1900, "data": {"time": 72.55}}, {"step": 1900, "data": {"rate": 602980.23}}, {"step": 1900, "data": {"gnorm": 0.2096}}, {"step": 2000, "data": {"epoch": 1}}, {"step": 2000, "data": {"sen": 40480830}}, {"step": 2000, "data": {"cost": 0.42296642}}, {"step": 2000, "data": {"time": 73.11}}, {"step": 2000, "data": {"rate": 597591.66}}, {"step": 2000, "data": {"gnorm": 0.2105}}, {"step": 2000, "data": {"epoch": 1}}, {"step": 2000, "data": {"perplexity": 9.37382}}, {"step": 2000, "data": {"chrf": 56.5645}}, {"step": 2000, "data": {"ce_mean_words": 2.23792}}, {"step": 2000, "data": {"bleu_detok": 29.2485}}, {"step": 2100, "data": {"epoch": 1}}, {"step": 2100, "data": {"sen": 42508592}}, {"step": 2100, "data": {"cost": 0.42160124}}, {"step": 2100, "data": {"time": 98.94}}, {"step": 2100, "data": {"rate": 447976.82}}, {"step": 2100, "data": {"gnorm": 0.2102}}, {"step": 2200, "data": {"epoch": 1}}, {"step": 2200, "data": {"sen": 44446794}}, {"step": 2200, "data": {"cost": 0.42323029}}, {"step": 2200, "data": {"time": 72.61}}, {"step": 2200, "data": {"rate": 598092.04}}, {"step": 2200, "data": {"gnorm": 0.2153}}, {"step": 2300, "data": {"epoch": 1}}, {"step": 2300, "data": {"sen": 46521578}}, {"step": 2300, "data": {"cost": 0.4216395}}, {"step": 2300, "data": {"time": 72.75}}, {"step": 2300, "data": {"rate": 606211.79}}, {"step": 2300, "data": {"gnorm": 0.2173}}, {"step": 2400, "data": {"epoch": 1}}, {"step": 2400, "data": {"sen": 48611127}}, {"step": 2400, "data": {"cost": 0.42312729}}, {"step": 2400, "data": {"time": 74.05}}, {"step": 2400, "data": {"rate": 601908.91}}, {"step": 2400, "data": {"gnorm": 0.2175}}, {"step": 2500, "data": {"epoch": 1}}, {"step": 2500, "data": {"sen": 50616784}}, {"step": 2500, "data": {"cost": 0.42202282}}, {"step": 2500, "data": {"time": 74.39}}, {"step": 2500, "data": {"rate": 608994.22}}, {"step": 2500, "data": {"gnorm": 0.215}}, {"step": 2500, "data": {"epoch": 1}}, {"step": 2500, "data": {"perplexity": 9.3359}}, {"step": 2500, "data": {"chrf": 56.5788}}, {"step": 2500, "data": {"ce_mean_words": 2.23387}}, {"step": 2500, "data": {"bleu_detok": 29.2723}}, {"step": 2600, "data": {"epoch": 1}}, {"step": 2600, "data": {"sen": 52665109}}, {"step": 2600, "data": {"cost": 0.42341959}}, {"step": 2600, "data": {"time": 101.21}}, {"step": 2600, "data": {"rate": 441377.74}}, {"step": 2600, "data": {"gnorm": 0.22}}, {"step": 2700, "data": {"epoch": 1}}, {"step": 2700, "data": {"sen": 54751029}}, {"step": 2700, "data": {"cost": 0.4228147}}, {"step": 2700, "data": {"time": 74.07}}, {"step": 2700, "data": {"rate": 605778.5}}, {"step": 2700, "data": {"gnorm": 0.2325}}, {"step": 2800, "data": {"epoch": 1}}, {"step": 2800, "data": {"sen": 56697833}}, {"step": 2800, "data": {"cost": 0.42488825}}, {"step": 2800, "data": {"time": 73.07}}, {"step": 2800, "data": {"rate": 592207.41}}, {"step": 2800, "data": {"gnorm": 0.234}}, {"step": 2900, "data": {"epoch": 1}}, {"step": 2900, "data": {"sen": 58710103}}, {"step": 2900, "data": {"cost": 0.42300135}}, {"step": 2900, "data": {"time": 72.37}}, {"step": 2900, "data": {"rate": 603884.52}}, {"step": 2900, "data": {"gnorm": 0.2391}}, {"step": 3000, "data": {"epoch": 1}}, {"step": 3000, "data": {"sen": 60731790}}, {"step": 3000, "data": {"cost": 0.42334017}}, {"step": 3000, "data": {"time": 73.3}}, {"step": 3000, "data": {"rate": 608389.92}}, {"step": 3000, "data": {"gnorm": 0.2352}}, {"step": 3000, "data": {"epoch": 1}}, {"step": 3000, "data": {"perplexity": 9.32788}}, {"step": 3000, "data": {"chrf": 56.5463}}, {"step": 3000, "data": {"ce_mean_words": 2.23301}}, {"step": 3000, "data": {"bleu_detok": 29.261}}, {"step": 3100, "data": {"epoch": 1}}, {"step": 3100, "data": {"sen": 62814002}}, {"step": 3100, "data": {"cost": 0.42631865}}, {"step": 3100, "data": {"time": 101.85}}, {"step": 3100, "data": {"rate": 433415.18}}, {"step": 3100, "data": {"gnorm": 0.2503}}, {"step": 3200, "data": {"epoch": 1}}, {"step": 3200, "data": {"sen": 64797019}}, {"step": 3200, "data": {"cost": 0.42404962}}, {"step": 3200, "data": {"time": 74.02}}, {"step": 3200, "data": {"rate": 603494.47}}, {"step": 3200, "data": {"gnorm": 0.274}}, {"step": 3300, "data": {"epoch": 1}}, {"step": 3300, "data": {"sen": 66773097}}, {"step": 3300, "data": {"cost": 0.42503634}}, {"step": 3300, "data": {"time": 72.82}}, {"step": 3300, "data": {"rate": 595798.26}}, {"step": 3300, "data": {"gnorm": 0.2474}}, {"step": 3400, "data": {"epoch": 1}}, {"step": 3400, "data": {"sen": 68833093}}, {"step": 3400, "data": {"cost": 0.42650777}}, {"step": 3400, "data": {"time": 72.5}}, {"step": 3400, "data": {"rate": 598267.34}}, {"step": 3400, "data": {"gnorm": 0.2536}}, {"step": 3500, "data": {"epoch": 1}}, {"step": 3500, "data": {"sen": 70871965}}, {"step": 3500, "data": {"cost": 0.42652583}}, {"step": 3500, "data": {"time": 76.44}}, {"step": 3500, "data": {"rate": 596718.85}}, {"step": 3500, "data": {"gnorm": 0.2366}}, {"step": 3500, "data": {"epoch": 1}}, {"step": 3500, "data": {"perplexity": 9.4323}}, {"step": 3500, "data": {"chrf": 56.6618}}, {"step": 3500, "data": {"ce_mean_words": 2.24414}}, {"step": 3500, "data": {"bleu_detok": 29.3573}}, {"step": 3600, "data": {"epoch": 1}}, {"step": 3600, "data": {"sen": 72899705}}, {"step": 3600, "data": {"cost": 0.42629641}}, {"step": 3600, "data": {"time": 100.77}}, {"step": 3600, "data": {"rate": 434667.64}}, {"step": 3600, "data": {"gnorm": 0.2747}}, {"step": 3700, "data": {"epoch": 1}}, {"step": 3700, "data": {"sen": 74832526}}, {"step": 3700, "data": {"cost": 0.42659682}}, {"step": 3700, "data": {"time": 72.35}}, {"step": 3700, "data": {"rate": 599055.0}}, {"step": 3700, "data": {"gnorm": 0.2594}}, {"step": 3800, "data": {"epoch": 1}}, {"step": 3800, "data": {"sen": 76787743}}, {"step": 3800, "data": {"cost": 0.42606211}}, {"step": 3800, "data": {"time": 73.33}}, {"step": 3800, "data": {"rate": 599140.37}}, {"step": 3800, "data": {"gnorm": 0.2525}}, {"step": 3900, "data": {"epoch": 1}}, {"step": 3900, "data": {"sen": 78859264}}, {"step": 3900, "data": {"cost": 0.42699769}}, {"step": 3900, "data": {"time": 72.48}}, {"step": 3900, "data": {"rate": 600182.04}}, {"step": 3900, "data": {"gnorm": 0.2671}}, {"step": 4000, "data": {"epoch": 1}}, {"step": 4000, "data": {"sen": 80978709}}, {"step": 4000, "data": {"cost": 0.42775595}}, {"step": 4000, "data": {"time": 74.96}}, {"step": 4000, "data": {"rate": 604410.73}}, {"step": 4000, "data": {"gnorm": 0.2469}}, {"step": 4000, "data": {"epoch": 1}}, {"step": 4000, "data": {"perplexity": 9.35376}}, {"step": 4000, "data": {"chrf": 56.5737}}, {"step": 4000, "data": {"ce_mean_words": 2.23578}}, {"step": 4000, "data": {"bleu_detok": 29.288}}, {"step": 4100, "data": {"epoch": 1}}, {"step": 4100, "data": {"sen": 82981325}}, {"step": 4100, "data": {"cost": 0.42928466}}, {"step": 4100, "data": {"time": 102.43}}, {"step": 4100, "data": {"rate": 435927.11}}, {"step": 4100, "data": {"gnorm": 0.25}}, {"step": 4200, "data": {"epoch": 1}}, {"step": 4200, "data": {"sen": 84999717}}, {"step": 4200, "data": {"cost": 0.42870831}}, {"step": 4200, "data": {"time": 73.52}}, {"step": 4200, "data": {"rate": 600522.94}}, {"step": 4200, "data": {"gnorm": 0.2771}}, {"step": 4300, "data": {"epoch": 1}}, {"step": 4300, "data": {"sen": 87018110}}, {"step": 4300, "data": {"cost": 0.42872104}}, {"step": 4300, "data": {"time": 74.58}}, {"step": 4300, "data": {"rate": 590972.74}}, {"step": 4300, "data": {"gnorm": 0.2667}}, {"step": 4400, "data": {"epoch": 1}}, {"step": 4400, "data": {"sen": 89015220}}, {"step": 4400, "data": {"cost": 0.42949602}}, {"step": 4400, "data": {"time": 73.35}}, {"step": 4400, "data": {"rate": 596353.2}}, {"step": 4400, "data": {"gnorm": 0.2754}}, {"step": 4500, "data": {"epoch": 1}}, {"step": 4500, "data": {"sen": 91035501}}, {"step": 4500, "data": {"cost": 0.43040338}}, {"step": 4500, "data": {"time": 74.53}}, {"step": 4500, "data": {"rate": 594490.93}}, {"step": 4500, "data": {"gnorm": 0.2677}}, {"step": 4500, "data": {"epoch": 1}}, {"step": 4500, "data": {"perplexity": 9.42398}}, {"step": 4500, "data": {"chrf": 56.5394}}, {"step": 4500, "data": {"ce_mean_words": 2.24326}}, {"step": 4500, "data": {"bleu_detok": 29.2102}}, {"step": 4600, "data": {"epoch": 1}}, {"step": 4600, "data": {"sen": 93082704}}, {"step": 4600, "data": {"cost": 0.42988995}}, {"step": 4600, "data": {"time": 103.65}}, {"step": 4600, "data": {"rate": 428646.73}}, {"step": 4600, "data": {"gnorm": 0.2881}}, {"step": 4700, "data": {"epoch": 1}}, {"step": 4700, "data": {"sen": 95116183}}, {"step": 4700, "data": {"cost": 0.43111899}}, {"step": 4700, "data": {"time": 75.4}}, {"step": 4700, "data": {"rate": 591226.56}}, {"step": 4700, "data": {"gnorm": 0.276}}, {"step": 4800, "data": {"epoch": 1}}, {"step": 4800, "data": {"sen": 97148241}}, {"step": 4800, "data": {"cost": 0.43269148}}, {"step": 4800, "data": {"time": 73.53}}, {"step": 4800, "data": {"rate": 586090.77}}, {"step": 4800, "data": {"gnorm": 0.3151}}, {"step": 4900, "data": {"epoch": 1}}, {"step": 4900, "data": {"sen": 99112142}}, {"step": 4900, "data": {"cost": 0.43132946}}, {"step": 4900, "data": {"time": 74.32}}, {"step": 4900, "data": {"rate": 601209.31}}, {"step": 4900, "data": {"gnorm": 0.3033}}, {"step": 5000, "data": {"epoch": 1}}, {"step": 5000, "data": {"sen": 101103636}}, {"step": 5000, "data": {"cost": 0.43485913}}, {"step": 5000, "data": {"time": 75.15}}, {"step": 5000, "data": {"rate": 583653.43}}, {"step": 5000, "data": {"gnorm": 0.3132}}, {"step": 5000, "data": {"epoch": 1}}, {"step": 5000, "data": {"perplexity": 9.24899}}, {"step": 5000, "data": {"chrf": 56.6403}}, {"step": 5000, "data": {"ce_mean_words": 2.22451}}, {"step": 5000, "data": {"bleu_detok": 29.2715}}, {"step": 5100, "data": {"epoch": 1}}, {"step": 5100, "data": {"sen": 103154270}}, {"step": 5100, "data": {"cost": 0.43177292}}, {"step": 5100, "data": {"time": 106.14}}, {"step": 5100, "data": {"rate": 426039.12}}, {"step": 5100, "data": {"gnorm": 0.2857}}, {"step": 5200, "data": {"epoch": 1}}, {"step": 5200, "data": {"sen": 105159325}}, {"step": 5200, "data": {"cost": 0.43331209}}, {"step": 5200, "data": {"time": 74.33}}, {"step": 5200, "data": {"rate": 584205.72}}, {"step": 5200, "data": {"gnorm": 0.3055}}, {"step": 5300, "data": {"epoch": 1}}, {"step": 5300, "data": {"sen": 107284045}}, {"step": 5300, "data": {"cost": 0.43181026}}, {"step": 5300, "data": {"time": 75.11}}, {"step": 5300, "data": {"rate": 582902.75}}, {"step": 5300, "data": {"gnorm": 0.2991}}, {"step": 5400, "data": {"epoch": 1}}, {"step": 5400, "data": {"sen": 109224083}}, {"step": 5400, "data": {"cost": 0.43384504}}, {"step": 5400, "data": {"time": 75.32}}, {"step": 5400, "data": {"rate": 588539.5}}, {"step": 5400, "data": {"gnorm": 0.3145}}, {"step": 5500, "data": {"epoch": 1}}, {"step": 5500, "data": {"sen": 111295183}}, {"step": 5500, "data": {"cost": 0.43385842}}, {"step": 5500, "data": {"time": 76.3}}, {"step": 5500, "data": {"rate": 592825.18}}, {"step": 5500, "data": {"gnorm": 0.3024}}, {"step": 5500, "data": {"epoch": 1}}, {"step": 5500, "data": {"perplexity": 9.3606}}, {"step": 5500, "data": {"chrf": 56.5076}}, {"step": 5500, "data": {"ce_mean_words": 2.23651}}, {"step": 5500, "data": {"bleu_detok": 29.1567}}, {"step": 5600, "data": {"epoch": 1}}, {"step": 5600, "data": {"sen": 113321525}}, {"step": 5600, "data": {"cost": 0.43588015}}, {"step": 5600, "data": {"time": 104.58}}, {"step": 5600, "data": {"rate": 420513.29}}, {"step": 5600, "data": {"gnorm": 0.3374}}, {"step": 5700, "data": {"epoch": 1}}, {"step": 5700, "data": {"sen": 115413794}}, {"step": 5700, "data": {"cost": 0.43279886}}, {"step": 5700, "data": {"time": 75.69}}, {"step": 5700, "data": {"rate": 587461.17}}, {"step": 5700, "data": {"gnorm": 0.2974}}, {"step": 5800, "data": {"epoch": 1}}, {"step": 5800, "data": {"sen": 117391161}}, {"step": 5800, "data": {"cost": 0.43686602}}, {"step": 5800, "data": {"time": 73.79}}, {"step": 5800, "data": {"rate": 596981.17}}, {"step": 5800, "data": {"gnorm": 0.3185}}, {"step": 5900, "data": {"epoch": 2}}, {"step": 5900, "data": {"sen": 1759060}}, {"step": 5900, "data": {"cost": 0.43529254}}, {"step": 5900, "data": {"time": 106.19}}, {"step": 5900, "data": {"rate": 416891.41}}, {"step": 5900, "data": {"gnorm": 0.3173}}, {"step": 6000, "data": {"epoch": 2}}, {"step": 6000, "data": {"sen": 3793502}}, {"step": 6000, "data": {"cost": 0.43505535}}, {"step": 6000, "data": {"time": 76.37}}, {"step": 6000, "data": {"rate": 585816.0}}, {"step": 6000, "data": {"gnorm": 0.3628}}, {"step": 6000, "data": {"epoch": 2}}, {"step": 6000, "data": {"perplexity": 9.30435}}, {"step": 6000, "data": {"chrf": 56.3588}}, {"step": 6000, "data": {"ce_mean_words": 2.23048}}, {"step": 6000, "data": {"bleu_detok": 29.01}}, {"step": 6100, "data": {"epoch": 2}}, {"step": 6100, "data": {"sen": 5817010}}, {"step": 6100, "data": {"cost": 0.4358722}}, {"step": 6100, "data": {"time": 102.24}}, {"step": 6100, "data": {"rate": 424497.34}}, {"step": 6100, "data": {"gnorm": 0.3741}}, {"step": 6200, "data": {"epoch": 2}}, {"step": 6200, "data": {"sen": 7846391}}, {"step": 6200, "data": {"cost": 0.43628591}}, {"step": 6200, "data": {"time": 76.76}}, {"step": 6200, "data": {"rate": 587200.75}}, {"step": 6200, "data": {"gnorm": 0.3199}}, {"step": 6300, "data": {"epoch": 2}}, {"step": 6300, "data": {"sen": 9911326}}, {"step": 6300, "data": {"cost": 0.43842334}}, {"step": 6300, "data": {"time": 77.24}}, {"step": 6300, "data": {"rate": 581417.8}}, {"step": 6300, "data": {"gnorm": 0.3379}}, {"step": 6400, "data": {"epoch": 2}}, {"step": 6400, "data": {"sen": 11926230}}, {"step": 6400, "data": {"cost": 0.43785232}}, {"step": 6400, "data": {"time": 74.44}}, {"step": 6400, "data": {"rate": 582614.21}}, {"step": 6400, "data": {"gnorm": 0.4041}}, {"step": 6500, "data": {"epoch": 2}}, {"step": 6500, "data": {"sen": 13972690}}, {"step": 6500, "data": {"cost": 0.43664911}}, {"step": 6500, "data": {"time": 76.55}}, {"step": 6500, "data": {"rate": 586749.16}}, {"step": 6500, "data": {"gnorm": 0.3411}}, {"step": 6500, "data": {"epoch": 2}}, {"step": 6500, "data": {"perplexity": 9.41835}}, {"step": 6500, "data": {"chrf": 56.5684}}, {"step": 6500, "data": {"ce_mean_words": 2.24266}}, {"step": 6500, "data": {"bleu_detok": 29.2192}}, {"step": 6600, "data": {"epoch": 2}}, {"step": 6600, "data": {"sen": 15999950}}, {"step": 6600, "data": {"cost": 0.44089934}}, {"step": 6600, "data": {"time": 103.88}}, {"step": 6600, "data": {"rate": 429050.2}}, {"step": 6600, "data": {"gnorm": 0.3799}}, {"step": 6700, "data": {"epoch": 2}}, {"step": 6700, "data": {"sen": 18006988}}, {"step": 6700, "data": {"cost": 0.43976825}}, {"step": 6700, "data": {"time": 76.08}}, {"step": 6700, "data": {"rate": 581273.13}}, {"step": 6700, "data": {"gnorm": 0.3497}}, {"step": 6800, "data": {"epoch": 2}}, {"step": 6800, "data": {"sen": 20050151}}, {"step": 6800, "data": {"cost": 0.43943217}}, {"step": 6800, "data": {"time": 75.77}}, {"step": 6800, "data": {"rate": 582056.26}}, {"step": 6800, "data": {"gnorm": 0.3594}}, {"step": 6900, "data": {"epoch": 2}}, {"step": 6900, "data": {"sen": 22084756}}, {"step": 6900, "data": {"cost": 0.43961427}}, {"step": 6900, "data": {"time": 76.36}}, {"step": 6900, "data": {"rate": 585126.16}}, {"step": 6900, "data": {"gnorm": 0.3427}}, {"step": 7000, "data": {"epoch": 2}}, {"step": 7000, "data": {"sen": 24084997}}, {"step": 7000, "data": {"cost": 0.43950185}}, {"step": 7000, "data": {"time": 75.83}}, {"step": 7000, "data": {"rate": 583140.96}}, {"step": 7000, "data": {"gnorm": 0.3508}}, {"step": 7000, "data": {"epoch": 2}}, {"step": 7000, "data": {"perplexity": 9.51477}}, {"step": 7000, "data": {"chrf": 56.5243}}, {"step": 7000, "data": {"ce_mean_words": 2.25285}}, {"step": 7000, "data": {"bleu_detok": 28.998}}, {"step": 7100, "data": {"epoch": 2}}, {"step": 7100, "data": {"sen": 26087338}}, {"step": 7100, "data": {"cost": 0.44170338}}, {"step": 7100, "data": {"time": 107.98}}, {"step": 7100, "data": {"rate": 406419.42}}, {"step": 7100, "data": {"gnorm": 0.344}}, {"step": 7200, "data": {"epoch": 2}}, {"step": 7200, "data": {"sen": 28135428}}, {"step": 7200, "data": {"cost": 0.44162363}}, {"step": 7200, "data": {"time": 75.54}}, {"step": 7200, "data": {"rate": 578628.76}}, {"step": 7200, "data": {"gnorm": 0.3666}}, {"step": 7300, "data": {"epoch": 2}}, {"step": 7300, "data": {"sen": 30179637}}, {"step": 7300, "data": {"cost": 0.44242415}}, {"step": 7300, "data": {"time": 77.01}}, {"step": 7300, "data": {"rate": 580615.65}}, {"step": 7300, "data": {"gnorm": 0.3686}}, {"step": 7400, "data": {"epoch": 2}}, {"step": 7400, "data": {"sen": 32111469}}, {"step": 7400, "data": {"cost": 0.4432987}}, {"step": 7400, "data": {"time": 74.08}}, {"step": 7400, "data": {"rate": 578951.92}}, {"step": 7400, "data": {"gnorm": 0.4167}}, {"step": 7500, "data": {"epoch": 2}}, {"step": 7500, "data": {"sen": 34178837}}, {"step": 7500, "data": {"cost": 0.44330108}}, {"step": 7500, "data": {"time": 76.84}}, {"step": 7500, "data": {"rate": 582295.75}}, {"step": 7500, "data": {"gnorm": 0.3482}}, {"step": 7500, "data": {"epoch": 2}}, {"step": 7500, "data": {"perplexity": 9.64654}}, {"step": 7500, "data": {"chrf": 56.353}}, {"step": 7500, "data": {"ce_mean_words": 2.2666}}, {"step": 7500, "data": {"bleu_detok": 28.9778}}, {"step": 7600, "data": {"epoch": 2}}, {"step": 7600, "data": {"sen": 36229331}}, {"step": 7600, "data": {"cost": 0.44393086}}, {"step": 7600, "data": {"time": 105.48}}, {"step": 7600, "data": {"rate": 411116.48}}, {"step": 7600, "data": {"gnorm": 0.3554}}, {"step": 7700, "data": {"epoch": 2}}, {"step": 7700, "data": {"sen": 38199675}}, {"step": 7700, "data": {"cost": 0.44434705}}, {"step": 7700, "data": {"time": 76.49}}, {"step": 7700, "data": {"rate": 578888.46}}, {"step": 7700, "data": {"gnorm": 0.3605}}, {"step": 7800, "data": {"epoch": 2}}, {"step": 7800, "data": {"sen": 40259349}}, {"step": 7800, "data": {"cost": 0.44409201}}, {"step": 7800, "data": {"time": 76.86}}, {"step": 7800, "data": {"rate": 581931.44}}, {"step": 7800, "data": {"gnorm": 0.3679}}, {"step": 7900, "data": {"epoch": 2}}, {"step": 7900, "data": {"sen": 42260642}}, {"step": 7900, "data": {"cost": 0.441957}}, {"step": 7900, "data": {"time": 75.92}}, {"step": 7900, "data": {"rate": 583178.74}}, {"step": 7900, "data": {"gnorm": 0.3653}}, {"step": 8000, "data": {"epoch": 2}}, {"step": 8000, "data": {"sen": 44275879}}, {"step": 8000, "data": {"cost": 0.45018107}}, {"step": 8000, "data": {"time": 74.88}}, {"step": 8000, "data": {"rate": 579747.29}}, {"step": 8000, "data": {"gnorm": 0.3928}}, {"step": 8000, "data": {"epoch": 2}}, {"step": 8000, "data": {"perplexity": 9.33703}}, {"step": 8000, "data": {"chrf": 56.3478}}, {"step": 8000, "data": {"ce_mean_words": 2.23399}}, {"step": 8000, "data": {"bleu_detok": 28.9121}}, {"step": 8100, "data": {"epoch": 2}}, {"step": 8100, "data": {"sen": 46254985}}, {"step": 8100, "data": {"cost": 0.44577724}}, {"step": 8100, "data": {"time": 106.94}}, {"step": 8100, "data": {"rate": 417302.57}}, {"step": 8100, "data": {"gnorm": 0.377}}, {"step": 8200, "data": {"epoch": 2}}, {"step": 8200, "data": {"sen": 48304421}}, {"step": 8200, "data": {"cost": 0.44609118}}, {"step": 8200, "data": {"time": 75.44}}, {"step": 8200, "data": {"rate": 585282.25}}, {"step": 8200, "data": {"gnorm": 0.4433}}, {"step": 8300, "data": {"epoch": 2}}, {"step": 8300, "data": {"sen": 50287261}}, {"step": 8300, "data": {"cost": 0.44771793}}, {"step": 8300, "data": {"time": 75.85}}, {"step": 8300, "data": {"rate": 580812.2}}, {"step": 8300, "data": {"gnorm": 0.4062}}, {"step": 8400, "data": {"epoch": 2}}, {"step": 8400, "data": {"sen": 52320170}}, {"step": 8400, "data": {"cost": 0.44723606}}, {"step": 8400, "data": {"time": 76.87}}, {"step": 8400, "data": {"rate": 585065.01}}, {"step": 8400, "data": {"gnorm": 0.3877}}, {"step": 8500, "data": {"epoch": 2}}, {"step": 8500, "data": {"sen": 54412165}}, {"step": 8500, "data": {"cost": 0.45229584}}, {"step": 8500, "data": {"time": 74.52}}, {"step": 8500, "data": {"rate": 577499.29}}, {"step": 8500, "data": {"gnorm": 0.4185}}, {"step": 8500, "data": {"epoch": 2}}, {"step": 8500, "data": {"perplexity": 9.46526}}, {"step": 8500, "data": {"chrf": 56.4991}}, {"step": 8500, "data": {"ce_mean_words": 2.24763}}, {"step": 8500, "data": {"bleu_detok": 29.0003}}, {"step": 8600, "data": {"epoch": 2}}, {"step": 8600, "data": {"sen": 56361675}}, {"step": 8600, "data": {"cost": 0.44640896}}, {"step": 8600, "data": {"time": 105.94}}, {"step": 8600, "data": {"rate": 419720.9}}, {"step": 8600, "data": {"gnorm": 0.3808}}, {"step": 8700, "data": {"epoch": 2}}, {"step": 8700, "data": {"sen": 58368646}}, {"step": 8700, "data": {"cost": 0.4512361}}, {"step": 8700, "data": {"time": 75.49}}, {"step": 8700, "data": {"rate": 580507.1}}, {"step": 8700, "data": {"gnorm": 0.402}}, {"step": 8800, "data": {"epoch": 2}}, {"step": 8800, "data": {"sen": 60390401}}, {"step": 8800, "data": {"cost": 0.44908383}}, {"step": 8800, "data": {"time": 76.66}}, {"step": 8800, "data": {"rate": 584864.57}}, {"step": 8800, "data": {"gnorm": 0.3837}}, {"step": 8900, "data": {"epoch": 2}}, {"step": 8900, "data": {"sen": 62456131}}, {"step": 8900, "data": {"cost": 0.45019126}}, {"step": 8900, "data": {"time": 75.68}}, {"step": 8900, "data": {"rate": 577331.51}}, {"step": 8900, "data": {"gnorm": 0.3968}}, {"step": 9000, "data": {"epoch": 2}}, {"step": 9000, "data": {"sen": 64479410}}, {"step": 9000, "data": {"cost": 0.45145935}}, {"step": 9000, "data": {"time": 75.33}}, {"step": 9000, "data": {"rate": 582451.9}}, {"step": 9000, "data": {"gnorm": 0.4086}}, {"step": 9000, "data": {"epoch": 2}}, {"step": 9000, "data": {"perplexity": 9.37685}}, {"step": 9000, "data": {"chrf": 56.2681}}, {"step": 9000, "data": {"ce_mean_words": 2.23824}}, {"step": 9000, "data": {"bleu_detok": 28.9621}}, {"step": 9100, "data": {"epoch": 2}}, {"step": 9100, "data": {"sen": 66479815}}, {"step": 9100, "data": {"cost": 0.45879593}}, {"step": 9100, "data": {"time": 105.16}}, {"step": 9100, "data": {"rate": 423269.5}}, {"step": 9100, "data": {"gnorm": 0.4866}}, {"step": 9200, "data": {"epoch": 2}}, {"step": 9200, "data": {"sen": 68546239}}, {"step": 9200, "data": {"cost": 0.45201558}}, {"step": 9200, "data": {"time": 76.35}}, {"step": 9200, "data": {"rate": 584531.65}}, {"step": 9200, "data": {"gnorm": 0.3865}}, {"step": 9300, "data": {"epoch": 2}}, {"step": 9300, "data": {"sen": 70643337}}, {"step": 9300, "data": {"cost": 0.45301008}}, {"step": 9300, "data": {"time": 77.44}}, {"step": 9300, "data": {"rate": 577800.46}}, {"step": 9300, "data": {"gnorm": 0.4138}}, {"step": 9400, "data": {"epoch": 2}}, {"step": 9400, "data": {"sen": 72590253}}, {"step": 9400, "data": {"cost": 0.45366746}}, {"step": 9400, "data": {"time": 75.85}}, {"step": 9400, "data": {"rate": 587144.93}}, {"step": 9400, "data": {"gnorm": 0.3965}}, {"step": 9500, "data": {"epoch": 2}}, {"step": 9500, "data": {"sen": 74591158}}, {"step": 9500, "data": {"cost": 0.45370144}}, {"step": 9500, "data": {"time": 76.1}}, {"step": 9500, "data": {"rate": 584992.8}}, {"step": 9500, "data": {"gnorm": 0.4483}}, {"step": 9500, "data": {"epoch": 2}}, {"step": 9500, "data": {"perplexity": 9.51243}}, {"step": 9500, "data": {"chrf": 56.3308}}, {"step": 9500, "data": {"ce_mean_words": 2.2526}}, {"step": 9500, "data": {"bleu_detok": 28.9965}}, {"step": 9600, "data": {"epoch": 2}}, {"step": 9600, "data": {"sen": 76715472}}, {"step": 9600, "data": {"cost": 0.45129025}}, {"step": 9600, "data": {"time": 104.23}}, {"step": 9600, "data": {"rate": 423844.94}}, {"step": 9600, "data": {"gnorm": 0.3917}}, {"step": 9700, "data": {"epoch": 2}}, {"step": 9700, "data": {"sen": 78675644}}, {"step": 9700, "data": {"cost": 0.45458451}}, {"step": 9700, "data": {"time": 76.52}}, {"step": 9700, "data": {"rate": 589839.64}}, {"step": 9700, "data": {"gnorm": 0.4244}}, {"step": 9800, "data": {"epoch": 2}}, {"step": 9800, "data": {"sen": 80738999}}, {"step": 9800, "data": {"cost": 0.45216843}}, {"step": 9800, "data": {"time": 76.26}}, {"step": 9800, "data": {"rate": 579181.32}}, {"step": 9800, "data": {"gnorm": 0.3907}}, {"step": 9900, "data": {"epoch": 2}}, {"step": 9900, "data": {"sen": 82775047}}, {"step": 9900, "data": {"cost": 0.45305732}}, {"step": 9900, "data": {"time": 77.05}}, {"step": 9900, "data": {"rate": 581495.03}}, {"step": 9900, "data": {"gnorm": 0.4023}}, {"step": 10000, "data": {"epoch": 2}}, {"step": 10000, "data": {"sen": 84843466}}, {"step": 10000, "data": {"cost": 0.45518455}}, {"step": 10000, "data": {"time": 75.74}}, {"step": 10000, "data": {"rate": 581560.29}}, {"step": 10000, "data": {"gnorm": 0.4078}}, {"step": 10000, "data": {"epoch": 2}}, {"step": 10000, "data": {"perplexity": 9.22822}}, {"step": 10000, "data": {"chrf": 56.4188}}, {"step": 10000, "data": {"ce_mean_words": 2.22227}}, {"step": 10000, "data": {"bleu_detok": 29.1601}}, {"step": 10100, "data": {"epoch": 2}}, {"step": 10100, "data": {"sen": 86907910}}, {"step": 10100, "data": {"cost": 0.45677298}}, {"step": 10100, "data": {"time": 105.7}}, {"step": 10100, "data": {"rate": 425702.18}}, {"step": 10100, "data": {"gnorm": 0.4084}}, {"step": 10200, "data": {"epoch": 2}}, {"step": 10200, "data": {"sen": 88918335}}, {"step": 10200, "data": {"cost": 0.46012917}}, {"step": 10200, "data": {"time": 75.5}}, {"step": 10200, "data": {"rate": 580249.41}}, {"step": 10200, "data": {"gnorm": 0.4314}}, {"step": 10300, "data": {"epoch": 2}}, {"step": 10300, "data": {"sen": 90883750}}, {"step": 10300, "data": {"cost": 0.45785868}}, {"step": 10300, "data": {"time": 75.8}}, {"step": 10300, "data": {"rate": 579047.49}}, {"step": 10300, "data": {"gnorm": 0.4459}}, {"step": 10400, "data": {"epoch": 2}}, {"step": 10400, "data": {"sen": 92972840}}, {"step": 10400, "data": {"cost": 0.45930928}}, {"step": 10400, "data": {"time": 76.56}}, {"step": 10400, "data": {"rate": 584945.36}}, {"step": 10400, "data": {"gnorm": 0.4518}}, {"step": 10500, "data": {"epoch": 2}}, {"step": 10500, "data": {"sen": 94990336}}, {"step": 10500, "data": {"cost": 0.45713091}}, {"step": 10500, "data": {"time": 76.06}}, {"step": 10500, "data": {"rate": 582565.55}}, {"step": 10500, "data": {"gnorm": 0.4192}}, {"step": 10500, "data": {"epoch": 2}}, {"step": 10500, "data": {"perplexity": 9.27049}}, {"step": 10500, "data": {"chrf": 56.354}}, {"step": 10500, "data": {"ce_mean_words": 2.22684}}, {"step": 10500, "data": {"bleu_detok": 29.0794}}, {"step": 10600, "data": {"epoch": 2}}, {"step": 10600, "data": {"sen": 96955642}}, {"step": 10600, "data": {"cost": 0.454353}}, {"step": 10600, "data": {"time": 102.61}}, {"step": 10600, "data": {"rate": 420785.72}}, {"step": 10600, "data": {"gnorm": 0.4133}}, {"step": 10700, "data": {"epoch": 2}}, {"step": 10700, "data": {"sen": 98969314}}, {"step": 10700, "data": {"cost": 0.45708016}}, {"step": 10700, "data": {"time": 75.3}}, {"step": 10700, "data": {"rate": 585647.33}}, {"step": 10700, "data": {"gnorm": 0.4092}}, {"step": 10800, "data": {"epoch": 2}}, {"step": 10800, "data": {"sen": 101013066}}, {"step": 10800, "data": {"cost": 0.45888111}}, {"step": 10800, "data": {"time": 76.46}}, {"step": 10800, "data": {"rate": 583534.56}}, {"step": 10800, "data": {"gnorm": 0.4177}}, {"step": 10900, "data": {"epoch": 2}}, {"step": 10900, "data": {"sen": 103050464}}, {"step": 10900, "data": {"cost": 0.45468414}}, {"step": 10900, "data": {"time": 76.57}}, {"step": 10900, "data": {"rate": 576351.55}}, {"step": 10900, "data": {"gnorm": 0.417}}, {"step": 11000, "data": {"epoch": 2}}, {"step": 11000, "data": {"sen": 105041454}}, {"step": 11000, "data": {"cost": 0.46108475}}, {"step": 11000, "data": {"time": 75.5}}, {"step": 11000, "data": {"rate": 580819.64}}, {"step": 11000, "data": {"gnorm": 0.4326}}, {"step": 11000, "data": {"epoch": 2}}, {"step": 11000, "data": {"perplexity": 9.14892}}, {"step": 11000, "data": {"chrf": 56.2931}}, {"step": 11000, "data": {"ce_mean_words": 2.21364}}, {"step": 11000, "data": {"bleu_detok": 28.9172}}, {"step": 11100, "data": {"epoch": 2}}, {"step": 11100, "data": {"sen": 107010069}}, {"step": 11100, "data": {"cost": 0.46091339}}, {"step": 11100, "data": {"time": 106.86}}, {"step": 11100, "data": {"rate": 402902.42}}, {"step": 11100, "data": {"gnorm": 0.4309}}, {"step": 11200, "data": {"epoch": 2}}, {"step": 11200, "data": {"sen": 109047432}}, {"step": 11200, "data": {"cost": 0.45988846}}, {"step": 11200, "data": {"time": 75.8}}, {"step": 11200, "data": {"rate": 582882.59}}, {"step": 11200, "data": {"gnorm": 0.437}}, {"step": 11300, "data": {"epoch": 2}}, {"step": 11300, "data": {"sen": 111057831}}, {"step": 11300, "data": {"cost": 0.46027207}}, {"step": 11300, "data": {"time": 74.82}}, {"step": 11300, "data": {"rate": 583328.64}}, {"step": 11300, "data": {"gnorm": 0.4479}}, {"step": 11400, "data": {"epoch": 2}}, {"step": 11400, "data": {"sen": 113071514}}, {"step": 11400, "data": {"cost": 0.46048781}}, {"step": 11400, "data": {"time": 78.03}}, {"step": 11400, "data": {"rate": 578308.26}}, {"step": 11400, "data": {"gnorm": 0.4477}}, {"step": 11500, "data": {"epoch": 2}}, {"step": 11500, "data": {"sen": 115197748}}, {"step": 11500, "data": {"cost": 0.46182981}}, {"step": 11500, "data": {"time": 76.42}}, {"step": 11500, "data": {"rate": 585154.3}}, {"step": 11500, "data": {"gnorm": 0.4314}}, {"step": 11500, "data": {"epoch": 2}}, {"step": 11500, "data": {"perplexity": 9.29636}}, {"step": 11500, "data": {"chrf": 55.8254}}, {"step": 11500, "data": {"ce_mean_words": 2.22962}}, {"step": 11500, "data": {"bleu_detok": 28.6646}}, {"step": 11600, "data": {"epoch": 2}}, {"step": 11600, "data": {"sen": 117173558}}, {"step": 11600, "data": {"cost": 0.46155766}}, {"step": 11600, "data": {"time": 107.09}}, {"step": 11600, "data": {"rate": 423447.31}}, {"step": 11600, "data": {"gnorm": 0.4168}}, {"step": 11700, "data": {"epoch": 3}}, {"step": 11700, "data": {"sen": 1671609}}, {"step": 11700, "data": {"cost": 0.45964742}}, {"step": 11700, "data": {"time": 106.52}}, {"step": 11700, "data": {"rate": 416334.51}}, {"step": 11700, "data": {"gnorm": 0.4468}}, {"step": 11800, "data": {"epoch": 3}}, {"step": 11800, "data": {"sen": 3653504}}, {"step": 11800, "data": {"cost": 0.46393234}}, {"step": 11800, "data": {"time": 76.09}}, {"step": 11800, "data": {"rate": 582960.87}}, {"step": 11800, "data": {"gnorm": 0.4803}}, {"step": 11900, "data": {"epoch": 3}}, {"step": 11900, "data": {"sen": 5698176}}, {"step": 11900, "data": {"cost": 0.46153855}}, {"step": 11900, "data": {"time": 76.11}}, {"step": 11900, "data": {"rate": 584973.99}}, {"step": 11900, "data": {"gnorm": 0.4442}}, {"step": 12000, "data": {"epoch": 3}}, {"step": 12000, "data": {"sen": 7727909}}, {"step": 12000, "data": {"cost": 0.47250891}}, {"step": 12000, "data": {"time": 73.63}}, {"step": 12000, "data": {"rate": 576527.28}}, {"step": 12000, "data": {"gnorm": 0.4762}}, {"step": 12000, "data": {"epoch": 3}}, {"step": 12000, "data": {"perplexity": 9.40242}}, {"step": 12000, "data": {"chrf": 56.2097}}, {"step": 12000, "data": {"ce_mean_words": 2.24097}}, {"step": 12000, "data": {"bleu_detok": 28.8862}}, {"step": 12100, "data": {"epoch": 3}}, {"step": 12100, "data": {"sen": 9717101}}, {"step": 12100, "data": {"cost": 0.45884091}}, {"step": 12100, "data": {"time": 103.07}}, {"step": 12100, "data": {"rate": 435746.93}}, {"step": 12100, "data": {"gnorm": 0.4207}}, {"step": 12200, "data": {"epoch": 3}}, {"step": 12200, "data": {"sen": 11709810}}, {"step": 12200, "data": {"cost": 0.46756554}}, {"step": 12200, "data": {"time": 75.7}}, {"step": 12200, "data": {"rate": 580201.81}}, {"step": 12200, "data": {"gnorm": 0.4524}}, {"step": 12300, "data": {"epoch": 3}}, {"step": 12300, "data": {"sen": 13629920}}, {"step": 12300, "data": {"cost": 0.45817339}}, {"step": 12300, "data": {"time": 74.93}}, {"step": 12300, "data": {"rate": 584348.03}}, {"step": 12300, "data": {"gnorm": 0.4205}}, {"step": 12400, "data": {"epoch": 3}}, {"step": 12400, "data": {"sen": 15712911}}, {"step": 12400, "data": {"cost": 0.46949366}}, {"step": 12400, "data": {"time": 76.01}}, {"step": 12400, "data": {"rate": 582989.77}}, {"step": 12400, "data": {"gnorm": 0.4378}}, {"step": 12500, "data": {"epoch": 3}}, {"step": 12500, "data": {"sen": 17800160}}, {"step": 12500, "data": {"cost": 0.46521175}}, {"step": 12500, "data": {"time": 75.63}}, {"step": 12500, "data": {"rate": 581631.5}}, {"step": 12500, "data": {"gnorm": 0.4864}}, {"step": 12500, "data": {"epoch": 3}}, {"step": 12500, "data": {"perplexity": 9.57626}}, {"step": 12500, "data": {"chrf": 56.2395}}, {"step": 12500, "data": {"ce_mean_words": 2.25929}}, {"step": 12500, "data": {"bleu_detok": 28.7866}}, {"step": 12600, "data": {"epoch": 3}}, {"step": 12600, "data": {"sen": 19855500}}, {"step": 12600, "data": {"cost": 0.47429937}}, {"step": 12600, "data": {"time": 103.47}}, {"step": 12600, "data": {"rate": 427974.53}}, {"step": 12600, "data": {"gnorm": 0.5133}}, {"step": 12700, "data": {"epoch": 3}}, {"step": 12700, "data": {"sen": 21813808}}, {"step": 12700, "data": {"cost": 0.46300033}}, {"step": 12700, "data": {"time": 75.68}}, {"step": 12700, "data": {"rate": 582535.54}}, {"step": 12700, "data": {"gnorm": 0.4308}}, {"step": 12800, "data": {"epoch": 3}}, {"step": 12800, "data": {"sen": 23797319}}, {"step": 12800, "data": {"cost": 0.46415454}}, {"step": 12800, "data": {"time": 76.26}}, {"step": 12800, "data": {"rate": 584581.66}}, {"step": 12800, "data": {"gnorm": 0.4007}}, {"step": 12900, "data": {"epoch": 3}}, {"step": 12900, "data": {"sen": 25841592}}, {"step": 12900, "data": {"cost": 0.46727765}}, {"step": 12900, "data": {"time": 76.49}}, {"step": 12900, "data": {"rate": 583076.99}}, {"step": 12900, "data": {"gnorm": 0.4215}}, {"step": 13000, "data": {"epoch": 3}}, {"step": 13000, "data": {"sen": 27873942}}, {"step": 13000, "data": {"cost": 0.46824524}}, {"step": 13000, "data": {"time": 75.51}}, {"step": 13000, "data": {"rate": 576615.67}}, {"step": 13000, "data": {"gnorm": 0.4561}}, {"step": 13000, "data": {"epoch": 3}}, {"step": 13000, "data": {"perplexity": 9.318}}, {"step": 13000, "data": {"chrf": 56.2765}}, {"step": 13000, "data": {"ce_mean_words": 2.23195}}, {"step": 13000, "data": {"bleu_detok": 28.9013}}, {"step": 13100, "data": {"epoch": 3}}, {"step": 13100, "data": {"sen": 29912452}}, {"step": 13100, "data": {"cost": 0.46578091}}, {"step": 13100, "data": {"time": 104.79}}, {"step": 13100, "data": {"rate": 428318.34}}, {"step": 13100, "data": {"gnorm": 0.5091}}, {"step": 13200, "data": {"epoch": 3}}, {"step": 13200, "data": {"sen": 31965701}}, {"step": 13200, "data": {"cost": 0.4717367}}, {"step": 13200, "data": {"time": 76.51}}, {"step": 13200, "data": {"rate": 581037.29}}, {"step": 13200, "data": {"gnorm": 0.4398}}, {"step": 13300, "data": {"epoch": 3}}, {"step": 13300, "data": {"sen": 33974950}}, {"step": 13300, "data": {"cost": 0.46848965}}, {"step": 13300, "data": {"time": 75.64}}, {"step": 13300, "data": {"rate": 585932.89}}, {"step": 13300, "data": {"gnorm": 0.4986}}, {"step": 13400, "data": {"epoch": 3}}, {"step": 13400, "data": {"sen": 35988125}}, {"step": 13400, "data": {"cost": 0.4673993}}, {"step": 13400, "data": {"time": 75.79}}, {"step": 13400, "data": {"rate": 575556.95}}, {"step": 13400, "data": {"gnorm": 0.4796}}, {"step": 13500, "data": {"epoch": 3}}, {"step": 13500, "data": {"sen": 38040025}}, {"step": 13500, "data": {"cost": 0.46769854}}, {"step": 13500, "data": {"time": 77.39}}, {"step": 13500, "data": {"rate": 583679.24}}, {"step": 13500, "data": {"gnorm": 0.4217}}, {"step": 13500, "data": {"epoch": 3}}, {"step": 13500, "data": {"perplexity": 9.52013}}, {"step": 13500, "data": {"chrf": 56.2621}}, {"step": 13500, "data": {"ce_mean_words": 2.25341}}, {"step": 13500, "data": {"bleu_detok": 28.817}}, {"step": 13600, "data": {"epoch": 3}}, {"step": 13600, "data": {"sen": 40087938}}, {"step": 13600, "data": {"cost": 0.47603253}}, {"step": 13600, "data": {"time": 108.23}}, {"step": 13600, "data": {"rate": 413726.94}}, {"step": 13600, "data": {"gnorm": 0.4919}}, {"step": 13700, "data": {"epoch": 3}}, {"step": 13700, "data": {"sen": 42099953}}, {"step": 13700, "data": {"cost": 0.46771187}}, {"step": 13700, "data": {"time": 75.54}}, {"step": 13700, "data": {"rate": 581784.0}}, {"step": 13700, "data": {"gnorm": 0.4588}}, {"step": 13800, "data": {"epoch": 3}}, {"step": 13800, "data": {"sen": 44113058}}, {"step": 13800, "data": {"cost": 0.46890762}}, {"step": 13800, "data": {"time": 76.63}}, {"step": 13800, "data": {"rate": 577664.25}}, {"step": 13800, "data": {"gnorm": 0.4328}}, {"step": 13900, "data": {"epoch": 3}}, {"step": 13900, "data": {"sen": 46139173}}, {"step": 13900, "data": {"cost": 0.48387015}}, {"step": 13900, "data": {"time": 74.98}}, {"step": 13900, "data": {"rate": 584302.46}}, {"step": 13900, "data": {"gnorm": 0.4631}}, {"step": 14000, "data": {"epoch": 3}}, {"step": 14000, "data": {"sen": 48129537}}, {"step": 14000, "data": {"cost": 0.46535188}}, {"step": 14000, "data": {"time": 76.59}}, {"step": 14000, "data": {"rate": 581935.6}}, {"step": 14000, "data": {"gnorm": 0.4233}}, {"step": 14000, "data": {"epoch": 3}}, {"step": 14000, "data": {"perplexity": 9.33328}}, {"step": 14000, "data": {"chrf": 56.271}}, {"step": 14000, "data": {"ce_mean_words": 2.23359}}, {"step": 14000, "data": {"bleu_detok": 29.0086}}, {"step": 14100, "data": {"epoch": 3}}, {"step": 14100, "data": {"sen": 50143182}}, {"step": 14100, "data": {"cost": 0.47033134}}, {"step": 14100, "data": {"time": 105.94}}, {"step": 14100, "data": {"rate": 415345.01}}, {"step": 14100, "data": {"gnorm": 0.4536}}, {"step": 14200, "data": {"epoch": 3}}, {"step": 14200, "data": {"sen": 52158574}}, {"step": 14200, "data": {"cost": 0.47534651}}, {"step": 14200, "data": {"time": 75.07}}, {"step": 14200, "data": {"rate": 580570.0}}, {"step": 14200, "data": {"gnorm": 0.4307}}, {"step": 14300, "data": {"epoch": 3}}, {"step": 14300, "data": {"sen": 54179021}}, {"step": 14300, "data": {"cost": 0.47154137}}, {"step": 14300, "data": {"time": 74.95}}, {"step": 14300, "data": {"rate": 574895.05}}, {"step": 14300, "data": {"gnorm": 0.4565}}, {"step": 14400, "data": {"epoch": 3}}, {"step": 14400, "data": {"sen": 56179259}}, {"step": 14400, "data": {"cost": 0.46831015}}, {"step": 14400, "data": {"time": 76.74}}, {"step": 14400, "data": {"rate": 591462.13}}, {"step": 14400, "data": {"gnorm": 0.3965}}, {"step": 14500, "data": {"epoch": 3}}, {"step": 14500, "data": {"sen": 58235967}}, {"step": 14500, "data": {"cost": 0.47158495}}, {"step": 14500, "data": {"time": 75.35}}, {"step": 14500, "data": {"rate": 579913.63}}, {"step": 14500, "data": {"gnorm": 0.4274}}, {"step": 14500, "data": {"epoch": 3}}, {"step": 14500, "data": {"perplexity": 9.34278}}, {"step": 14500, "data": {"chrf": 56.2104}}, {"step": 14500, "data": {"ce_mean_words": 2.2346}}, {"step": 14500, "data": {"bleu_detok": 28.6602}}, {"step": 14600, "data": {"epoch": 3}}, {"step": 14600, "data": {"sen": 60208386}}, {"step": 14600, "data": {"cost": 0.4804472}}, {"step": 14600, "data": {"time": 106.99}}, {"step": 14600, "data": {"rate": 410852.68}}, {"step": 14600, "data": {"gnorm": 0.4894}}, {"step": 14700, "data": {"epoch": 3}}, {"step": 14700, "data": {"sen": 62338711}}, {"step": 14700, "data": {"cost": 0.46734679}}, {"step": 14700, "data": {"time": 75.56}}, {"step": 14700, "data": {"rate": 580911.73}}, {"step": 14700, "data": {"gnorm": 0.4083}}, {"step": 14800, "data": {"epoch": 3}}, {"step": 14800, "data": {"sen": 64254309}}, {"step": 14800, "data": {"cost": 0.47762144}}, {"step": 14800, "data": {"time": 75.25}}, {"step": 14800, "data": {"rate": 590008.0}}, {"step": 14800, "data": {"gnorm": 0.44}}, {"step": 14900, "data": {"epoch": 3}}, {"step": 14900, "data": {"sen": 66360700}}, {"step": 14900, "data": {"cost": 0.4726859}}, {"step": 14900, "data": {"time": 77.13}}, {"step": 14900, "data": {"rate": 578426.39}}, {"step": 14900, "data": {"gnorm": 0.4305}}, {"step": 15000, "data": {"epoch": 3}}, {"step": 15000, "data": {"sen": 68293053}}, {"step": 15000, "data": {"cost": 0.47462302}}, {"step": 15000, "data": {"time": 75.35}}, {"step": 15000, "data": {"rate": 581211.45}}, {"step": 15000, "data": {"gnorm": 0.4436}}, {"step": 15000, "data": {"epoch": 3}}, {"step": 15000, "data": {"perplexity": 9.15696}}, {"step": 15000, "data": {"chrf": 56.2248}}, {"step": 15000, "data": {"ce_mean_words": 2.21451}}, {"step": 15000, "data": {"bleu_detok": 28.8902}}, {"step": 15100, "data": {"epoch": 3}}, {"step": 15100, "data": {"sen": 70368915}}, {"step": 15100, "data": {"cost": 0.47612333}}, {"step": 15100, "data": {"time": 104.59}}, {"step": 15100, "data": {"rate": 415710.84}}, {"step": 15100, "data": {"gnorm": 0.4889}}, {"step": 15200, "data": {"epoch": 3}}, {"step": 15200, "data": {"sen": 72299456}}, {"step": 15200, "data": {"cost": 0.47654164}}, {"step": 15200, "data": {"time": 75.51}}, {"step": 15200, "data": {"rate": 583900.81}}, {"step": 15200, "data": {"gnorm": 0.4822}}, {"step": 15300, "data": {"epoch": 3}}, {"step": 15300, "data": {"sen": 74329510}}, {"step": 15300, "data": {"cost": 0.46934593}}, {"step": 15300, "data": {"time": 75.66}}, {"step": 15300, "data": {"rate": 578013.7}}, {"step": 15300, "data": {"gnorm": 0.443}}, {"step": 15400, "data": {"epoch": 3}}, {"step": 15400, "data": {"sen": 76414468}}, {"step": 15400, "data": {"cost": 0.46952039}}, {"step": 15400, "data": {"time": 77.62}}, {"step": 15400, "data": {"rate": 584847.54}}, {"step": 15400, "data": {"gnorm": 0.3987}}, {"step": 15500, "data": {"epoch": 3}}, {"step": 15500, "data": {"sen": 78501375}}, {"step": 15500, "data": {"cost": 0.48149359}}, {"step": 15500, "data": {"time": 77.31}}, {"step": 15500, "data": {"rate": 572085.5}}, {"step": 15500, "data": {"gnorm": 0.4704}}, {"step": 15500, "data": {"epoch": 3}}, {"step": 15500, "data": {"perplexity": 9.62813}}, {"step": 15500, "data": {"chrf": 56.1592}}, {"step": 15500, "data": {"ce_mean_words": 2.26469}}, {"step": 15500, "data": {"bleu_detok": 28.5019}}, {"step": 15600, "data": {"epoch": 3}}, {"step": 15600, "data": {"sen": 80462406}}, {"step": 15600, "data": {"cost": 0.46997869}}, {"step": 15600, "data": {"time": 104.51}}, {"step": 15600, "data": {"rate": 421935.12}}, {"step": 15600, "data": {"gnorm": 0.4147}}, {"step": 15700, "data": {"epoch": 3}}, {"step": 15700, "data": {"sen": 82517031}}, {"step": 15700, "data": {"cost": 0.47373977}}, {"step": 15700, "data": {"time": 77.02}}, {"step": 15700, "data": {"rate": 582248.19}}, {"step": 15700, "data": {"gnorm": 0.4226}}, {"step": 15800, "data": {"epoch": 3}}, {"step": 15800, "data": {"sen": 84594197}}, {"step": 15800, "data": {"cost": 0.48098871}}, {"step": 15800, "data": {"time": 77.81}}, {"step": 15800, "data": {"rate": 579768.34}}, {"step": 15800, "data": {"gnorm": 0.4195}}, {"step": 15900, "data": {"epoch": 3}}, {"step": 15900, "data": {"sen": 86572298}}, {"step": 15900, "data": {"cost": 0.4765307}}, {"step": 15900, "data": {"time": 75.78}}, {"step": 15900, "data": {"rate": 578139.52}}, {"step": 15900, "data": {"gnorm": 0.4516}}, {"step": 16000, "data": {"epoch": 3}}, {"step": 16000, "data": {"sen": 88596982}}, {"step": 16000, "data": {"cost": 0.47467619}}, {"step": 16000, "data": {"time": 75.4}}, {"step": 16000, "data": {"rate": 583457.22}}, {"step": 16000, "data": {"gnorm": 0.4336}}, {"step": 16000, "data": {"epoch": 3}}, {"step": 16000, "data": {"perplexity": 9.5513}}, {"step": 16000, "data": {"chrf": 56.3754}}, {"step": 16000, "data": {"ce_mean_words": 2.25668}}, {"step": 16000, "data": {"bleu_detok": 28.8131}}, {"step": 16100, "data": {"epoch": 3}}, {"step": 16100, "data": {"sen": 90731794}}, {"step": 16100, "data": {"cost": 0.47113079}}, {"step": 16100, "data": {"time": 105.04}}, {"step": 16100, "data": {"rate": 425719.06}}, {"step": 16100, "data": {"gnorm": 0.3926}}, {"step": 16200, "data": {"epoch": 3}}, {"step": 16200, "data": {"sen": 92610834}}, {"step": 16200, "data": {"cost": 0.48181129}}, {"step": 16200, "data": {"time": 75.59}}, {"step": 16200, "data": {"rate": 581579.48}}, {"step": 16200, "data": {"gnorm": 0.4852}}, {"step": 16300, "data": {"epoch": 3}}, {"step": 16300, "data": {"sen": 94719324}}, {"step": 16300, "data": {"cost": 0.47987059}}, {"step": 16300, "data": {"time": 77.32}}, {"step": 16300, "data": {"rate": 583982.64}}, {"step": 16300, "data": {"gnorm": 0.4526}}, {"step": 16400, "data": {"epoch": 3}}, {"step": 16400, "data": {"sen": 96765484}}, {"step": 16400, "data": {"cost": 0.4798727}}, {"step": 16400, "data": {"time": 75.87}}, {"step": 16400, "data": {"rate": 589372.74}}, {"step": 16400, "data": {"gnorm": 0.4206}}, {"step": 16500, "data": {"epoch": 3}}, {"step": 16500, "data": {"sen": 98902774}}, {"step": 16500, "data": {"cost": 0.47636414}}, {"step": 16500, "data": {"time": 77.57}}, {"step": 16500, "data": {"rate": 580060.92}}, {"step": 16500, "data": {"gnorm": 0.4195}}, {"step": 16500, "data": {"epoch": 3}}, {"step": 16500, "data": {"perplexity": 9.46918}}, {"step": 16500, "data": {"chrf": 56.1834}}, {"step": 16500, "data": {"ce_mean_words": 2.24804}}, {"step": 16500, "data": {"bleu_detok": 28.7244}}, {"step": 16600, "data": {"epoch": 3}}, {"step": 16600, "data": {"sen": 100851392}}, {"step": 16600, "data": {"cost": 0.48424125}}, {"step": 16600, "data": {"time": 104.38}}, {"step": 16600, "data": {"rate": 422066.08}}, {"step": 16600, "data": {"gnorm": 0.4949}}, {"step": 16700, "data": {"epoch": 3}}, {"step": 16700, "data": {"sen": 102887582}}, {"step": 16700, "data": {"cost": 0.48038274}}, {"step": 16700, "data": {"time": 76.02}}, {"step": 16700, "data": {"rate": 586214.24}}, {"step": 16700, "data": {"gnorm": 0.4304}}, {"step": 16800, "data": {"epoch": 3}}, {"step": 16800, "data": {"sen": 104951959}}, {"step": 16800, "data": {"cost": 0.47021589}}, {"step": 16800, "data": {"time": 76.11}}, {"step": 16800, "data": {"rate": 582376.28}}, {"step": 16800, "data": {"gnorm": 0.3774}}, {"step": 16900, "data": {"epoch": 3}}, {"step": 16900, "data": {"sen": 106977233}}, {"step": 16900, "data": {"cost": 0.48289722}}, {"step": 16900, "data": {"time": 77.16}}, {"step": 16900, "data": {"rate": 585827.13}}, {"step": 16900, "data": {"gnorm": 0.4206}}, {"step": 17000, "data": {"epoch": 3}}, {"step": 17000, "data": {"sen": 108999629}}, {"step": 17000, "data": {"cost": 0.47646508}}, {"step": 17000, "data": {"time": 75.58}}, {"step": 17000, "data": {"rate": 583125.81}}, {"step": 17000, "data": {"gnorm": 0.4517}}, {"step": 17000, "data": {"epoch": 3}}, {"step": 17000, "data": {"perplexity": 9.62203}}, {"step": 17000, "data": {"chrf": 56.1015}}, {"step": 17000, "data": {"ce_mean_words": 2.26406}}, {"step": 17000, "data": {"bleu_detok": 28.2269}}, {"step": 17100, "data": {"epoch": 3}}, {"step": 17100, "data": {"sen": 110971203}}, {"step": 17100, "data": {"cost": 0.48067573}}, {"step": 17100, "data": {"time": 103.05}}, {"step": 17100, "data": {"rate": 419748.13}}, {"step": 17100, "data": {"gnorm": 0.4701}}, {"step": 17200, "data": {"epoch": 3}}, {"step": 17200, "data": {"sen": 112999613}}, {"step": 17200, "data": {"cost": 0.47870857}}, {"step": 17200, "data": {"time": 75.54}}, {"step": 17200, "data": {"rate": 584255.14}}, {"step": 17200, "data": {"gnorm": 0.4414}}, {"step": 17300, "data": {"epoch": 3}}, {"step": 17300, "data": {"sen": 115028024}}, {"step": 17300, "data": {"cost": 0.47173128}}, {"step": 17300, "data": {"time": 75.91}}, {"step": 17300, "data": {"rate": 582010.95}}, {"step": 17300, "data": {"gnorm": 0.4053}}, {"step": 17400, "data": {"epoch": 3}}, {"step": 17400, "data": {"sen": 117054127}}, {"step": 17400, "data": {"cost": 0.47336337}}, {"step": 17400, "data": {"time": 75.67}}, {"step": 17400, "data": {"rate": 590901.73}}, {"step": 17400, "data": {"gnorm": 0.4202}}, {"step": 17500, "data": {"epoch": 4}}, {"step": 17500, "data": {"sen": 1480984}}, {"step": 17500, "data": {"cost": 0.47692963}}, {"step": 17500, "data": {"time": 105.41}}, {"step": 17500, "data": {"rate": 421095.29}}, {"step": 17500, "data": {"gnorm": 0.4256}}, {"step": 17500, "data": {"epoch": 4}}, {"step": 17500, "data": {"perplexity": 9.48157}}, {"step": 17500, "data": {"chrf": 56.2014}}, {"step": 17500, "data": {"ce_mean_words": 2.24935}}, {"step": 17500, "data": {"bleu_detok": 28.8258}}, {"step": 17600, "data": {"epoch": 4}}, {"step": 17600, "data": {"sen": 3526973}}, {"step": 17600, "data": {"cost": 0.47091413}}, {"step": 17600, "data": {"time": 105.85}}, {"step": 17600, "data": {"rate": 424498.69}}, {"step": 17600, "data": {"gnorm": 0.4167}}, {"step": 17700, "data": {"epoch": 4}}, {"step": 17700, "data": {"sen": 5600550}}, {"step": 17700, "data": {"cost": 0.47595051}}, {"step": 17700, "data": {"time": 76.17}}, {"step": 17700, "data": {"rate": 578486.72}}, {"step": 17700, "data": {"gnorm": 0.4375}}, {"step": 17800, "data": {"epoch": 4}}, {"step": 17800, "data": {"sen": 7608083}}, {"step": 17800, "data": {"cost": 0.47765484}}, {"step": 17800, "data": {"time": 77.81}}, {"step": 17800, "data": {"rate": 581657.09}}, {"step": 17800, "data": {"gnorm": 0.4512}}, {"step": 17900, "data": {"epoch": 4}}, {"step": 17900, "data": {"sen": 9699387}}, {"step": 17900, "data": {"cost": 0.46951371}}, {"step": 17900, "data": {"time": 76.18}}, {"step": 17900, "data": {"rate": 582437.9}}, {"step": 17900, "data": {"gnorm": 0.3986}}, {"step": 18000, "data": {"epoch": 4}}, {"step": 18000, "data": {"sen": 11700507}}, {"step": 18000, "data": {"cost": 0.47678539}}, {"step": 18000, "data": {"time": 77.02}}, {"step": 18000, "data": {"rate": 585343.76}}, {"step": 18000, "data": {"gnorm": 0.4318}}, {"step": 18000, "data": {"epoch": 4}}, {"step": 18000, "data": {"perplexity": 9.32908}}, {"step": 18000, "data": {"chrf": 56.2267}}, {"step": 18000, "data": {"ce_mean_words": 2.23314}}, {"step": 18000, "data": {"bleu_detok": 28.7161}}, {"step": 18100, "data": {"epoch": 4}}, {"step": 18100, "data": {"sen": 13751025}}, {"step": 18100, "data": {"cost": 0.48254299}}, {"step": 18100, "data": {"time": 103.52}}, {"step": 18100, "data": {"rate": 423998.91}}, {"step": 18100, "data": {"gnorm": 0.5092}}, {"step": 18200, "data": {"epoch": 4}}, {"step": 18200, "data": {"sen": 15702908}}, {"step": 18200, "data": {"cost": 0.4667525}}, {"step": 18200, "data": {"time": 77.14}}, {"step": 18200, "data": {"rate": 587624.8}}, {"step": 18200, "data": {"gnorm": 0.3814}}, {"step": 18300, "data": {"epoch": 4}}, {"step": 18300, "data": {"sen": 17787408}}, {"step": 18300, "data": {"cost": 0.48447189}}, {"step": 18300, "data": {"time": 75.32}}, {"step": 18300, "data": {"rate": 573576.01}}, {"step": 18300, "data": {"gnorm": 0.4291}}, {"step": 18400, "data": {"epoch": 4}}, {"step": 18400, "data": {"sen": 19823404}}, {"step": 18400, "data": {"cost": 0.47182244}}, {"step": 18400, "data": {"time": 75.91}}, {"step": 18400, "data": {"rate": 579879.43}}, {"step": 18400, "data": {"gnorm": 0.4295}}, {"step": 18500, "data": {"epoch": 4}}, {"step": 18500, "data": {"sen": 21828848}}, {"step": 18500, "data": {"cost": 0.47877741}}, {"step": 18500, "data": {"time": 76.55}}, {"step": 18500, "data": {"rate": 581015.92}}, {"step": 18500, "data": {"gnorm": 0.4354}}, {"step": 18500, "data": {"epoch": 4}}, {"step": 18500, "data": {"perplexity": 9.0907}}, {"step": 18500, "data": {"chrf": 56.208}}, {"step": 18500, "data": {"ce_mean_words": 2.20725}}, {"step": 18500, "data": {"bleu_detok": 28.8047}}, {"step": 18600, "data": {"epoch": 4}}, {"step": 18600, "data": {"sen": 23853257}}, {"step": 18600, "data": {"cost": 0.47310445}}, {"step": 18600, "data": {"time": 104.5}}, {"step": 18600, "data": {"rate": 427147.31}}, {"step": 18600, "data": {"gnorm": 0.4203}}, {"step": 18700, "data": {"epoch": 4}}, {"step": 18700, "data": {"sen": 25930086}}, {"step": 18700, "data": {"cost": 0.474498}}, {"step": 18700, "data": {"time": 76.47}}, {"step": 18700, "data": {"rate": 589523.15}}, {"step": 18700, "data": {"gnorm": 0.4043}}, {"step": 18800, "data": {"epoch": 4}}, {"step": 18800, "data": {"sen": 27999905}}, {"step": 18800, "data": {"cost": 0.48376888}}, {"step": 18800, "data": {"time": 77.64}}, {"step": 18800, "data": {"rate": 583551.1}}, {"step": 18800, "data": {"gnorm": 0.4815}}, {"step": 18900, "data": {"epoch": 4}}, {"step": 18900, "data": {"sen": 30013301}}, {"step": 18900, "data": {"cost": 0.4735831}}, {"step": 18900, "data": {"time": 76.19}}, {"step": 18900, "data": {"rate": 579990.18}}, {"step": 18900, "data": {"gnorm": 0.3977}}, {"step": 19000, "data": {"epoch": 4}}, {"step": 19000, "data": {"sen": 32013988}}, {"step": 19000, "data": {"cost": 0.47513306}}, {"step": 19000, "data": {"time": 75.11}}, {"step": 19000, "data": {"rate": 581926.85}}, {"step": 19000, "data": {"gnorm": 0.4234}}, {"step": 19000, "data": {"epoch": 4}}, {"step": 19000, "data": {"perplexity": 9.82361}}, {"step": 19000, "data": {"chrf": 56.3072}}, {"step": 19000, "data": {"ce_mean_words": 2.28479}}, {"step": 19000, "data": {"bleu_detok": 28.5701}}, {"step": 19100, "data": {"epoch": 4}}, {"step": 19100, "data": {"sen": 34054848}}, {"step": 19100, "data": {"cost": 0.47650492}}, {"step": 19100, "data": {"time": 108.3}}, {"step": 19100, "data": {"rate": 412605.8}}, {"step": 19100, "data": {"gnorm": 0.4211}}, {"step": 19200, "data": {"epoch": 4}}, {"step": 19200, "data": {"sen": 36102336}}, {"step": 19200, "data": {"cost": 0.47795889}}, {"step": 19200, "data": {"time": 76.72}}, {"step": 19200, "data": {"rate": 578273.76}}, {"step": 19200, "data": {"gnorm": 0.434}}, {"step": 19300, "data": {"epoch": 4}}, {"step": 19300, "data": {"sen": 38139526}}, {"step": 19300, "data": {"cost": 0.47741884}}, {"step": 19300, "data": {"time": 77.59}}, {"step": 19300, "data": {"rate": 583233.06}}, {"step": 19300, "data": {"gnorm": 0.4443}}, {"step": 19400, "data": {"epoch": 4}}, {"step": 19400, "data": {"sen": 40198388}}, {"step": 19400, "data": {"cost": 0.47990811}}, {"step": 19400, "data": {"time": 76.13}}, {"step": 19400, "data": {"rate": 579417.2}}, {"step": 19400, "data": {"gnorm": 0.4223}}, {"step": 19500, "data": {"epoch": 4}}, {"step": 19500, "data": {"sen": 42266378}}, {"step": 19500, "data": {"cost": 0.47211689}}, {"step": 19500, "data": {"time": 77.73}}, {"step": 19500, "data": {"rate": 581920.59}}, {"step": 19500, "data": {"gnorm": 0.3941}}, {"step": 19500, "data": {"epoch": 4}}, {"step": 19500, "data": {"perplexity": 9.45106}}, {"step": 19500, "data": {"chrf": 56.2041}}, {"step": 19500, "data": {"ce_mean_words": 2.24613}}, {"step": 19500, "data": {"bleu_detok": 28.6743}}, {"step": 19600, "data": {"epoch": 4}}, {"step": 19600, "data": {"sen": 44320719}}, {"step": 19600, "data": {"cost": 0.47429773}}, {"step": 19600, "data": {"time": 107.7}}, {"step": 19600, "data": {"rate": 412714.84}}, {"step": 19600, "data": {"gnorm": 0.4107}}, {"step": 19700, "data": {"epoch": 4}}, {"step": 19700, "data": {"sen": 46346736}}, {"step": 19700, "data": {"cost": 0.47986162}}, {"step": 19700, "data": {"time": 77.39}}, {"step": 19700, "data": {"rate": 587669.73}}, {"step": 19700, "data": {"gnorm": 0.4507}}, {"step": 19800, "data": {"epoch": 4}}, {"step": 19800, "data": {"sen": 48423579}}, {"step": 19800, "data": {"cost": 0.46999311}}, {"step": 19800, "data": {"time": 76.09}}, {"step": 19800, "data": {"rate": 583455.61}}, {"step": 19800, "data": {"gnorm": 0.3931}}, {"step": 19900, "data": {"epoch": 4}}, {"step": 19900, "data": {"sen": 50421797}}, {"step": 19900, "data": {"cost": 0.47174162}}, {"step": 19900, "data": {"time": 74.97}}, {"step": 19900, "data": {"rate": 587846.64}}, {"step": 19900, "data": {"gnorm": 0.3744}}, {"step": 20000, "data": {"epoch": 4}}, {"step": 20000, "data": {"sen": 52446439}}, {"step": 20000, "data": {"cost": 0.48135871}}, {"step": 20000, "data": {"time": 77.42}}, {"step": 20000, "data": {"rate": 578774.99}}, {"step": 20000, "data": {"gnorm": 0.4504}}, {"step": 20000, "data": {"epoch": 4}}, {"step": 20000, "data": {"perplexity": 9.29394}}, {"step": 20000, "data": {"chrf": 55.9614}}, {"step": 20000, "data": {"ce_mean_words": 2.22936}}, {"step": 20000, "data": {"bleu_detok": 28.8239}}, {"step": 20100, "data": {"epoch": 4}}, {"step": 20100, "data": {"sen": 54422958}}, {"step": 20100, "data": {"cost": 0.47260919}}, {"step": 20100, "data": {"time": 103.18}}, {"step": 20100, "data": {"rate": 425495.55}}, {"step": 20100, "data": {"gnorm": 0.4287}}, {"step": 20200, "data": {"epoch": 4}}, {"step": 20200, "data": {"sen": 56485591}}, {"step": 20200, "data": {"cost": 0.4735091}}, {"step": 20200, "data": {"time": 74.88}}, {"step": 20200, "data": {"rate": 583676.83}}, {"step": 20200, "data": {"gnorm": 0.4085}}, {"step": 20300, "data": {"epoch": 4}}, {"step": 20300, "data": {"sen": 58483522}}, {"step": 20300, "data": {"cost": 0.47610691}}, {"step": 20300, "data": {"time": 76.27}}, {"step": 20300, "data": {"rate": 581827.65}}, {"step": 20300, "data": {"gnorm": 0.4122}}, {"step": 20400, "data": {"epoch": 4}}, {"step": 20400, "data": {"sen": 60538595}}, {"step": 20400, "data": {"cost": 0.47679818}}, {"step": 20400, "data": {"time": 75.26}}, {"step": 20400, "data": {"rate": 575451.05}}, {"step": 20400, "data": {"gnorm": 0.4673}}, {"step": 20500, "data": {"epoch": 4}}, {"step": 20500, "data": {"sen": 62462615}}, {"step": 20500, "data": {"cost": 0.47036618}}, {"step": 20500, "data": {"time": 76.7}}, {"step": 20500, "data": {"rate": 587180.8}}, {"step": 20500, "data": {"gnorm": 0.3953}}, {"step": 20500, "data": {"epoch": 4}}, {"step": 20500, "data": {"perplexity": 9.68364}}, {"step": 20500, "data": {"chrf": 56.3672}}, {"step": 20500, "data": {"ce_mean_words": 2.27044}}, {"step": 20500, "data": {"bleu_detok": 28.5528}}, {"step": 20600, "data": {"epoch": 4}}, {"step": 20600, "data": {"sen": 64600256}}, {"step": 20600, "data": {"cost": 0.47821447}}, {"step": 20600, "data": {"time": 103.79}}, {"step": 20600, "data": {"rate": 417171.41}}, {"step": 20600, "data": {"gnorm": 0.449}}, {"step": 20700, "data": {"epoch": 4}}, {"step": 20700, "data": {"sen": 66588255}}, {"step": 20700, "data": {"cost": 0.4805049}}, {"step": 20700, "data": {"time": 77.81}}, {"step": 20700, "data": {"rate": 583369.32}}, {"step": 20700, "data": {"gnorm": 0.4046}}, {"step": 20800, "data": {"epoch": 4}}, {"step": 20800, "data": {"sen": 68634805}}, {"step": 20800, "data": {"cost": 0.4654941}}, {"step": 20800, "data": {"time": 74.43}}, {"step": 20800, "data": {"rate": 581418.38}}, {"step": 20800, "data": {"gnorm": 0.369}}, {"step": 20900, "data": {"epoch": 4}}, {"step": 20900, "data": {"sen": 70565040}}, {"step": 20900, "data": {"cost": 0.48486909}}, {"step": 20900, "data": {"time": 75.6}}, {"step": 20900, "data": {"rate": 581213.68}}, {"step": 20900, "data": {"gnorm": 0.4392}}, {"step": 21000, "data": {"epoch": 4}}, {"step": 21000, "data": {"sen": 72655658}}, {"step": 21000, "data": {"cost": 0.47220075}}, {"step": 21000, "data": {"time": 76.68}}, {"step": 21000, "data": {"rate": 582675.41}}, {"step": 21000, "data": {"gnorm": 0.3753}}, {"step": 21000, "data": {"epoch": 4}}, {"step": 21000, "data": {"perplexity": 9.53131}}, {"step": 21000, "data": {"chrf": 56.3232}}, {"step": 21000, "data": {"ce_mean_words": 2.25458}}, {"step": 21000, "data": {"bleu_detok": 28.8992}}, {"step": 21100, "data": {"epoch": 4}}, {"step": 21100, "data": {"sen": 74649401}}, {"step": 21100, "data": {"cost": 0.47341245}}, {"step": 21100, "data": {"time": 103.82}}, {"step": 21100, "data": {"rate": 426394.37}}, {"step": 21100, "data": {"gnorm": 0.385}}, {"step": 21200, "data": {"epoch": 4}}, {"step": 21200, "data": {"sen": 76669158}}, {"step": 21200, "data": {"cost": 0.48099446}}, {"step": 21200, "data": {"time": 75.16}}, {"step": 21200, "data": {"rate": 579878.56}}, {"step": 21200, "data": {"gnorm": 0.4155}}, {"step": 21300, "data": {"epoch": 4}}, {"step": 21300, "data": {"sen": 78623908}}, {"step": 21300, "data": {"cost": 0.47789583}}, {"step": 21300, "data": {"time": 76.07}}, {"step": 21300, "data": {"rate": 577534.62}}, {"step": 21300, "data": {"gnorm": 0.4012}}, {"step": 21400, "data": {"epoch": 4}}, {"step": 21400, "data": {"sen": 80745194}}, {"step": 21400, "data": {"cost": 0.4693794}}, {"step": 21400, "data": {"time": 77.09}}, {"step": 21400, "data": {"rate": 587285.57}}, {"step": 21400, "data": {"gnorm": 0.3689}}, {"step": 21500, "data": {"epoch": 4}}, {"step": 21500, "data": {"sen": 82784565}}, {"step": 21500, "data": {"cost": 0.48403752}}, {"step": 21500, "data": {"time": 74.8}}, {"step": 21500, "data": {"rate": 578175.99}}, {"step": 21500, "data": {"gnorm": 0.5415}}, {"step": 21500, "data": {"epoch": 4}}, {"step": 21500, "data": {"perplexity": 9.92363}}, {"step": 21500, "data": {"chrf": 55.7172}}, {"step": 21500, "data": {"ce_mean_words": 2.29492}}, {"step": 21500, "data": {"bleu_detok": 28.1072}}, {"step": 21600, "data": {"epoch": 4}}, {"step": 21600, "data": {"sen": 84814669}}, {"step": 21600, "data": {"cost": 0.47800669}}, {"step": 21600, "data": {"time": 104.36}}, {"step": 21600, "data": {"rate": 430076.5}}, {"step": 21600, "data": {"gnorm": 0.4189}}, {"step": 21700, "data": {"epoch": 4}}, {"step": 21700, "data": {"sen": 86845556}}, {"step": 21700, "data": {"cost": 0.47247571}}, {"step": 21700, "data": {"time": 75.85}}, {"step": 21700, "data": {"rate": 584144.8}}, {"step": 21700, "data": {"gnorm": 0.4126}}, {"step": 21800, "data": {"epoch": 4}}, {"step": 21800, "data": {"sen": 88917569}}, {"step": 21800, "data": {"cost": 0.47969043}}, {"step": 21800, "data": {"time": 77.31}}, {"step": 21800, "data": {"rate": 583844.61}}, {"step": 21800, "data": {"gnorm": 0.4611}}, {"step": 21900, "data": {"epoch": 4}}, {"step": 21900, "data": {"sen": 90918780}}, {"step": 21900, "data": {"cost": 0.48129776}}, {"step": 21900, "data": {"time": 74.89}}, {"step": 21900, "data": {"rate": 584033.0}}, {"step": 21900, "data": {"gnorm": 0.426}}, {"step": 22000, "data": {"epoch": 4}}, {"step": 22000, "data": {"sen": 92923469}}, {"step": 22000, "data": {"cost": 0.47230512}}, {"step": 22000, "data": {"time": 75.68}}, {"step": 22000, "data": {"rate": 582390.53}}, {"step": 22000, "data": {"gnorm": 0.3925}}, {"step": 22000, "data": {"epoch": 4}}, {"step": 22000, "data": {"perplexity": 9.0497}}, {"step": 22000, "data": {"chrf": 56.136}}, {"step": 22000, "data": {"ce_mean_words": 2.20273}}, {"step": 22000, "data": {"bleu_detok": 28.6788}}, {"step": 22100, "data": {"epoch": 4}}, {"step": 22100, "data": {"sen": 94926508}}, {"step": 22100, "data": {"cost": 0.49688643}}, {"step": 22100, "data": {"time": 104.96}}, {"step": 22100, "data": {"rate": 415318.78}}, {"step": 22100, "data": {"gnorm": 0.5032}}, {"step": 22200, "data": {"epoch": 4}}, {"step": 22200, "data": {"sen": 96931722}}, {"step": 22200, "data": {"cost": 0.46518004}}, {"step": 22200, "data": {"time": 75.28}}, {"step": 22200, "data": {"rate": 582106.8}}, {"step": 22200, "data": {"gnorm": 0.3573}}, {"step": 22300, "data": {"epoch": 4}}, {"step": 22300, "data": {"sen": 98932849}}, {"step": 22300, "data": {"cost": 0.47355267}}, {"step": 22300, "data": {"time": 76.56}}, {"step": 22300, "data": {"rate": 581625.94}}, {"step": 22300, "data": {"gnorm": 0.3889}}, {"step": 22400, "data": {"epoch": 4}}, {"step": 22400, "data": {"sen": 100975231}}, {"step": 22400, "data": {"cost": 0.49106917}}, {"step": 22400, "data": {"time": 74.6}}, {"step": 22400, "data": {"rate": 589413.15}}, {"step": 22400, "data": {"gnorm": 0.4928}}, {"step": 22500, "data": {"epoch": 4}}, {"step": 22500, "data": {"sen": 102966851}}, {"step": 22500, "data": {"cost": 0.47297055}}, {"step": 22500, "data": {"time": 76.26}}, {"step": 22500, "data": {"rate": 580897.44}}, {"step": 22500, "data": {"gnorm": 0.3873}}, {"step": 22500, "data": {"epoch": 4}}, {"step": 22500, "data": {"perplexity": 9.20448}}, {"step": 22500, "data": {"chrf": 56.3469}}, {"step": 22500, "data": {"ce_mean_words": 2.21969}}, {"step": 22500, "data": {"bleu_detok": 28.9611}}, {"step": 22600, "data": {"epoch": 4}}, {"step": 22600, "data": {"sen": 104999634}}, {"step": 22600, "data": {"cost": 0.46815878}}, {"step": 22600, "data": {"time": 103.52}}, {"step": 22600, "data": {"rate": 425960.75}}, {"step": 22600, "data": {"gnorm": 0.3813}}, {"step": 22700, "data": {"epoch": 4}}, {"step": 22700, "data": {"sen": 107008974}}, {"step": 22700, "data": {"cost": 0.47777727}}, {"step": 22700, "data": {"time": 75.62}}, {"step": 22700, "data": {"rate": 584597.08}}, {"step": 22700, "data": {"gnorm": 0.4121}}, {"step": 22800, "data": {"epoch": 4}}, {"step": 22800, "data": {"sen": 109026232}}, {"step": 22800, "data": {"cost": 0.47281483}}, {"step": 22800, "data": {"time": 74.59}}, {"step": 22800, "data": {"rate": 583897.11}}, {"step": 22800, "data": {"gnorm": 0.394}}, {"step": 22900, "data": {"epoch": 4}}, {"step": 22900, "data": {"sen": 111104995}}, {"step": 22900, "data": {"cost": 0.4728753}}, {"step": 22900, "data": {"time": 76.59}}, {"step": 22900, "data": {"rate": 581945.74}}, {"step": 22900, "data": {"gnorm": 0.4004}}, {"step": 23000, "data": {"epoch": 4}}, {"step": 23000, "data": {"sen": 113113340}}, {"step": 23000, "data": {"cost": 0.47935024}}, {"step": 23000, "data": {"time": 75.67}}, {"step": 23000, "data": {"rate": 583807.78}}, {"step": 23000, "data": {"gnorm": 0.4562}}, {"step": 23000, "data": {"epoch": 4}}, {"step": 23000, "data": {"perplexity": 9.56825}}, {"step": 23000, "data": {"chrf": 55.7366}}, {"step": 23000, "data": {"ce_mean_words": 2.25845}}, {"step": 23000, "data": {"bleu_detok": 28.1397}}, {"step": 23100, "data": {"epoch": 4}}, {"step": 23100, "data": {"sen": 115052724}}, {"step": 23100, "data": {"cost": 0.47350657}}, {"step": 23100, "data": {"time": 107.78}}, {"step": 23100, "data": {"rate": 411354.81}}, {"step": 23100, "data": {"gnorm": 0.3719}}, {"step": 23200, "data": {"epoch": 4}}, {"step": 23200, "data": {"sen": 117125785}}, {"step": 23200, "data": {"cost": 0.47413418}}, {"step": 23200, "data": {"time": 74.06}}, {"step": 23200, "data": {"rate": 588562.84}}, {"step": 23200, "data": {"gnorm": 0.3843}}, {"step": 23300, "data": {"epoch": 5}}, {"step": 23300, "data": {"sen": 1442710}}, {"step": 23300, "data": {"cost": 0.47374704}}, {"step": 23300, "data": {"time": 104.47}}, {"step": 23300, "data": {"rate": 413355.77}}, {"step": 23300, "data": {"gnorm": 0.4326}}, {"step": 23400, "data": {"epoch": 5}}, {"step": 23400, "data": {"sen": 3360755}}, {"step": 23400, "data": {"cost": 0.46994328}}, {"step": 23400, "data": {"time": 75.06}}, {"step": 23400, "data": {"rate": 587849.02}}, {"step": 23400, "data": {"gnorm": 0.4069}}, {"step": 23500, "data": {"epoch": 5}}, {"step": 23500, "data": {"sen": 5470869}}, {"step": 23500, "data": {"cost": 0.47480464}}, {"step": 23500, "data": {"time": 75.66}}, {"step": 23500, "data": {"rate": 579371.16}}, {"step": 23500, "data": {"gnorm": 0.4053}}, {"step": 23500, "data": {"epoch": 5}}, {"step": 23500, "data": {"perplexity": 9.50897}}, {"step": 23500, "data": {"chrf": 56.09}}, {"step": 23500, "data": {"ce_mean_words": 2.25224}}, {"step": 23500, "data": {"bleu_detok": 28.7452}}, {"step": 23600, "data": {"epoch": 5}}, {"step": 23600, "data": {"sen": 7455041}}, {"step": 23600, "data": {"cost": 0.46992564}}, {"step": 23600, "data": {"time": 103.52}}, {"step": 23600, "data": {"rate": 422248.42}}, {"step": 23600, "data": {"gnorm": 0.404}}, {"step": 23700, "data": {"epoch": 5}}, {"step": 23700, "data": {"sen": 9439355}}, {"step": 23700, "data": {"cost": 0.47418058}}, {"step": 23700, "data": {"time": 76.81}}, {"step": 23700, "data": {"rate": 585134.15}}, {"step": 23700, "data": {"gnorm": 0.3896}}, {"step": 23800, "data": {"epoch": 5}}, {"step": 23800, "data": {"sen": 11545327}}, {"step": 23800, "data": {"cost": 0.47194257}}, {"step": 23800, "data": {"time": 76.15}}, {"step": 23800, "data": {"rate": 577856.65}}, {"step": 23800, "data": {"gnorm": 0.4095}}, {"step": 23900, "data": {"epoch": 5}}, {"step": 23900, "data": {"sen": 13569568}}, {"step": 23900, "data": {"cost": 0.47448057}}, {"step": 23900, "data": {"time": 75.3}}, {"step": 23900, "data": {"rate": 581011.31}}, {"step": 23900, "data": {"gnorm": 0.433}}, {"step": 24000, "data": {"epoch": 5}}, {"step": 24000, "data": {"sen": 15541047}}, {"step": 24000, "data": {"cost": 0.46767649}}, {"step": 24000, "data": {"time": 76.85}}, {"step": 24000, "data": {"rate": 582807.67}}, {"step": 24000, "data": {"gnorm": 0.3715}}, {"step": 24000, "data": {"epoch": 5}}, {"step": 24000, "data": {"perplexity": 9.30011}}, {"step": 24000, "data": {"chrf": 56.213}}, {"step": 24000, "data": {"ce_mean_words": 2.23003}}, {"step": 24000, "data": {"bleu_detok": 28.8377}}, {"step": 24100, "data": {"epoch": 5}}, {"step": 24100, "data": {"sen": 17648354}}, {"step": 24100, "data": {"cost": 0.46975702}}, {"step": 24100, "data": {"time": 105.2}}, {"step": 24100, "data": {"rate": 425517.91}}, {"step": 24100, "data": {"gnorm": 0.3882}}, {"step": 24200, "data": {"epoch": 5}}, {"step": 24200, "data": {"sen": 19712650}}, {"step": 24200, "data": {"cost": 0.4740895}}, {"step": 24200, "data": {"time": 77.48}}, {"step": 24200, "data": {"rate": 585088.52}}, {"step": 24200, "data": {"gnorm": 0.3906}}, {"step": 24300, "data": {"epoch": 5}}, {"step": 24300, "data": {"sen": 21656075}}, {"step": 24300, "data": {"cost": 0.47156057}}, {"step": 24300, "data": {"time": 75.18}}, {"step": 24300, "data": {"rate": 581693.19}}, {"step": 24300, "data": {"gnorm": 0.3781}}, {"step": 24400, "data": {"epoch": 5}}, {"step": 24400, "data": {"sen": 23739819}}, {"step": 24400, "data": {"cost": 0.4710955}}, {"step": 24400, "data": {"time": 74.73}}, {"step": 24400, "data": {"rate": 577399.82}}, {"step": 24400, "data": {"gnorm": 0.3844}}, {"step": 24500, "data": {"epoch": 5}}, {"step": 24500, "data": {"sen": 25710861}}, {"step": 24500, "data": {"cost": 0.4724445}}, {"step": 24500, "data": {"time": 76.13}}, {"step": 24500, "data": {"rate": 584522.89}}, {"step": 24500, "data": {"gnorm": 0.3999}}, {"step": 24500, "data": {"epoch": 5}}, {"step": 24500, "data": {"perplexity": 9.56461}}, {"step": 24500, "data": {"chrf": 55.5645}}, {"step": 24500, "data": {"ce_mean_words": 2.25807}}, {"step": 24500, "data": {"bleu_detok": 28.0782}}, {"step": 24600, "data": {"epoch": 5}}, {"step": 24600, "data": {"sen": 27682087}}, {"step": 24600, "data": {"cost": 0.47136596}}, {"step": 24600, "data": {"time": 103.7}}, {"step": 24600, "data": {"rate": 422558.37}}, {"step": 24600, "data": {"gnorm": 0.4157}}, {"step": 24700, "data": {"epoch": 5}}, {"step": 24700, "data": {"sen": 29794073}}, {"step": 24700, "data": {"cost": 0.47220996}}, {"step": 24700, "data": {"time": 76.27}}, {"step": 24700, "data": {"rate": 581401.11}}, {"step": 24700, "data": {"gnorm": 0.4015}}, {"step": 24800, "data": {"epoch": 5}}, {"step": 24800, "data": {"sen": 31845076}}, {"step": 24800, "data": {"cost": 0.4813982}}, {"step": 24800, "data": {"time": 76.87}}, {"step": 24800, "data": {"rate": 586749.37}}, {"step": 24800, "data": {"gnorm": 0.4758}}, {"step": 24900, "data": {"epoch": 5}}, {"step": 24900, "data": {"sen": 33880769}}, {"step": 24900, "data": {"cost": 0.47370744}}, {"step": 24900, "data": {"time": 75.9}}, {"step": 24900, "data": {"rate": 579112.42}}, {"step": 24900, "data": {"gnorm": 0.4069}}, {"step": 25000, "data": {"epoch": 5}}, {"step": 25000, "data": {"sen": 35802786}}, {"step": 25000, "data": {"cost": 0.4671416}}, {"step": 25000, "data": {"time": 76.13}}, {"step": 25000, "data": {"rate": 595378.64}}, {"step": 25000, "data": {"gnorm": 0.3616}}, {"step": 25000, "data": {"epoch": 5}}, {"step": 25000, "data": {"perplexity": 9.43729}}, {"step": 25000, "data": {"chrf": 56.4697}}, {"step": 25000, "data": {"ce_mean_words": 2.24467}}, {"step": 25000, "data": {"bleu_detok": 28.9544}}, {"step": 25100, "data": {"epoch": 5}}, {"step": 25100, "data": {"sen": 37911065}}, {"step": 25100, "data": {"cost": 0.47847483}}, {"step": 25100, "data": {"time": 101.61}}, {"step": 25100, "data": {"rate": 420550.74}}, {"step": 25100, "data": {"gnorm": 0.447}}, {"step": 25200, "data": {"epoch": 5}}, {"step": 25200, "data": {"sen": 39971069}}, {"step": 25200, "data": {"cost": 0.47760281}}, {"step": 25200, "data": {"time": 76.47}}, {"step": 25200, "data": {"rate": 584996.94}}, {"step": 25200, "data": {"gnorm": 0.3945}}, {"step": 25300, "data": {"epoch": 5}}, {"step": 25300, "data": {"sen": 41999862}}, {"step": 25300, "data": {"cost": 0.46821919}}, {"step": 25300, "data": {"time": 77.31}}, {"step": 25300, "data": {"rate": 585040.86}}, {"step": 25300, "data": {"gnorm": 0.3858}}, {"step": 25400, "data": {"epoch": 5}}, {"step": 25400, "data": {"sen": 43989425}}, {"step": 25400, "data": {"cost": 0.48704341}}, {"step": 25400, "data": {"time": 74.62}}, {"step": 25400, "data": {"rate": 579190.69}}, {"step": 25400, "data": {"gnorm": 0.4321}}, {"step": 25500, "data": {"epoch": 5}}, {"step": 25500, "data": {"sen": 45991401}}, {"step": 25500, "data": {"cost": 0.46704391}}, {"step": 25500, "data": {"time": 74.99}}, {"step": 25500, "data": {"rate": 581691.49}}, {"step": 25500, "data": {"gnorm": 0.3745}}, {"step": 25500, "data": {"epoch": 5}}, {"step": 25500, "data": {"perplexity": 9.2425}}, {"step": 25500, "data": {"chrf": 56.0064}}, {"step": 25500, "data": {"ce_mean_words": 2.22381}}, {"step": 25500, "data": {"bleu_detok": 28.5233}}, {"step": 25600, "data": {"epoch": 5}}, {"step": 25600, "data": {"sen": 47999845}}, {"step": 25600, "data": {"cost": 0.4759658}}, {"step": 25600, "data": {"time": 104.34}}, {"step": 25600, "data": {"rate": 423921.66}}, {"step": 25600, "data": {"gnorm": 0.3862}}, {"step": 25700, "data": {"epoch": 5}}, {"step": 25700, "data": {"sen": 50040641}}, {"step": 25700, "data": {"cost": 0.47374931}}, {"step": 25700, "data": {"time": 76.32}}, {"step": 25700, "data": {"rate": 583959.84}}, {"step": 25700, "data": {"gnorm": 0.3919}}, {"step": 25800, "data": {"epoch": 5}}, {"step": 25800, "data": {"sen": 52077468}}, {"step": 25800, "data": {"cost": 0.47225434}}, {"step": 25800, "data": {"time": 76.38}}, {"step": 25800, "data": {"rate": 584021.65}}, {"step": 25800, "data": {"gnorm": 0.3919}}, {"step": 25900, "data": {"epoch": 5}}, {"step": 25900, "data": {"sen": 54071276}}, {"step": 25900, "data": {"cost": 0.47661442}}, {"step": 25900, "data": {"time": 74.72}}, {"step": 25900, "data": {"rate": 579013.8}}, {"step": 25900, "data": {"gnorm": 0.4617}}, {"step": 26000, "data": {"epoch": 5}}, {"step": 26000, "data": {"sen": 56089913}}, {"step": 26000, "data": {"cost": 0.46921775}}, {"step": 26000, "data": {"time": 76.61}}, {"step": 26000, "data": {"rate": 581186.64}}, {"step": 26000, "data": {"gnorm": 0.3729}}, {"step": 26000, "data": {"epoch": 5}}, {"step": 26000, "data": {"perplexity": 9.74225}}, {"step": 26000, "data": {"chrf": 56.3065}}, {"step": 26000, "data": {"ce_mean_words": 2.27647}}, {"step": 26000, "data": {"bleu_detok": 28.569}}, {"step": 26100, "data": {"epoch": 5}}, {"step": 26100, "data": {"sen": 58151204}}, {"step": 26100, "data": {"cost": 0.47245178}}, {"step": 26100, "data": {"time": 109.36}}, {"step": 26100, "data": {"rate": 413567.89}}, {"step": 26100, "data": {"gnorm": 0.3767}}, {"step": 26200, "data": {"epoch": 5}}, {"step": 26200, "data": {"sen": 60230980}}, {"step": 26200, "data": {"cost": 0.4715853}}, {"step": 26200, "data": {"time": 74.92}}, {"step": 26200, "data": {"rate": 583654.74}}, {"step": 26200, "data": {"gnorm": 0.3986}}, {"step": 26300, "data": {"epoch": 5}}, {"step": 26300, "data": {"sen": 62176493}}, {"step": 26300, "data": {"cost": 0.47163433}}, {"step": 26300, "data": {"time": 76.17}}, {"step": 26300, "data": {"rate": 584631.84}}, {"step": 26300, "data": {"gnorm": 0.3539}}, {"step": 26400, "data": {"epoch": 5}}, {"step": 26400, "data": {"sen": 64268047}}, {"step": 26400, "data": {"cost": 0.47099233}}, {"step": 26400, "data": {"time": 75.74}}, {"step": 26400, "data": {"rate": 585092.64}}, {"step": 26400, "data": {"gnorm": 0.3793}}, {"step": 26500, "data": {"epoch": 5}}, {"step": 26500, "data": {"sen": 66368527}}, {"step": 26500, "data": {"cost": 0.47744834}}, {"step": 26500, "data": {"time": 76.41}}, {"step": 26500, "data": {"rate": 581498.06}}, {"step": 26500, "data": {"gnorm": 0.4153}}, {"step": 26500, "data": {"epoch": 5}}, {"step": 26500, "data": {"perplexity": 9.24925}}, {"step": 26500, "data": {"chrf": 55.9755}}, {"step": 26500, "data": {"ce_mean_words": 2.22454}}, {"step": 26500, "data": {"bleu_detok": 28.5708}}, {"step": 26600, "data": {"epoch": 5}}, {"step": 26600, "data": {"sen": 68290733}}, {"step": 26600, "data": {"cost": 0.47429317}}, {"step": 26600, "data": {"time": 105.56}}, {"step": 26600, "data": {"rate": 416675.8}}, {"step": 26600, "data": {"gnorm": 0.4022}}, {"step": 26700, "data": {"epoch": 5}}, {"step": 26700, "data": {"sen": 70287306}}, {"step": 26700, "data": {"cost": 0.47963434}}, {"step": 26700, "data": {"time": 75.31}}, {"step": 26700, "data": {"rate": 581165.11}}, {"step": 26700, "data": {"gnorm": 0.4092}}, {"step": 26800, "data": {"epoch": 5}}, {"step": 26800, "data": {"sen": 72292638}}, {"step": 26800, "data": {"cost": 0.4737342}}, {"step": 26800, "data": {"time": 74.84}}, {"step": 26800, "data": {"rate": 579396.42}}, {"step": 26800, "data": {"gnorm": 0.4052}}, {"step": 26900, "data": {"epoch": 5}}, {"step": 26900, "data": {"sen": 74246819}}, {"step": 26900, "data": {"cost": 0.47709998}}, {"step": 26900, "data": {"time": 74.61}}, {"step": 26900, "data": {"rate": 582866.61}}, {"step": 26900, "data": {"gnorm": 0.4074}}, {"step": 27000, "data": {"epoch": 5}}, {"step": 27000, "data": {"sen": 76263194}}, {"step": 27000, "data": {"cost": 0.46942705}}, {"step": 27000, "data": {"time": 77.53}}, {"step": 27000, "data": {"rate": 586771.22}}, {"step": 27000, "data": {"gnorm": 0.36}}, {"step": 27000, "data": {"epoch": 5}}, {"step": 27000, "data": {"perplexity": 9.5043}}, {"step": 27000, "data": {"chrf": 56.2391}}, {"step": 27000, "data": {"ce_mean_words": 2.25174}}, {"step": 27000, "data": {"bleu_detok": 28.7538}}, {"step": 27100, "data": {"epoch": 5}}, {"step": 27100, "data": {"sen": 78361623}}, {"step": 27100, "data": {"cost": 0.47348094}}, {"step": 27100, "data": {"time": 105.58}}, {"step": 27100, "data": {"rate": 417323.03}}, {"step": 27100, "data": {"gnorm": 0.3596}}, {"step": 27200, "data": {"epoch": 5}}, {"step": 27200, "data": {"sen": 80397690}}, {"step": 27200, "data": {"cost": 0.46760589}}, {"step": 27200, "data": {"time": 75.4}}, {"step": 27200, "data": {"rate": 586307.27}}, {"step": 27200, "data": {"gnorm": 0.35}}, {"step": 27300, "data": {"epoch": 5}}, {"step": 27300, "data": {"sen": 82487753}}, {"step": 27300, "data": {"cost": 0.47541919}}, {"step": 27300, "data": {"time": 76.39}}, {"step": 27300, "data": {"rate": 574456.48}}, {"step": 27300, "data": {"gnorm": 0.3863}}, {"step": 27400, "data": {"epoch": 5}}, {"step": 27400, "data": {"sen": 84462139}}, {"step": 27400, "data": {"cost": 0.47592857}}, {"step": 27400, "data": {"time": 77.43}}, {"step": 27400, "data": {"rate": 588286.63}}, {"step": 27400, "data": {"gnorm": 0.4163}}, {"step": 27500, "data": {"epoch": 5}}, {"step": 27500, "data": {"sen": 86489132}}, {"step": 27500, "data": {"cost": 0.47397634}}, {"step": 27500, "data": {"time": 77.15}}, {"step": 27500, "data": {"rate": 576875.31}}, {"step": 27500, "data": {"gnorm": 0.3802}}, {"step": 27500, "data": {"epoch": 5}}, {"step": 27500, "data": {"perplexity": 9.15246}}, {"step": 27500, "data": {"chrf": 56.1179}}, {"step": 27500, "data": {"ce_mean_words": 2.21402}}, {"step": 27500, "data": {"bleu_detok": 28.7277}}, {"step": 27600, "data": {"epoch": 5}}, {"step": 27600, "data": {"sen": 88444764}}, {"step": 27600, "data": {"cost": 0.46742699}}, {"step": 27600, "data": {"time": 102.46}}, {"step": 27600, "data": {"rate": 423206.42}}, {"step": 27600, "data": {"gnorm": 0.388}}, {"step": 27700, "data": {"epoch": 5}}, {"step": 27700, "data": {"sen": 90442222}}, {"step": 27700, "data": {"cost": 0.47142285}}, {"step": 27700, "data": {"time": 75.41}}, {"step": 27700, "data": {"rate": 583133.77}}, {"step": 27700, "data": {"gnorm": 0.3451}}, {"step": 27800, "data": {"epoch": 5}}, {"step": 27800, "data": {"sen": 92475487}}, {"step": 27800, "data": {"cost": 0.47490439}}, {"step": 27800, "data": {"time": 76.35}}, {"step": 27800, "data": {"rate": 583126.25}}, {"step": 27800, "data": {"gnorm": 0.3725}}, {"step": 27900, "data": {"epoch": 5}}, {"step": 27900, "data": {"sen": 94557890}}, {"step": 27900, "data": {"cost": 0.47821912}}, {"step": 27900, "data": {"time": 75.07}}, {"step": 27900, "data": {"rate": 583428.67}}, {"step": 27900, "data": {"gnorm": 0.4125}}, {"step": 28000, "data": {"epoch": 5}}, {"step": 28000, "data": {"sen": 96610941}}, {"step": 28000, "data": {"cost": 0.47505906}}, {"step": 28000, "data": {"time": 76.73}}, {"step": 28000, "data": {"rate": 590665.27}}, {"step": 28000, "data": {"gnorm": 0.3717}}, {"step": 28000, "data": {"epoch": 5}}, {"step": 28000, "data": {"perplexity": 9.40343}}, {"step": 28000, "data": {"chrf": 56.0086}}, {"step": 28000, "data": {"ce_mean_words": 2.24108}}, {"step": 28000, "data": {"bleu_detok": 28.7308}}, {"step": 28100, "data": {"epoch": 5}}, {"step": 28100, "data": {"sen": 98632437}}, {"step": 28100, "data": {"cost": 0.47137201}}, {"step": 28100, "data": {"time": 105.63}}, {"step": 28100, "data": {"rate": 425541.53}}, {"step": 28100, "data": {"gnorm": 0.3557}}, {"step": 28200, "data": {"epoch": 5}}, {"step": 28200, "data": {"sen": 100688582}}, {"step": 28200, "data": {"cost": 0.47993022}}, {"step": 28200, "data": {"time": 75.75}}, {"step": 28200, "data": {"rate": 577239.34}}, {"step": 28200, "data": {"gnorm": 0.4125}}, {"step": 28300, "data": {"epoch": 5}}, {"step": 28300, "data": {"sen": 102674365}}, {"step": 28300, "data": {"cost": 0.46624178}}, {"step": 28300, "data": {"time": 74.5}}, {"step": 28300, "data": {"rate": 593026.97}}, {"step": 28300, "data": {"gnorm": 0.376}}, {"step": 28400, "data": {"epoch": 5}}, {"step": 28400, "data": {"sen": 104752728}}, {"step": 28400, "data": {"cost": 0.47804269}}, {"step": 28400, "data": {"time": 76.89}}, {"step": 28400, "data": {"rate": 581731.59}}, {"step": 28400, "data": {"gnorm": 0.3787}}, {"step": 28500, "data": {"epoch": 5}}, {"step": 28500, "data": {"sen": 106732175}}, {"step": 28500, "data": {"cost": 0.47637525}}, {"step": 28500, "data": {"time": 76.02}}, {"step": 28500, "data": {"rate": 584376.41}}, {"step": 28500, "data": {"gnorm": 0.3797}}, {"step": 28500, "data": {"epoch": 5}}, {"step": 28500, "data": {"perplexity": 9.50043}}, {"step": 28500, "data": {"chrf": 56.2485}}, {"step": 28500, "data": {"ce_mean_words": 2.25134}}, {"step": 28500, "data": {"bleu_detok": 28.6929}}, {"step": 28600, "data": {"epoch": 5}}, {"step": 28600, "data": {"sen": 108833070}}, {"step": 28600, "data": {"cost": 0.48193774}}, {"step": 28600, "data": {"time": 102.29}}, {"step": 28600, "data": {"rate": 417108.99}}, {"step": 28600, "data": {"gnorm": 0.4288}}, {"step": 28700, "data": {"epoch": 5}}, {"step": 28700, "data": {"sen": 110816259}}, {"step": 28700, "data": {"cost": 0.47197807}}, {"step": 28700, "data": {"time": 75.44}}, {"step": 28700, "data": {"rate": 584956.03}}, {"step": 28700, "data": {"gnorm": 0.4097}}, {"step": 28800, "data": {"epoch": 5}}, {"step": 28800, "data": {"sen": 112826414}}, {"step": 28800, "data": {"cost": 0.47193605}}, {"step": 28800, "data": {"time": 75.94}}, {"step": 28800, "data": {"rate": 584788.24}}, {"step": 28800, "data": {"gnorm": 0.376}}, {"step": 28900, "data": {"epoch": 5}}, {"step": 28900, "data": {"sen": 114850871}}, {"step": 28900, "data": {"cost": 0.47788286}}, {"step": 28900, "data": {"time": 77.78}}, {"step": 28900, "data": {"rate": 581796.33}}, {"step": 28900, "data": {"gnorm": 0.3974}}, {"step": 29000, "data": {"epoch": 5}}, {"step": 29000, "data": {"sen": 116926670}}, {"step": 29000, "data": {"cost": 0.47548437}}, {"step": 29000, "data": {"time": 75.79}}, {"step": 29000, "data": {"rate": 587310.44}}, {"step": 29000, "data": {"gnorm": 0.4166}}, {"step": 29000, "data": {"epoch": 5}}, {"step": 29000, "data": {"perplexity": 9.21096}}, {"step": 29000, "data": {"chrf": 56.3682}}, {"step": 29000, "data": {"ce_mean_words": 2.22039}}, {"step": 29000, "data": {"bleu_detok": 28.9228}}, {"step": 29100, "data": {"epoch": 6}}, {"step": 29100, "data": {"sen": 1333581}}, {"step": 29100, "data": {"cost": 0.46966952}}, {"step": 29100, "data": {"time": 132.86}}, {"step": 29100, "data": {"rate": 335959.86}}, {"step": 29100, "data": {"gnorm": 0.395}}, {"step": 29200, "data": {"epoch": 6}}, {"step": 29200, "data": {"sen": 3293400}}, {"step": 29200, "data": {"cost": 0.46503839}}, {"step": 29200, "data": {"time": 75.65}}, {"step": 29200, "data": {"rate": 581739.62}}, {"step": 29200, "data": {"gnorm": 0.3448}}, {"step": 29300, "data": {"epoch": 6}}, {"step": 29300, "data": {"sen": 5341022}}, {"step": 29300, "data": {"cost": 0.47273311}}, {"step": 29300, "data": {"time": 75.72}}, {"step": 29300, "data": {"rate": 586295.58}}, {"step": 29300, "data": {"gnorm": 0.3926}}, {"step": 29400, "data": {"epoch": 6}}, {"step": 29400, "data": {"sen": 7412116}}, {"step": 29400, "data": {"cost": 0.46999809}}, {"step": 29400, "data": {"time": 75.72}}, {"step": 29400, "data": {"rate": 579008.38}}, {"step": 29400, "data": {"gnorm": 0.3573}}, {"step": 29500, "data": {"epoch": 6}}, {"step": 29500, "data": {"sen": 9375112}}, {"step": 29500, "data": {"cost": 0.47253028}}, {"step": 29500, "data": {"time": 75.65}}, {"step": 29500, "data": {"rate": 587600.22}}, {"step": 29500, "data": {"gnorm": 0.3742}}, {"step": 29500, "data": {"epoch": 6}}, {"step": 29500, "data": {"perplexity": 9.34545}}, {"step": 29500, "data": {"chrf": 56.18}}, {"step": 29500, "data": {"ce_mean_words": 2.23489}}, {"step": 29500, "data": {"bleu_detok": 28.9495}}, {"step": 29600, "data": {"epoch": 6}}, {"step": 29600, "data": {"sen": 11430517}}, {"step": 29600, "data": {"cost": 0.47268033}}, {"step": 29600, "data": {"time": 106.88}}, {"step": 29600, "data": {"rate": 420453.89}}, {"step": 29600, "data": {"gnorm": 0.3631}}, {"step": 29700, "data": {"epoch": 6}}, {"step": 29700, "data": {"sen": 13463032}}, {"step": 29700, "data": {"cost": 0.47030401}}, {"step": 29700, "data": {"time": 73.7}}, {"step": 29700, "data": {"rate": 578995.1}}, {"step": 29700, "data": {"gnorm": 0.3736}}, {"step": 29800, "data": {"epoch": 6}}, {"step": 29800, "data": {"sen": 15518559}}, {"step": 29800, "data": {"cost": 0.47908771}}, {"step": 29800, "data": {"time": 77.51}}, {"step": 29800, "data": {"rate": 578773.73}}, {"step": 29800, "data": {"gnorm": 0.4376}}, {"step": 29900, "data": {"epoch": 6}}, {"step": 29900, "data": {"sen": 17566166}}, {"step": 29900, "data": {"cost": 0.46783257}}, {"step": 29900, "data": {"time": 77.46}}, {"step": 29900, "data": {"rate": 590623.58}}, {"step": 29900, "data": {"gnorm": 0.373}}, {"step": 30000, "data": {"epoch": 6}}, {"step": 30000, "data": {"sen": 19618174}}, {"step": 30000, "data": {"cost": 0.4735083}}, {"step": 30000, "data": {"time": 75.63}}, {"step": 30000, "data": {"rate": 580181.14}}, {"step": 30000, "data": {"gnorm": 0.3677}}, {"step": 30000, "data": {"epoch": 6}}, {"step": 30000, "data": {"perplexity": 9.2881}}, {"step": 30000, "data": {"chrf": 56.45}}, {"step": 30000, "data": {"ce_mean_words": 2.22873}}, {"step": 30000, "data": {"bleu_detok": 28.9423}}, {"step": 30100, "data": {"epoch": 6}}, {"step": 30100, "data": {"sen": 21679609}}, {"step": 30100, "data": {"cost": 0.47252882}}, {"step": 30100, "data": {"time": 106.66}}, {"step": 30100, "data": {"rate": 425754.75}}, {"step": 30100, "data": {"gnorm": 0.3702}}, {"step": 30200, "data": {"epoch": 6}}, {"step": 30200, "data": {"sen": 23659774}}, {"step": 30200, "data": {"cost": 0.4667708}}, {"step": 30200, "data": {"time": 76.25}}, {"step": 30200, "data": {"rate": 582840.03}}, {"step": 30200, "data": {"gnorm": 0.3432}}, {"step": 30300, "data": {"epoch": 6}}, {"step": 30300, "data": {"sen": 25654044}}, {"step": 30300, "data": {"cost": 0.46850276}}, {"step": 30300, "data": {"time": 75.88}}, {"step": 30300, "data": {"rate": 587200.7}}, {"step": 30300, "data": {"gnorm": 0.3455}}, {"step": 30400, "data": {"epoch": 6}}, {"step": 30400, "data": {"sen": 27717502}}, {"step": 30400, "data": {"cost": 0.47688112}}, {"step": 30400, "data": {"time": 75.7}}, {"step": 30400, "data": {"rate": 579038.81}}, {"step": 30400, "data": {"gnorm": 0.4286}}, {"step": 30500, "data": {"epoch": 6}}, {"step": 30500, "data": {"sen": 29812420}}, {"step": 30500, "data": {"cost": 0.46614942}}, {"step": 30500, "data": {"time": 75.78}}, {"step": 30500, "data": {"rate": 587626.25}}, {"step": 30500, "data": {"gnorm": 0.3636}}, {"step": 30500, "data": {"epoch": 6}}, {"step": 30500, "data": {"perplexity": 9.43091}}, {"step": 30500, "data": {"chrf": 56.3002}}, {"step": 30500, "data": {"ce_mean_words": 2.24399}}, {"step": 30500, "data": {"bleu_detok": 28.8277}}, {"step": 30600, "data": {"epoch": 6}}, {"step": 30600, "data": {"sen": 31755383}}, {"step": 30600, "data": {"cost": 0.47693065}}, {"step": 30600, "data": {"time": 102.43}}, {"step": 30600, "data": {"rate": 424767.5}}, {"step": 30600, "data": {"gnorm": 0.3646}}, {"step": 30700, "data": {"epoch": 6}}, {"step": 30700, "data": {"sen": 33800399}}, {"step": 30700, "data": {"cost": 0.4712663}}, {"step": 30700, "data": {"time": 75.85}}, {"step": 30700, "data": {"rate": 581047.14}}, {"step": 30700, "data": {"gnorm": 0.3535}}, {"step": 30800, "data": {"epoch": 6}}, {"step": 30800, "data": {"sen": 35842921}}, {"step": 30800, "data": {"cost": 0.47169334}}, {"step": 30800, "data": {"time": 77.91}}, {"step": 30800, "data": {"rate": 581014.7}}, {"step": 30800, "data": {"gnorm": 0.3826}}, {"step": 30900, "data": {"epoch": 6}}, {"step": 30900, "data": {"sen": 37845367}}, {"step": 30900, "data": {"cost": 0.46993446}}, {"step": 30900, "data": {"time": 75.98}}, {"step": 30900, "data": {"rate": 580652.82}}, {"step": 30900, "data": {"gnorm": 0.3431}}, {"step": 31000, "data": {"epoch": 6}}, {"step": 31000, "data": {"sen": 39926590}}, {"step": 31000, "data": {"cost": 0.47394589}}, {"step": 31000, "data": {"time": 75.83}}, {"step": 31000, "data": {"rate": 581360.6}}, {"step": 31000, "data": {"gnorm": 0.3782}}, {"step": 31000, "data": {"epoch": 6}}, {"step": 31000, "data": {"perplexity": 9.54424}}, {"step": 31000, "data": {"chrf": 55.8972}}, {"step": 31000, "data": {"ce_mean_words": 2.25594}}, {"step": 31000, "data": {"bleu_detok": 28.6004}}, {"step": 31100, "data": {"epoch": 6}}, {"step": 31100, "data": {"sen": 41864917}}, {"step": 31100, "data": {"cost": 0.47722626}}, {"step": 31100, "data": {"time": 102.86}}, {"step": 31100, "data": {"rate": 423831.29}}, {"step": 31100, "data": {"gnorm": 0.3952}}, {"step": 31200, "data": {"epoch": 6}}, {"step": 31200, "data": {"sen": 43888720}}, {"step": 31200, "data": {"cost": 0.46790355}}, {"step": 31200, "data": {"time": 75.3}}, {"step": 31200, "data": {"rate": 584833.84}}, {"step": 31200, "data": {"gnorm": 0.4035}}, {"step": 31300, "data": {"epoch": 6}}, {"step": 31300, "data": {"sen": 45954632}}, {"step": 31300, "data": {"cost": 0.47324082}}, {"step": 31300, "data": {"time": 76.97}}, {"step": 31300, "data": {"rate": 582367.75}}, {"step": 31300, "data": {"gnorm": 0.3993}}, {"step": 31400, "data": {"epoch": 6}}, {"step": 31400, "data": {"sen": 47999846}}, {"step": 31400, "data": {"cost": 0.47412416}}, {"step": 31400, "data": {"time": 76.79}}, {"step": 31400, "data": {"rate": 586596.96}}, {"step": 31400, "data": {"gnorm": 0.3889}}, {"step": 31500, "data": {"epoch": 6}}, {"step": 31500, "data": {"sen": 50049502}}, {"step": 31500, "data": {"cost": 0.46941414}}, {"step": 31500, "data": {"time": 77.32}}, {"step": 31500, "data": {"rate": 583264.75}}, {"step": 31500, "data": {"gnorm": 0.3463}}, {"step": 31500, "data": {"epoch": 6}}, {"step": 31500, "data": {"perplexity": 9.53533}}, {"step": 31500, "data": {"chrf": 56.4311}}, {"step": 31500, "data": {"ce_mean_words": 2.255}}, {"step": 31500, "data": {"bleu_detok": 29.0306}}, {"step": 31600, "data": {"epoch": 6}}, {"step": 31600, "data": {"sen": 52118981}}, {"step": 31600, "data": {"cost": 0.4683778}}, {"step": 31600, "data": {"time": 108.21}}, {"step": 31600, "data": {"rate": 411812.35}}, {"step": 31600, "data": {"gnorm": 0.3753}}, {"step": 31700, "data": {"epoch": 6}}, {"step": 31700, "data": {"sen": 54134032}}, {"step": 31700, "data": {"cost": 0.4718377}}, {"step": 31700, "data": {"time": 75.08}}, {"step": 31700, "data": {"rate": 580342.01}}, {"step": 31700, "data": {"gnorm": 0.3825}}, {"step": 31800, "data": {"epoch": 6}}, {"step": 31800, "data": {"sen": 56078442}}, {"step": 31800, "data": {"cost": 0.47752008}}, {"step": 31800, "data": {"time": 74.22}}, {"step": 31800, "data": {"rate": 578162.47}}, {"step": 31800, "data": {"gnorm": 0.3862}}, {"step": 31900, "data": {"epoch": 6}}, {"step": 31900, "data": {"sen": 58111140}}, {"step": 31900, "data": {"cost": 0.47620571}}, {"step": 31900, "data": {"time": 76.69}}, {"step": 31900, "data": {"rate": 582288.38}}, {"step": 31900, "data": {"gnorm": 0.3873}}, {"step": 32000, "data": {"epoch": 6}}, {"step": 32000, "data": {"sen": 60126495}}, {"step": 32000, "data": {"cost": 0.47227418}}, {"step": 32000, "data": {"time": 76.52}}, {"step": 32000, "data": {"rate": 582797.39}}, {"step": 32000, "data": {"gnorm": 0.4013}}, {"step": 32000, "data": {"epoch": 6}}, {"step": 32000, "data": {"perplexity": 9.50458}}, {"step": 32000, "data": {"chrf": 56.0271}}, {"step": 32000, "data": {"ce_mean_words": 2.25177}}, {"step": 32000, "data": {"bleu_detok": 28.6194}}]
+[
+    {
+        "step": 1,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "sen": 7760
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "cost": 10.09652901
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "time": 244.67
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "rate": 888.05
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "gnorm": 5.2392
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "sen": 26992
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "cost": 9.85704613
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "time": 0.49
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "rate": 473332.55
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "gnorm": 5.7787
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "sen": 32864
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "cost": 10.21446133
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "time": 0.39
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "rate": 552223.51
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "gnorm": 5.8445
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "sen": 44064
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "cost": 9.94169617
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "time": 0.4
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "rate": 474925.7
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "gnorm": 5.6558
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "sen": 52619
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "cost": 10.21191692
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "time": 0.42
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "rate": 698787.83
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "gnorm": 5.7659
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "sen": 59323
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "cost": 10.22371006
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "time": 0.41
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "rate": 632149.45
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "gnorm": 5.7923
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "sen": 75999
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "cost": 10.08034992
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "time": 0.43
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "rate": 772682.62
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "gnorm": 5.7947
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "sen": 78799
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "cost": 10.33155155
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "time": 0.46
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "rate": 527948.27
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "gnorm": 5.7238
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "sen": 82047
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "cost": 10.32328033
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "time": 0.48
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "rate": 543979.19
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "gnorm": 5.7177
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "sen": 93247
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "cost": 10.02314568
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "time": 0.4
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "rate": 608849.21
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "gnorm": 5.6175
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "sen": 11826448
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "cost": 8.16687393
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "time": 418.52
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "rate": 611107.59
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "gnorm": 1.498
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "sen": 23663821
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "cost": 6.1054821
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "time": 423.43
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "rate": 609109.22
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "gnorm": 2.3888
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "sen": 35442478
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "cost": 5.21276331
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "time": 424.45
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "rate": 606478.69
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "gnorm": 2.1461
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "sen": 47228904
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "cost": 4.55404186
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "time": 424.94
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "rate": 608185.31
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "gnorm": 2.9981
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "sen": 59029081
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "cost": 3.8885138
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "time": 421.13
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "rate": 611362.51
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "gnorm": 3.4638
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "chrf": 25.5239
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "ce_mean_words": 4.56891
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "bleu_detok": 4.0551
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "perplexity": 96.4394
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "sen": 70726322
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "cost": 3.27664042
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "time": 447.89
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "rate": 572551.45
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "gnorm": 4.5978
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "sen": 82442979
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "cost": 2.83908176
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "time": 425.39
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "rate": 604265.57
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "gnorm": 3.2209
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "sen": 94250487
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "cost": 2.44592214
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "time": 424.54
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "rate": 603593.46
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "gnorm": 3.1368
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "sen": 106036373
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "cost": 2.12659574
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "time": 424.5
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "rate": 607527.62
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "gnorm": 2.3815
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "sen": 108925
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "cost": 1.89645851
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "time": 441.86
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "rate": 578723.92
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "gnorm": 2.1298
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "chrf": 42.5467
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "ce_mean_words": 3.19141
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "bleu_detok": 14.6807
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "perplexity": 24.3228
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "sen": 11862481
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "cost": 1.71168828
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "time": 445.05
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "rate": 577578.95
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "gnorm": 1.8633
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "sen": 23682880
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "cost": 1.56886828
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "time": 424.24
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "rate": 606415.7
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "gnorm": 1.7238
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "sen": 35434587
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "cost": 1.44796801
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "time": 426.61
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "rate": 603455.56
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "gnorm": 1.4451
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "sen": 47203957
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "cost": 1.35240018
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "time": 424.42
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "rate": 606780.48
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "gnorm": 1.3498
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "sen": 58990593
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "cost": 1.26196682
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "time": 423.09
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "rate": 607688.12
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "gnorm": 1.1876
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "chrf": 48.354
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "ce_mean_words": 2.7236
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "bleu_detok": 19.9078
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "perplexity": 15.2351
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "sen": 70802100
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "cost": 1.20254648
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "time": 447.8
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "rate": 576659.07
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "gnorm": 1.1636
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "sen": 82582686
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "cost": 1.12801802
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "time": 424.34
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "rate": 605259.46
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "gnorm": 1.1352
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "sen": 94365470
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "cost": 1.05992734
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "time": 425.99
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "rate": 606716.21
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "gnorm": 1.0415
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "sen": 106034961
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "cost": 1.01547647
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "time": 421.62
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "rate": 604856.67
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "gnorm": 0.9318
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "sen": 195198
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "cost": 0.96424389
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "time": 445.17
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "rate": 578743.54
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "gnorm": 0.7591
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "chrf": 51.5436
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "ce_mean_words": 2.51993
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "bleu_detok": 22.6274
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "perplexity": 12.4278
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "sen": 11999948
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "cost": 0.92161202
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "time": 443.99
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "rate": 578968.79
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "gnorm": 0.8806
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "sen": 23788560
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "cost": 0.89308023
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "time": 427.12
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "rate": 605079.04
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "gnorm": 0.783
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "sen": 35650909
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "cost": 0.86150789
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "time": 425.49
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "rate": 605090.53
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "gnorm": 0.7715
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "sen": 47365112
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "cost": 0.83436853
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "time": 426.91
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "rate": 604424.26
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "gnorm": 0.6976
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "sen": 59258913
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "cost": 0.81355709
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "time": 427.68
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "rate": 606258.4
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "gnorm": 0.7049
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "chrf": 52.6074
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "ce_mean_words": 2.43086
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "bleu_detok": 24.4593
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "perplexity": 11.3686
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "sen": 70999758
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "cost": 0.78981107
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "time": 444.5
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "rate": 576104.54
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "gnorm": 0.6471
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "sen": 82768335
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "cost": 0.77213115
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "time": 424.91
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "rate": 605289.19
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "gnorm": 0.586
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "sen": 94585769
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "cost": 0.75580764
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "time": 427.18
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "rate": 604355.58
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "gnorm": 0.6501
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "sen": 106353570
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "cost": 0.74278587
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "time": 425.87
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "rate": 604879.96
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "gnorm": 0.8841
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "sen": 431389
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "cost": 0.72724628
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "time": 440.61
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "rate": 578771.0
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "gnorm": 0.6045
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "chrf": 53.3918
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "ce_mean_words": 2.42906
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "bleu_detok": 24.7525
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "perplexity": 11.3483
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "sen": 12239704
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "cost": 0.71076536
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "time": 449.37
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "rate": 575028.39
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "gnorm": 0.5714
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "sen": 24062221
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "cost": 0.70075667
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "time": 424.23
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "rate": 608654.27
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "gnorm": 0.6688
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "sen": 35843799
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "cost": 0.69009537
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "time": 425.02
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "rate": 603680.37
+        }
+    },
+    {
+        "step": 33000,
+        "data": {
+            "gnorm": 0.6101
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "sen": 47537216
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "cost": 0.68314195
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "time": 425.07
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "rate": 604310.94
+        }
+    },
+    {
+        "step": 34000,
+        "data": {
+            "gnorm": 0.6816
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "sen": 59415851
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "cost": 0.67175812
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "time": 426.18
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "rate": 606709.87
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "gnorm": 0.5757
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "chrf": 53.9462
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "ce_mean_words": 2.334
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "bleu_detok": 26.2343
+        }
+    },
+    {
+        "step": 35000,
+        "data": {
+            "perplexity": 10.3192
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "sen": 71205189
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "cost": 0.66021705
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "time": 447.07
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "rate": 577334.84
+        }
+    },
+    {
+        "step": 36000,
+        "data": {
+            "gnorm": 0.5142
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "sen": 82979317
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "cost": 0.65161037
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "time": 424.97
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "rate": 605417.05
+        }
+    },
+    {
+        "step": 37000,
+        "data": {
+            "gnorm": 0.5538
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "sen": 94700080
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "cost": 0.64473414
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "time": 424.88
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "rate": 603667.63
+        }
+    },
+    {
+        "step": 38000,
+        "data": {
+            "gnorm": 0.5425
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "sen": 106508709
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "cost": 0.63728291
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "time": 425.01
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "rate": 605755.13
+        }
+    },
+    {
+        "step": 39000,
+        "data": {
+            "gnorm": 0.551
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "sen": 699516
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "cost": 0.63142753
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "time": 445.34
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "rate": 578601.94
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "gnorm": 0.5092
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "chrf": 54.7006
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "ce_mean_words": 2.31258
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "bleu_detok": 26.8031
+        }
+    },
+    {
+        "step": 40000,
+        "data": {
+            "perplexity": 10.1005
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "sen": 12477905
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "cost": 0.62065649
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "time": 448.83
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "rate": 575745.39
+        }
+    },
+    {
+        "step": 41000,
+        "data": {
+            "gnorm": 0.5133
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "sen": 24330451
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "cost": 0.61697447
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "time": 426.54
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "rate": 603950.1
+        }
+    },
+    {
+        "step": 42000,
+        "data": {
+            "gnorm": 0.4906
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "sen": 36161100
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "cost": 0.61005586
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "time": 427.45
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "rate": 606846.02
+        }
+    },
+    {
+        "step": 43000,
+        "data": {
+            "gnorm": 0.4658
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "sen": 47888220
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "cost": 0.60739821
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "time": 423.66
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "rate": 604777.49
+        }
+    },
+    {
+        "step": 44000,
+        "data": {
+            "gnorm": 0.4906
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "sen": 59724043
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "cost": 0.60197359
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "time": 426.65
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "rate": 604227.77
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "gnorm": 0.4849
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "chrf": 54.5072
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "ce_mean_words": 2.30773
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "bleu_detok": 26.5298
+        }
+    },
+    {
+        "step": 45000,
+        "data": {
+            "perplexity": 10.0515
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "sen": 71548701
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "cost": 0.59727478
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "time": 447.36
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "rate": 576896.14
+        }
+    },
+    {
+        "step": 46000,
+        "data": {
+            "gnorm": 0.5168
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "sen": 83263499
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "cost": 0.5932005
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "time": 426.46
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "rate": 602768.41
+        }
+    },
+    {
+        "step": 47000,
+        "data": {
+            "gnorm": 0.4963
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "sen": 95064001
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "cost": 0.58822775
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "time": 425.89
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "rate": 605302.56
+        }
+    },
+    {
+        "step": 48000,
+        "data": {
+            "gnorm": 0.4871
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "sen": 106826214
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "cost": 0.58441615
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "time": 425.87
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "rate": 604672.44
+        }
+    },
+    {
+        "step": 49000,
+        "data": {
+            "gnorm": 0.4458
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "sen": 948974
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "cost": 0.57994843
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "time": 443.32
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "rate": 577165.89
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "gnorm": 0.4568
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "chrf": 54.6534
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "ce_mean_words": 2.2953
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "bleu_detok": 26.8405
+        }
+    },
+    {
+        "step": 50000,
+        "data": {
+            "perplexity": 9.92745
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "sen": 12690274
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "cost": 0.5746485
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "time": 447.53
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "rate": 574739.97
+        }
+    },
+    {
+        "step": 51000,
+        "data": {
+            "gnorm": 0.5029
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "sen": 24471233
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "cost": 0.57095617
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "time": 427.17
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "rate": 603864.86
+        }
+    },
+    {
+        "step": 52000,
+        "data": {
+            "gnorm": 0.4198
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "sen": 36267253
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "cost": 0.56824714
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "time": 425.68
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "rate": 603203.25
+        }
+    },
+    {
+        "step": 53000,
+        "data": {
+            "gnorm": 0.4878
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "sen": 48011828
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "cost": 0.56487316
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "time": 424.15
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "rate": 606222.51
+        }
+    },
+    {
+        "step": 54000,
+        "data": {
+            "gnorm": 0.4586
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "sen": 59756795
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "cost": 0.56299537
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "time": 426.58
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "rate": 603265.84
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "gnorm": 0.4485
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "chrf": 54.936
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "ce_mean_words": 2.26426
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "bleu_detok": 27.2262
+        }
+    },
+    {
+        "step": 55000,
+        "data": {
+            "perplexity": 9.62396
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "sen": 71562845
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "cost": 0.55916399
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "time": 449.2
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "rate": 573929.42
+        }
+    },
+    {
+        "step": 56000,
+        "data": {
+            "gnorm": 0.4387
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "sen": 83402575
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "cost": 0.55701637
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "time": 427.43
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "rate": 603058.35
+        }
+    },
+    {
+        "step": 57000,
+        "data": {
+            "gnorm": 0.4791
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "sen": 95167348
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "cost": 0.55514681
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "time": 425.99
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "rate": 606378.08
+        }
+    },
+    {
+        "step": 58000,
+        "data": {
+            "gnorm": 0.4131
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "sen": 107008835
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "cost": 0.55203605
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "time": 426.1
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "rate": 604750.74
+        }
+    },
+    {
+        "step": 59000,
+        "data": {
+            "gnorm": 0.4189
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "sen": 1160371
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "cost": 0.54889005
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "time": 445.96
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "rate": 575041.55
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "gnorm": 0.4356
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "chrf": 55.4446
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "ce_mean_words": 2.28608
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "bleu_detok": 27.7837
+        }
+    },
+    {
+        "step": 60000,
+        "data": {
+            "perplexity": 9.83628
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "sen": 12867204
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "cost": 0.54493934
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "time": 444.58
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "rate": 576627.15
+        }
+    },
+    {
+        "step": 61000,
+        "data": {
+            "gnorm": 0.4702
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "sen": 24646261
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "cost": 0.54324657
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "time": 425.87
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "rate": 603363.55
+        }
+    },
+    {
+        "step": 62000,
+        "data": {
+            "gnorm": 0.451
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "sen": 36361673
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "cost": 0.54085487
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "time": 426.99
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "rate": 604488.8
+        }
+    },
+    {
+        "step": 63000,
+        "data": {
+            "gnorm": 0.4385
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "sen": 48213781
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "cost": 0.53979135
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "time": 428.0
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "rate": 603097.81
+        }
+    },
+    {
+        "step": 64000,
+        "data": {
+            "gnorm": 0.4162
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "sen": 60078170
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "cost": 0.53684783
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "time": 428.58
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "rate": 604686.18
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "gnorm": 0.4323
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "chrf": 55.4056
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "ce_mean_words": 2.26546
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "bleu_detok": 27.6646
+        }
+    },
+    {
+        "step": 65000,
+        "data": {
+            "perplexity": 9.63551
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "sen": 71907019
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "cost": 0.53633779
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "time": 447.81
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "rate": 575002.07
+        }
+    },
+    {
+        "step": 66000,
+        "data": {
+            "gnorm": 0.4572
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "sen": 83749327
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "cost": 0.53310555
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "time": 427.72
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "rate": 602626.8
+        }
+    },
+    {
+        "step": 67000,
+        "data": {
+            "gnorm": 0.3941
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "sen": 95483561
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "cost": 0.53319538
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "time": 427.42
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "rate": 602231.99
+        }
+    },
+    {
+        "step": 68000,
+        "data": {
+            "gnorm": 0.4304
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "epoch": 7
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "sen": 107254276
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "cost": 0.53168845
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "time": 429.67
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "rate": 601151.09
+        }
+    },
+    {
+        "step": 69000,
+        "data": {
+            "gnorm": 0.4127
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "sen": 1333257
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "cost": 0.52841294
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "time": 443.89
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "rate": 577829.79
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "gnorm": 0.4591
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "chrf": 55.4915
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "ce_mean_words": 2.26248
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "bleu_detok": 28.0887
+        }
+    },
+    {
+        "step": 70000,
+        "data": {
+            "perplexity": 9.60693
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "sen": 13173167
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "cost": 0.52371109
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "time": 448.24
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "rate": 575146.87
+        }
+    },
+    {
+        "step": 71000,
+        "data": {
+            "gnorm": 0.3987
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "sen": 24969408
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "cost": 0.52350378
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "time": 424.19
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "rate": 605515.66
+        }
+    },
+    {
+        "step": 72000,
+        "data": {
+            "gnorm": 0.4074
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "sen": 36700779
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "cost": 0.52198935
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "time": 427.21
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "rate": 603649.23
+        }
+    },
+    {
+        "step": 73000,
+        "data": {
+            "gnorm": 0.4151
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "sen": 48518696
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "cost": 0.52123535
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "time": 427.18
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "rate": 600348.75
+        }
+    },
+    {
+        "step": 74000,
+        "data": {
+            "gnorm": 0.3951
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "sen": 60358594
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "cost": 0.51979423
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "time": 428.58
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "rate": 605294.44
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "gnorm": 0.4004
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "chrf": 55.8313
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "ce_mean_words": 2.261
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "bleu_detok": 28.0371
+        }
+    },
+    {
+        "step": 75000,
+        "data": {
+            "perplexity": 9.59269
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "sen": 72161996
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "cost": 0.51826388
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "time": 449.93
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "rate": 574412.66
+        }
+    },
+    {
+        "step": 76000,
+        "data": {
+            "gnorm": 0.4005
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "sen": 83999721
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "cost": 0.51722735
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "time": 426.39
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "rate": 605297.95
+        }
+    },
+    {
+        "step": 77000,
+        "data": {
+            "gnorm": 0.4031
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "sen": 95697384
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "cost": 0.51598418
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "time": 425.91
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "rate": 600277.38
+        }
+    },
+    {
+        "step": 78000,
+        "data": {
+            "gnorm": 0.4317
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "epoch": 8
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "sen": 107475078
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "cost": 0.51495439
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "time": 426.82
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "rate": 602460.19
+        }
+    },
+    {
+        "step": 79000,
+        "data": {
+            "gnorm": 0.4167
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "sen": 1540934
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "cost": 0.51305491
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "time": 443.24
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "rate": 576975.57
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "gnorm": 0.4195
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "chrf": 55.8292
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "ce_mean_words": 2.25247
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "bleu_detok": 28.2713
+        }
+    },
+    {
+        "step": 80000,
+        "data": {
+            "perplexity": 9.51115
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "sen": 13439612
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "cost": 0.50866795
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "time": 451.24
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "rate": 574215.36
+        }
+    },
+    {
+        "step": 81000,
+        "data": {
+            "gnorm": 0.4251
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "sen": 25181361
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "cost": 0.50850552
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "time": 426.79
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "rate": 603155.54
+        }
+    },
+    {
+        "step": 82000,
+        "data": {
+            "gnorm": 0.3954
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "sen": 36989411
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "cost": 0.50816721
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "time": 426.69
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "rate": 603828.52
+        }
+    },
+    {
+        "step": 83000,
+        "data": {
+            "gnorm": 0.4149
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "sen": 48825615
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "cost": 0.50700623
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "time": 428.11
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "rate": 603222.74
+        }
+    },
+    {
+        "step": 84000,
+        "data": {
+            "gnorm": 0.3955
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "sen": 60517185
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "cost": 0.50596708
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "time": 425.69
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "rate": 602393.79
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "gnorm": 0.4157
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "chrf": 55.9314
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "ce_mean_words": 2.23625
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "bleu_detok": 28.3152
+        }
+    },
+    {
+        "step": 85000,
+        "data": {
+            "perplexity": 9.3582
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "sen": 72249310
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "cost": 0.50625765
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "time": 448.79
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "rate": 571211.11
+        }
+    },
+    {
+        "step": 86000,
+        "data": {
+            "gnorm": 0.4291
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "sen": 84047907
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "cost": 0.50437939
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "time": 426.21
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "rate": 603586.84
+        }
+    },
+    {
+        "step": 87000,
+        "data": {
+            "gnorm": 0.413
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "sen": 95903610
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "cost": 0.50375932
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "time": 429.35
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "rate": 602651.27
+        }
+    },
+    {
+        "step": 88000,
+        "data": {
+            "gnorm": 0.419
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "epoch": 9
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "sen": 107620094
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "cost": 0.50312281
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "time": 425.16
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "rate": 602835.98
+        }
+    },
+    {
+        "step": 89000,
+        "data": {
+            "gnorm": 0.4167
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "sen": 1706191
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "cost": 0.50137883
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "time": 445.73
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "rate": 575837.27
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "gnorm": 0.4233
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "chrf": 55.4832
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "ce_mean_words": 2.24029
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "bleu_detok": 27.9519
+        }
+    },
+    {
+        "step": 90000,
+        "data": {
+            "perplexity": 9.39603
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "sen": 13573769
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "cost": 0.49778035
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "time": 448.68
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "rate": 574899.32
+        }
+    },
+    {
+        "step": 91000,
+        "data": {
+            "gnorm": 0.4055
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "sen": 25280588
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "cost": 0.49746081
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "time": 426.6
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "rate": 602170.26
+        }
+    },
+    {
+        "step": 92000,
+        "data": {
+            "gnorm": 0.3841
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "sen": 37106308
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "cost": 0.49725124
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "time": 426.44
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "rate": 603056.65
+        }
+    },
+    {
+        "step": 93000,
+        "data": {
+            "gnorm": 0.3977
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "sen": 48850409
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "cost": 0.49611723
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "time": 426.58
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "rate": 603063.93
+        }
+    },
+    {
+        "step": 94000,
+        "data": {
+            "gnorm": 0.3958
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "sen": 60679806
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "cost": 0.49574691
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "time": 429.81
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "rate": 602486.21
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "gnorm": 0.3985
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "chrf": 55.8171
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "ce_mean_words": 2.24667
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "bleu_detok": 28.2061
+        }
+    },
+    {
+        "step": 95000,
+        "data": {
+            "perplexity": 9.45618
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "sen": 72462607
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "cost": 0.4946883
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "time": 448.97
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "rate": 572779.58
+        }
+    },
+    {
+        "step": 96000,
+        "data": {
+            "gnorm": 0.4166
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "sen": 84311203
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "cost": 0.49431637
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "time": 430.18
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "rate": 601358.32
+        }
+    },
+    {
+        "step": 97000,
+        "data": {
+            "gnorm": 0.3868
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "sen": 96017723
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "cost": 0.49413139
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "time": 426.86
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "rate": 600510.08
+        }
+    },
+    {
+        "step": 98000,
+        "data": {
+            "gnorm": 0.4466
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "epoch": 10
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "sen": 107696695
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "cost": 0.49291834
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "time": 426.86
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "rate": 599037.43
+        }
+    },
+    {
+        "step": 99000,
+        "data": {
+            "gnorm": 0.3921
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "sen": 1812109
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "cost": 0.49154162
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "time": 445.65
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "rate": 574131.95
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "gnorm": 0.3789
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "chrf": 56.0034
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "ce_mean_words": 2.25035
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "bleu_detok": 28.5268
+        }
+    },
+    {
+        "step": 100000,
+        "data": {
+            "perplexity": 9.4911
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "sen": 13594218
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "cost": 0.48933458
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "time": 449.66
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "rate": 569843.73
+        }
+    },
+    {
+        "step": 101000,
+        "data": {
+            "gnorm": 0.4026
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "sen": 25423739
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "cost": 0.48827583
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "time": 431.73
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "rate": 601304.74
+        }
+    },
+    {
+        "step": 102000,
+        "data": {
+            "gnorm": 0.4241
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "sen": 37204596
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "cost": 0.48820502
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "time": 428.31
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "rate": 598942.95
+        }
+    },
+    {
+        "step": 103000,
+        "data": {
+            "gnorm": 0.3954
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "sen": 48955798
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "cost": 0.48718339
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "time": 428.08
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "rate": 601172.75
+        }
+    },
+    {
+        "step": 104000,
+        "data": {
+            "gnorm": 0.3886
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "sen": 60659223
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "cost": 0.48741946
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "time": 428.59
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "rate": 598548.94
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "gnorm": 0.3828
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "chrf": 55.8588
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "ce_mean_words": 2.23386
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "bleu_detok": 28.3337
+        }
+    },
+    {
+        "step": 105000,
+        "data": {
+            "perplexity": 9.33579
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "sen": 72414964
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "cost": 0.48721126
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "time": 450.8
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "rate": 568970.67
+        }
+    },
+    {
+        "step": 106000,
+        "data": {
+            "gnorm": 0.4212
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "sen": 84249049
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "cost": 0.48628062
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "time": 431.49
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "rate": 600428.85
+        }
+    },
+    {
+        "step": 107000,
+        "data": {
+            "gnorm": 0.3898
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "sen": 95999677
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "cost": 0.48547062
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "time": 426.44
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "rate": 600307.25
+        }
+    },
+    {
+        "step": 108000,
+        "data": {
+            "gnorm": 0.3729
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "epoch": 11
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "sen": 107819116
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "cost": 0.4852626
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "time": 429.88
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "rate": 599594.31
+        }
+    },
+    {
+        "step": 109000,
+        "data": {
+            "gnorm": 0.403
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "sen": 1884413
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "cost": 0.48323965
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "time": 446.65
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "rate": 573235.1
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "gnorm": 0.3757
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "chrf": 55.9104
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "ce_mean_words": 2.22842
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "bleu_detok": 28.4369
+        }
+    },
+    {
+        "step": 110000,
+        "data": {
+            "perplexity": 9.28521
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "sen": 13601494
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "cost": 0.48019114
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "time": 449.72
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "rate": 569326.62
+        }
+    },
+    {
+        "step": 111000,
+        "data": {
+            "gnorm": 0.364
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "sen": 25398943
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "cost": 0.48115325
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "time": 430.74
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "rate": 598712.95
+        }
+    },
+    {
+        "step": 112000,
+        "data": {
+            "gnorm": 0.376
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "sen": 37251908
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "cost": 0.48136362
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "time": 431.8
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "rate": 598226.11
+        }
+    },
+    {
+        "step": 113000,
+        "data": {
+            "gnorm": 0.4088
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "sen": 49055452
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "cost": 0.48127928
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "time": 429.98
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "rate": 599834.87
+        }
+    },
+    {
+        "step": 114000,
+        "data": {
+            "gnorm": 0.4048
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "sen": 60911716
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "cost": 0.47995147
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "time": 431.35
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "rate": 600207.97
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "gnorm": 0.388
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "chrf": 56.0285
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "ce_mean_words": 2.22526
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "bleu_detok": 28.6539
+        }
+    },
+    {
+        "step": 115000,
+        "data": {
+            "perplexity": 9.25589
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "sen": 72677338
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "cost": 0.47926217
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "time": 453.42
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "rate": 568946.61
+        }
+    },
+    {
+        "step": 116000,
+        "data": {
+            "gnorm": 0.3896
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "sen": 84443317
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "cost": 0.47978944
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "time": 431.36
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "rate": 597007.88
+        }
+    },
+    {
+        "step": 117000,
+        "data": {
+            "gnorm": 0.4094
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "sen": 96262331
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "cost": 0.47889182
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "time": 430.84
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "rate": 598398.56
+        }
+    },
+    {
+        "step": 118000,
+        "data": {
+            "gnorm": 0.3829
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "epoch": 12
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "sen": 108041613
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "cost": 0.47837481
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "time": 428.35
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "rate": 599693.1
+        }
+    },
+    {
+        "step": 119000,
+        "data": {
+            "gnorm": 0.4301
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "sen": 2145653
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "cost": 0.47654736
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "time": 448.34
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "rate": 571710.68
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "gnorm": 0.3745
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "chrf": 56.3126
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "ce_mean_words": 2.25664
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "bleu_detok": 28.5648
+        }
+    },
+    {
+        "step": 120000,
+        "data": {
+            "perplexity": 9.55098
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "sen": 13883043
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "cost": 0.47427839
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "time": 451.54
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "rate": 568362.25
+        }
+    },
+    {
+        "step": 121000,
+        "data": {
+            "gnorm": 0.3796
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "sen": 25707222
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "cost": 0.47462633
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "time": 431.72
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "rate": 598876.82
+        }
+    },
+    {
+        "step": 122000,
+        "data": {
+            "gnorm": 0.3999
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "sen": 37525945
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "cost": 0.47471222
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "time": 432.02
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "rate": 596959.87
+        }
+    },
+    {
+        "step": 123000,
+        "data": {
+            "gnorm": 0.3748
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "sen": 49304166
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "cost": 0.47414112
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "time": 429.92
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "rate": 597655.08
+        }
+    },
+    {
+        "step": 124000,
+        "data": {
+            "gnorm": 0.3853
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "sen": 61142554
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "cost": 0.474098
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "time": 432.55
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "rate": 599497.53
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "gnorm": 0.3893
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "chrf": 56.2365
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "ce_mean_words": 2.25826
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "bleu_detok": 28.6552
+        }
+    },
+    {
+        "step": 125000,
+        "data": {
+            "perplexity": 9.56639
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "sen": 72939129
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "cost": 0.47340956
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "time": 451.08
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "rate": 570034.38
+        }
+    },
+    {
+        "step": 126000,
+        "data": {
+            "gnorm": 0.3862
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "sen": 84727392
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "cost": 0.47368377
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "time": 432.72
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "rate": 597376.39
+        }
+    },
+    {
+        "step": 127000,
+        "data": {
+            "gnorm": 0.4212
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "sen": 96603392
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "cost": 0.47246337
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "time": 432.16
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "rate": 598259.75
+        }
+    },
+    {
+        "step": 128000,
+        "data": {
+            "gnorm": 0.3867
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "epoch": 13
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "sen": 108279577
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "cost": 0.47282624
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "time": 430.75
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "rate": 596840.81
+        }
+    },
+    {
+        "step": 129000,
+        "data": {
+            "gnorm": 0.3707
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "sen": 2359467
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "cost": 0.47152594
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "time": 447.64
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "rate": 569861.07
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "gnorm": 0.3982
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "chrf": 56.181
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "ce_mean_words": 2.26107
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "bleu_detok": 28.662
+        }
+    },
+    {
+        "step": 130000,
+        "data": {
+            "perplexity": 9.59334
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "sen": 14218304
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "cost": 0.46889615
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "time": 452.05
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "rate": 569532.92
+        }
+    },
+    {
+        "step": 131000,
+        "data": {
+            "gnorm": 0.3904
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "sen": 25956516
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "cost": 0.46917397
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "time": 432.25
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "rate": 595984.97
+        }
+    },
+    {
+        "step": 132000,
+        "data": {
+            "gnorm": 0.3721
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "sen": 37718593
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "cost": 0.46958303
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "time": 431.8
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "rate": 596124.83
+        }
+    },
+    {
+        "step": 133000,
+        "data": {
+            "gnorm": 0.3977
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "sen": 49519580
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "cost": 0.46965498
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "time": 432.74
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "rate": 594250.6
+        }
+    },
+    {
+        "step": 134000,
+        "data": {
+            "gnorm": 0.3799
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "sen": 61314444
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "cost": 0.46847466
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "time": 431.5
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "rate": 597634.5
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "gnorm": 0.3852
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "chrf": 56.2072
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "ce_mean_words": 2.24397
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "bleu_detok": 28.822
+        }
+    },
+    {
+        "step": 135000,
+        "data": {
+            "perplexity": 9.4307
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "sen": 73093437
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "cost": 0.46794567
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "time": 452.98
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "rate": 569400.76
+        }
+    },
+    {
+        "step": 136000,
+        "data": {
+            "gnorm": 0.3585
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "sen": 84885325
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "cost": 0.46773368
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "time": 431.77
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "rate": 595638.35
+        }
+    },
+    {
+        "step": 137000,
+        "data": {
+            "gnorm": 0.3772
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "sen": 96615161
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "cost": 0.46750042
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "time": 431.52
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "rate": 597675.77
+        }
+    },
+    {
+        "step": 138000,
+        "data": {
+            "gnorm": 0.3455
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "epoch": 14
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "sen": 108456892
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "cost": 0.46773955
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "time": 432.87
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "rate": 593440.33
+        }
+    },
+    {
+        "step": 139000,
+        "data": {
+            "gnorm": 0.4057
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "sen": 2626249
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "cost": 0.46589574
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "time": 450.63
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "rate": 571058.8
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "gnorm": 0.3704
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "chrf": 56.353
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "ce_mean_words": 2.24775
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "bleu_detok": 28.9422
+        }
+    },
+    {
+        "step": 140000,
+        "data": {
+            "perplexity": 9.46642
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "sen": 14392346
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "cost": 0.46500969
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "time": 455.73
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "rate": 567607.84
+        }
+    },
+    {
+        "step": 141000,
+        "data": {
+            "gnorm": 0.353
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "sen": 26217731
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "cost": 0.46453327
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "time": 431.47
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "rate": 597581.2
+        }
+    },
+    {
+        "step": 142000,
+        "data": {
+            "gnorm": 0.3791
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "sen": 38094755
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "cost": 0.4641732
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "time": 433.56
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "rate": 596442.24
+        }
+    },
+    {
+        "step": 143000,
+        "data": {
+            "gnorm": 0.3836
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "sen": 49822577
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "cost": 0.46423176
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "time": 432.85
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "rate": 595073.98
+        }
+    },
+    {
+        "step": 144000,
+        "data": {
+            "gnorm": 0.3539
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "sen": 61614291
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "cost": 0.46501788
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "time": 430.37
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "rate": 595369.52
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "gnorm": 0.3955
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "chrf": 56.0107
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "ce_mean_words": 2.23236
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "bleu_detok": 28.4816
+        }
+    },
+    {
+        "step": 145000,
+        "data": {
+            "perplexity": 9.32185
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "sen": 73298661
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "cost": 0.46428731
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "time": 452.1
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "rate": 567770.85
+        }
+    },
+    {
+        "step": 146000,
+        "data": {
+            "gnorm": 0.3685
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "sen": 85095100
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "cost": 0.46374959
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "time": 434.45
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "rate": 591787.64
+        }
+    },
+    {
+        "step": 147000,
+        "data": {
+            "gnorm": 0.3695
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "sen": 96799184
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "cost": 0.46422428
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "time": 431.81
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "rate": 592741.93
+        }
+    },
+    {
+        "step": 148000,
+        "data": {
+            "gnorm": 0.4317
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "epoch": 15
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "sen": 108600682
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "cost": 0.46367741
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "time": 433.12
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "rate": 593267.96
+        }
+    },
+    {
+        "step": 149000,
+        "data": {
+            "gnorm": 0.3718
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "sen": 2666946
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "cost": 0.46222976
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "time": 452.27
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "rate": 565094.03
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "gnorm": 0.391
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "chrf": 56.2021
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "ce_mean_words": 2.24237
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "bleu_detok": 28.7866
+        }
+    },
+    {
+        "step": 150000,
+        "data": {
+            "perplexity": 9.41566
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "sen": 14361531
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "cost": 0.46048635
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "time": 454.22
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "rate": 565671.76
+        }
+    },
+    {
+        "step": 151000,
+        "data": {
+            "gnorm": 0.3628
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "sen": 26150599
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "cost": 0.45991597
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "time": 431.03
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "rate": 593568.93
+        }
+    },
+    {
+        "step": 152000,
+        "data": {
+            "gnorm": 0.3702
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "sen": 37898046
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "cost": 0.4611145
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "time": 434.02
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "rate": 592465.23
+        }
+    },
+    {
+        "step": 153000,
+        "data": {
+            "gnorm": 0.4066
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "sen": 49630879
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "cost": 0.4604539
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "time": 434.12
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "rate": 590939.05
+        }
+    },
+    {
+        "step": 154000,
+        "data": {
+            "gnorm": 0.3811
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "sen": 61471390
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "cost": 0.46033168
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "time": 436.71
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "rate": 592979.06
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "gnorm": 0.3468
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "chrf": 56.2884
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "ce_mean_words": 2.23886
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "bleu_detok": 28.7536
+        }
+    },
+    {
+        "step": 155000,
+        "data": {
+            "perplexity": 9.38266
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "sen": 73286426
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "cost": 0.46055719
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "time": 455.14
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "rate": 565341.13
+        }
+    },
+    {
+        "step": 156000,
+        "data": {
+            "gnorm": 0.3819
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "sen": 84990728
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "cost": 0.46030071
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "time": 433.42
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "rate": 591693.53
+        }
+    },
+    {
+        "step": 157000,
+        "data": {
+            "gnorm": 0.3935
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "sen": 96763954
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "cost": 0.46006843
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "time": 434.58
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "rate": 591797.96
+        }
+    },
+    {
+        "step": 158000,
+        "data": {
+            "gnorm": 0.3687
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "epoch": 16
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "sen": 108569407
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "cost": 0.45938495
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "time": 437.14
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "rate": 592444.35
+        }
+    },
+    {
+        "step": 159000,
+        "data": {
+            "gnorm": 0.3824
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "sen": 2655672
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "cost": 0.45810917
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "time": 453.05
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "rate": 565382.63
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "gnorm": 0.3771
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "chrf": 56.2319
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "ce_mean_words": 2.23923
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "bleu_detok": 28.8452
+        }
+    },
+    {
+        "step": 160000,
+        "data": {
+            "perplexity": 9.38606
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "sen": 14650564
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "cost": 0.45642519
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "time": 459.13
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "rate": 564502.23
+        }
+    },
+    {
+        "step": 161000,
+        "data": {
+            "gnorm": 0.3718
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "sen": 26438889
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "cost": 0.45680916
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "time": 437.33
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "rate": 589944.85
+        }
+    },
+    {
+        "step": 162000,
+        "data": {
+            "gnorm": 0.3816
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "sen": 38102428
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "cost": 0.45749706
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "time": 435.9
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "rate": 590246.85
+        }
+    },
+    {
+        "step": 163000,
+        "data": {
+            "gnorm": 0.3749
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "sen": 49955922
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "cost": 0.45631835
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "time": 435.5
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "rate": 591496.47
+        }
+    },
+    {
+        "step": 164000,
+        "data": {
+            "gnorm": 0.3878
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "sen": 61634217
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "cost": 0.45699695
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "time": 433.62
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "rate": 590482.02
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "gnorm": 0.3936
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "chrf": 56.1556
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "ce_mean_words": 2.22663
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "bleu_detok": 28.8576
+        }
+    },
+    {
+        "step": 165000,
+        "data": {
+            "perplexity": 9.26861
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "sen": 73463669
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "cost": 0.45690277
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "time": 456.69
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "rate": 566703.11
+        }
+    },
+    {
+        "step": 166000,
+        "data": {
+            "gnorm": 0.3503
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "sen": 85213899
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "cost": 0.45712119
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "time": 433.23
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "rate": 588901.35
+        }
+    },
+    {
+        "step": 167000,
+        "data": {
+            "gnorm": 0.4
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "sen": 96963530
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "cost": 0.45645934
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "time": 435.19
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "rate": 591524.42
+        }
+    },
+    {
+        "step": 168000,
+        "data": {
+            "gnorm": 0.3691
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "epoch": 17
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "sen": 108635373
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "cost": 0.4561255
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "time": 433.88
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "rate": 591375.95
+        }
+    },
+    {
+        "step": 169000,
+        "data": {
+            "gnorm": 0.3911
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "sen": 2833043
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "cost": 0.45509434
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "time": 453.42
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "rate": 565122.81
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "gnorm": 0.3784
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "chrf": 56.1352
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "ce_mean_words": 2.22203
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "bleu_detok": 28.6235
+        }
+    },
+    {
+        "step": 170000,
+        "data": {
+            "perplexity": 9.22607
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "sen": 14580566
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "cost": 0.45330366
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "time": 457.25
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "rate": 563187.27
+        }
+    },
+    {
+        "step": 171000,
+        "data": {
+            "gnorm": 0.362
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "sen": 26346048
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "cost": 0.45379007
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "time": 433.03
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "rate": 591421.65
+        }
+    },
+    {
+        "step": 172000,
+        "data": {
+            "gnorm": 0.3727
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "sen": 38180349
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "cost": 0.45368966
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "time": 438.43
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "rate": 592053.63
+        }
+    },
+    {
+        "step": 173000,
+        "data": {
+            "gnorm": 0.3707
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "sen": 49955553
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "cost": 0.45357865
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "time": 434.36
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "rate": 591075.21
+        }
+    },
+    {
+        "step": 174000,
+        "data": {
+            "gnorm": 0.3776
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "sen": 61637835
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "cost": 0.45371526
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "time": 433.08
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "rate": 590468.92
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "gnorm": 0.3769
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "chrf": 56.3345
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "ce_mean_words": 2.24781
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "bleu_detok": 28.7349
+        }
+    },
+    {
+        "step": 175000,
+        "data": {
+            "perplexity": 9.46701
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "sen": 73484556
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "cost": 0.45314974
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "time": 459.85
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "rate": 561668.63
+        }
+    },
+    {
+        "step": 176000,
+        "data": {
+            "gnorm": 0.3658
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "sen": 85286542
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "cost": 0.45406091
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "time": 438.53
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "rate": 590028.52
+        }
+    },
+    {
+        "step": 177000,
+        "data": {
+            "gnorm": 0.3754
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "sen": 97163786
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "cost": 0.45338452
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "time": 438.26
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "rate": 590944.83
+        }
+    },
+    {
+        "step": 178000,
+        "data": {
+            "gnorm": 0.3685
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "epoch": 18
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "sen": 108913175
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "cost": 0.45368055
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "time": 436.22
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "rate": 590888.31
+        }
+    },
+    {
+        "step": 179000,
+        "data": {
+            "gnorm": 0.3913
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "sen": 3119343
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "cost": 0.45204258
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "time": 456.96
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "rate": 562674.6
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "gnorm": 0.3758
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "chrf": 56.3672
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "ce_mean_words": 2.26105
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "bleu_detok": 28.9025
+        }
+    },
+    {
+        "step": 180000,
+        "data": {
+            "perplexity": 9.59316
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "sen": 14908010
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "cost": 0.44966587
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "time": 461.34
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "rate": 559030.41
+        }
+    },
+    {
+        "step": 181000,
+        "data": {
+            "gnorm": 0.3674
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "sen": 26611622
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "cost": 0.45041338
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "time": 436.28
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "rate": 587334.43
+        }
+    },
+    {
+        "step": 182000,
+        "data": {
+            "gnorm": 0.3684
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "sen": 38402012
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "cost": 0.45100725
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "time": 437.86
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "rate": 588172.49
+        }
+    },
+    {
+        "step": 183000,
+        "data": {
+            "gnorm": 0.3774
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "sen": 50182233
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "cost": 0.45046315
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "time": 438.52
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "rate": 587374.11
+        }
+    },
+    {
+        "step": 184000,
+        "data": {
+            "gnorm": 0.3685
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "sen": 61988589
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "cost": 0.45078316
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "time": 437.73
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "rate": 588969.37
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "gnorm": 0.3776
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "chrf": 56.25
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "ce_mean_words": 2.22662
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "bleu_detok": 28.9145
+        }
+    },
+    {
+        "step": 185000,
+        "data": {
+            "perplexity": 9.26849
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "sen": 73739542
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "cost": 0.45082703
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "time": 459.85
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "rate": 559354.71
+        }
+    },
+    {
+        "step": 186000,
+        "data": {
+            "gnorm": 0.3587
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "sen": 85516353
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "cost": 0.45025146
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "time": 439.43
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "rate": 586953.96
+        }
+    },
+    {
+        "step": 187000,
+        "data": {
+            "gnorm": 0.3727
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "sen": 97366084
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "cost": 0.45009664
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "time": 438.15
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "rate": 588498.97
+        }
+    },
+    {
+        "step": 188000,
+        "data": {
+            "gnorm": 0.3655
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "epoch": 19
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "sen": 109214881
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "cost": 0.4509193
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "time": 438.72
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "rate": 586556.55
+        }
+    },
+    {
+        "step": 189000,
+        "data": {
+            "gnorm": 0.4806
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "sen": 3243603
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "cost": 0.44915855
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "time": 459.73
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "rate": 557490.94
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "gnorm": 0.3582
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "chrf": 56.1698
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "ce_mean_words": 2.22515
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "bleu_detok": 28.8545
+        }
+    },
+    {
+        "step": 190000,
+        "data": {
+            "perplexity": 9.25491
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "sen": 15047039
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "cost": 0.44777152
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "time": 460.42
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "rate": 559465.78
+        }
+    },
+    {
+        "step": 191000,
+        "data": {
+            "gnorm": 0.3769
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "sen": 26906896
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "cost": 0.44720948
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "time": 441.37
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "rate": 586939.05
+        }
+    },
+    {
+        "step": 192000,
+        "data": {
+            "gnorm": 0.3755
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "sen": 38710308
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "cost": 0.44795078
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "time": 440.15
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "rate": 586988.57
+        }
+    },
+    {
+        "step": 193000,
+        "data": {
+            "gnorm": 0.3646
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "sen": 50478455
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "cost": 0.44791254
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "time": 436.98
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "rate": 587616.93
+        }
+    },
+    {
+        "step": 194000,
+        "data": {
+            "gnorm": 0.3581
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "sen": 62310191
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "cost": 0.44817236
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "time": 439.54
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "rate": 586492.13
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "gnorm": 0.3809
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "chrf": 56.3689
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "ce_mean_words": 2.22665
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "bleu_detok": 29.068
+        }
+    },
+    {
+        "step": 195000,
+        "data": {
+            "perplexity": 9.2688
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "sen": 74081476
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "cost": 0.44821185
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "time": 463.95
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "rate": 557280.46
+        }
+    },
+    {
+        "step": 196000,
+        "data": {
+            "gnorm": 0.379
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "sen": 85874959
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "cost": 0.44817808
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "time": 441.18
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "rate": 585258.33
+        }
+    },
+    {
+        "step": 197000,
+        "data": {
+            "gnorm": 0.3738
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "sen": 97699938
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "cost": 0.44812799
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "time": 441.58
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "rate": 583960.49
+        }
+    },
+    {
+        "step": 198000,
+        "data": {
+            "gnorm": 0.3888
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "epoch": 20
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "sen": 109615073
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "cost": 0.44742417
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "time": 443.05
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "rate": 583237.02
+        }
+    },
+    {
+        "step": 199000,
+        "data": {
+            "gnorm": 0.3879
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "sen": 3664252
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "cost": 0.44631025
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "time": 463.24
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "rate": 552376.84
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "gnorm": 0.3514
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "chrf": 56.3911
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "ce_mean_words": 2.24725
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "bleu_detok": 29.1056
+        }
+    },
+    {
+        "step": 200000,
+        "data": {
+            "perplexity": 9.46171
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "sen": 15413089
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "cost": 0.44541192
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "time": 461.88
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "rate": 557418.49
+        }
+    },
+    {
+        "step": 201000,
+        "data": {
+            "gnorm": 0.3657
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "sen": 27207391
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "cost": 0.44550568
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "time": 440.55
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "rate": 584804.3
+        }
+    },
+    {
+        "step": 202000,
+        "data": {
+            "gnorm": 0.3593
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "sen": 39005095
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "cost": 0.44585809
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "time": 440.26
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "rate": 585382.49
+        }
+    },
+    {
+        "step": 203000,
+        "data": {
+            "gnorm": 0.3681
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "sen": 50834531
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "cost": 0.4450379
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "time": 440.78
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "rate": 585618.8
+        }
+    },
+    {
+        "step": 204000,
+        "data": {
+            "gnorm": 0.3685
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "sen": 62539326
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "cost": 0.44587755
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "time": 440.66
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "rate": 582137.67
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "gnorm": 0.5461
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "chrf": 56.3655
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "ce_mean_words": 2.22724
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "bleu_detok": 29.1131
+        }
+    },
+    {
+        "step": 205000,
+        "data": {
+            "perplexity": 9.27423
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "sen": 74332640
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "cost": 0.44581839
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "time": 461.12
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "rate": 558274.54
+        }
+    },
+    {
+        "step": 206000,
+        "data": {
+            "gnorm": 0.3715
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "sen": 86151961
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "cost": 0.44576955
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "time": 440.05
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "rate": 584645.87
+        }
+    },
+    {
+        "step": 207000,
+        "data": {
+            "gnorm": 0.3646
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "sen": 97928126
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "cost": 0.44510272
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "time": 441.96
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "rate": 585809.14
+        }
+    },
+    {
+        "step": 208000,
+        "data": {
+            "gnorm": 0.4152
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "epoch": 21
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "sen": 109774150
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "cost": 0.44603771
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "time": 442.41
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "rate": 583062.17
+        }
+    },
+    {
+        "step": 209000,
+        "data": {
+            "gnorm": 0.4135
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "sen": 3864530
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "cost": 0.44470102
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "time": 464.54
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "rate": 551293.98
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "gnorm": 0.3914
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "chrf": 56.3888
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "ce_mean_words": 2.24145
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "bleu_detok": 29.0923
+        }
+    },
+    {
+        "step": 210000,
+        "data": {
+            "perplexity": 9.40695
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "sen": 15692928
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "cost": 0.44195884
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "time": 460.68
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "rate": 559008.31
+        }
+    },
+    {
+        "step": 211000,
+        "data": {
+            "gnorm": 0.3722
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "sen": 27515604
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "cost": 0.44305474
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "time": 443.38
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "rate": 583944.77
+        }
+    },
+    {
+        "step": 212000,
+        "data": {
+            "gnorm": 0.3709
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "sen": 39256353
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "cost": 0.44371077
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "time": 438.47
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "rate": 583726.95
+        }
+    },
+    {
+        "step": 213000,
+        "data": {
+            "gnorm": 0.3761
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "sen": 50970542
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "cost": 0.4435164
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "time": 440.71
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "rate": 583470.73
+        }
+    },
+    {
+        "step": 214000,
+        "data": {
+            "gnorm": 0.3652
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "sen": 62826980
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "cost": 0.44330567
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "time": 442.13
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "rate": 584738.87
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "gnorm": 0.3631
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "chrf": 56.5076
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "ce_mean_words": 2.24965
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "bleu_detok": 28.9888
+        }
+    },
+    {
+        "step": 215000,
+        "data": {
+            "perplexity": 9.48446
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "sen": 74588793
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "cost": 0.44342333
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "time": 460.87
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "rate": 556670.17
+        }
+    },
+    {
+        "step": 216000,
+        "data": {
+            "gnorm": 0.3869
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "sen": 86282526
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "cost": 0.44287375
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "time": 440.36
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "rate": 583021.6
+        }
+    },
+    {
+        "step": 217000,
+        "data": {
+            "gnorm": 0.3782
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "sen": 98116696
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "cost": 0.44278762
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "time": 442.99
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "rate": 583037.79
+        }
+    },
+    {
+        "step": 218000,
+        "data": {
+            "gnorm": 0.3573
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "epoch": 22
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "sen": 109904726
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "cost": 0.44348368
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "time": 442.33
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "rate": 581640.71
+        }
+    },
+    {
+        "step": 219000,
+        "data": {
+            "gnorm": 0.3644
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "sen": 3924291
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "cost": 0.44229835
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "time": 464.2
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "rate": 548037.8
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "gnorm": 0.3884
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "chrf": 56.5687
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "ce_mean_words": 2.25062
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "bleu_detok": 29.1362
+        }
+    },
+    {
+        "step": 220000,
+        "data": {
+            "perplexity": 9.49362
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "sen": 15639136
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "cost": 0.44064739
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "time": 462.97
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "rate": 552476.6
+        }
+    },
+    {
+        "step": 221000,
+        "data": {
+            "gnorm": 0.37
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "sen": 27482789
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "cost": 0.44081715
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "time": 444.32
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "rate": 582694.88
+        }
+    },
+    {
+        "step": 222000,
+        "data": {
+            "gnorm": 0.3547
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "sen": 39239547
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "cost": 0.44143939
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "time": 442.4
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "rate": 582051.12
+        }
+    },
+    {
+        "step": 223000,
+        "data": {
+            "gnorm": 0.3563
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "sen": 51070599
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "cost": 0.44150719
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "time": 443.73
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "rate": 582277.44
+        }
+    },
+    {
+        "step": 224000,
+        "data": {
+            "gnorm": 0.3559
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "sen": 62922818
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "cost": 0.44120145
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "time": 443.37
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "rate": 582883.64
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "gnorm": 0.3448
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "chrf": 56.4264
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "ce_mean_words": 2.24877
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "bleu_detok": 29.091
+        }
+    },
+    {
+        "step": 225000,
+        "data": {
+            "perplexity": 9.47606
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "sen": 74769932
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "cost": 0.441136
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "time": 465.99
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "rate": 554714.51
+        }
+    },
+    {
+        "step": 226000,
+        "data": {
+            "gnorm": 0.3702
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "sen": 86553276
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "cost": 0.44135451
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "time": 443.27
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "rate": 582456.14
+        }
+    },
+    {
+        "step": 227000,
+        "data": {
+            "gnorm": 0.3667
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "sen": 98302120
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "cost": 0.44117048
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "time": 441.9
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "rate": 580587.43
+        }
+    },
+    {
+        "step": 228000,
+        "data": {
+            "gnorm": 0.3592
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "epoch": 23
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "sen": 110104332
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "cost": 0.44181234
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "time": 443.06
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "rate": 582519.86
+        }
+    },
+    {
+        "step": 229000,
+        "data": {
+            "gnorm": 0.3674
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "sen": 4235877
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "cost": 0.44055501
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "time": 468.47
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "rate": 546440.2
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "gnorm": 0.3784
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "chrf": 56.452
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "ce_mean_words": 2.24602
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "bleu_detok": 29.1292
+        }
+    },
+    {
+        "step": 230000,
+        "data": {
+            "perplexity": 9.45005
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "sen": 15999938
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "cost": 0.43854019
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "time": 468.14
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "rate": 550634.82
+        }
+    },
+    {
+        "step": 231000,
+        "data": {
+            "gnorm": 0.3564
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "sen": 27793978
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "cost": 0.4391906
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "time": 443.76
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "rate": 579508.05
+        }
+    },
+    {
+        "step": 232000,
+        "data": {
+            "gnorm": 0.3903
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "sen": 39475069
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "cost": 0.43898764
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "time": 442.08
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "rate": 581847.24
+        }
+    },
+    {
+        "step": 233000,
+        "data": {
+            "gnorm": 0.365
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "sen": 51355934
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "cost": 0.43921655
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "time": 446.13
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "rate": 580067.05
+        }
+    },
+    {
+        "step": 234000,
+        "data": {
+            "gnorm": 0.3419
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "sen": 63169733
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "cost": 0.439834
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "time": 444.89
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "rate": 579706.15
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "gnorm": 0.4048
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "chrf": 56.3695
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "ce_mean_words": 2.21786
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "bleu_detok": 29.0076
+        }
+    },
+    {
+        "step": 235000,
+        "data": {
+            "perplexity": 9.18762
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "sen": 74946160
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "cost": 0.43989334
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "time": 468.08
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "rate": 549143.53
+        }
+    },
+    {
+        "step": 236000,
+        "data": {
+            "gnorm": 0.3879
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "sen": 86799248
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "cost": 0.43984589
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "time": 445.51
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "rate": 580123.87
+        }
+    },
+    {
+        "step": 237000,
+        "data": {
+            "gnorm": 0.3775
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "sen": 98557043
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "cost": 0.43930057
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "time": 444.6
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "rate": 579224.02
+        }
+    },
+    {
+        "step": 238000,
+        "data": {
+            "gnorm": 0.3639
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "epoch": 24
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "sen": 110379971
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "cost": 0.43950388
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "time": 446.2
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "rate": 579443.32
+        }
+    },
+    {
+        "step": 239000,
+        "data": {
+            "gnorm": 0.3504
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "sen": 4517893
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "cost": 0.43805051
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "time": 469.58
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "rate": 546513.6
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "gnorm": 0.3644
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "chrf": 56.372
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "ce_mean_words": 2.23157
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "bleu_detok": 29.1039
+        }
+    },
+    {
+        "step": 240000,
+        "data": {
+            "perplexity": 9.31448
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "sen": 16251314
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "cost": 0.43656027
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "time": 464.63
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "rate": 552753.62
+        }
+    },
+    {
+        "step": 241000,
+        "data": {
+            "gnorm": 0.3688
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "sen": 28104273
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "cost": 0.43687513
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "time": 444.16
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "rate": 580945.05
+        }
+    },
+    {
+        "step": 242000,
+        "data": {
+            "gnorm": 0.3669
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "sen": 39839136
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "cost": 0.43714023
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "time": 442.8
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "rate": 578811.59
+        }
+    },
+    {
+        "step": 243000,
+        "data": {
+            "gnorm": 0.3671
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "sen": 51528098
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "cost": 0.43764248
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "time": 443.87
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "rate": 577747.58
+        }
+    },
+    {
+        "step": 244000,
+        "data": {
+            "gnorm": 0.3815
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "sen": 63361767
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "cost": 0.43762565
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "time": 445.96
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "rate": 579996.89
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "gnorm": 0.3711
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "chrf": 56.5864
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "ce_mean_words": 2.22491
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "bleu_detok": 29.2153
+        }
+    },
+    {
+        "step": 245000,
+        "data": {
+            "perplexity": 9.25262
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "sen": 75175866
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "cost": 0.43792155
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "time": 469.51
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "rate": 549265.72
+        }
+    },
+    {
+        "step": 246000,
+        "data": {
+            "gnorm": 0.3553
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "sen": 86940594
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "cost": 0.43772209
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "time": 444.44
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "rate": 576614.5
+        }
+    },
+    {
+        "step": 247000,
+        "data": {
+            "gnorm": 0.3577
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "sen": 98588441
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "cost": 0.43818143
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "time": 443.79
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "rate": 577381.03
+        }
+    },
+    {
+        "step": 248000,
+        "data": {
+            "gnorm": 0.372
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "epoch": 25
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "sen": 110518320
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "cost": 0.43761593
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "time": 446.87
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "rate": 579812.49
+        }
+    },
+    {
+        "step": 249000,
+        "data": {
+            "gnorm": 0.3513
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "sen": 4638969
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "cost": 0.43637943
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "time": 473.1
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "rate": 543312.03
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "gnorm": 0.3605
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "chrf": 56.4923
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "ce_mean_words": 2.2243
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "bleu_detok": 29.0982
+        }
+    },
+    {
+        "step": 250000,
+        "data": {
+            "perplexity": 9.24702
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "sen": 16418784
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "cost": 0.43534884
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "time": 465.58
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "rate": 552307.99
+        }
+    },
+    {
+        "step": 251000,
+        "data": {
+            "gnorm": 0.3783
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "sen": 28287322
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "cost": 0.43536708
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "time": 447.9
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "rate": 579347.45
+        }
+    },
+    {
+        "step": 252000,
+        "data": {
+            "gnorm": 0.3466
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "sen": 40040099
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "cost": 0.43610796
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "time": 444.7
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "rate": 579016.33
+        }
+    },
+    {
+        "step": 253000,
+        "data": {
+            "gnorm": 0.3608
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "sen": 51777886
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "cost": 0.43596169
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "time": 443.98
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "rate": 577030.6
+        }
+    },
+    {
+        "step": 254000,
+        "data": {
+            "gnorm": 0.3614
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "sen": 63512352
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "cost": 0.43589422
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "time": 445.27
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "rate": 577831.69
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "gnorm": 0.3705
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "chrf": 56.5104
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "ce_mean_words": 2.22415
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "bleu_detok": 29.16
+        }
+    },
+    {
+        "step": 255000,
+        "data": {
+            "perplexity": 9.24564
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "sen": 75370681
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "cost": 0.43613812
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "time": 468.09
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "rate": 550292.87
+        }
+    },
+    {
+        "step": 256000,
+        "data": {
+            "gnorm": 0.3399
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "sen": 87140182
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "cost": 0.43605602
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "time": 444.9
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "rate": 579090.45
+        }
+    },
+    {
+        "step": 257000,
+        "data": {
+            "gnorm": 0.3589
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "sen": 98870839
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "cost": 0.4361105
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "time": 445.54
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "rate": 577282.07
+        }
+    },
+    {
+        "step": 258000,
+        "data": {
+            "gnorm": 0.3784
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "epoch": 26
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "sen": 110744655
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "cost": 0.43640849
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "time": 446.87
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "rate": 575647.99
+        }
+    },
+    {
+        "step": 259000,
+        "data": {
+            "gnorm": 0.3665
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "sen": 4751200
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "cost": 0.43441543
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "time": 472.45
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "rate": 542106.56
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "gnorm": 0.3771
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "chrf": 56.6339
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "ce_mean_words": 2.25863
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "bleu_detok": 29.117
+        }
+    },
+    {
+        "step": 260000,
+        "data": {
+            "perplexity": 9.56998
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "sen": 16542169
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "cost": 0.43353
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "time": 467.84
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "rate": 547956.95
+        }
+    },
+    {
+        "step": 261000,
+        "data": {
+            "gnorm": 0.3793
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "sen": 28371847
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "cost": 0.43384069
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "time": 447.45
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "rate": 576437.96
+        }
+    },
+    {
+        "step": 262000,
+        "data": {
+            "gnorm": 0.3761
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "sen": 40122068
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "cost": 0.4338806
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "time": 446.02
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "rate": 578640.14
+        }
+    },
+    {
+        "step": 263000,
+        "data": {
+            "gnorm": 0.3758
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "sen": 51960463
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "cost": 0.43449128
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "time": 447.87
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "rate": 575789.87
+        }
+    },
+    {
+        "step": 264000,
+        "data": {
+            "gnorm": 0.399
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "sen": 63650219
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "cost": 0.43423343
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "time": 445.65
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "rate": 575900.88
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "gnorm": 0.3605
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "chrf": 56.2178
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "ce_mean_words": 2.22188
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "bleu_detok": 28.866
+        }
+    },
+    {
+        "step": 265000,
+        "data": {
+            "perplexity": 9.22466
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "sen": 75455073
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "cost": 0.43440267
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "time": 467.3
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "rate": 551145.86
+        }
+    },
+    {
+        "step": 266000,
+        "data": {
+            "gnorm": 0.3569
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "sen": 87280933
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "cost": 0.43432069
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "time": 446.57
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "rate": 576969.89
+        }
+    },
+    {
+        "step": 267000,
+        "data": {
+            "gnorm": 0.3419
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "sen": 99100484
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "cost": 0.43452659
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "time": 448.32
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "rate": 576952.4
+        }
+    },
+    {
+        "step": 268000,
+        "data": {
+            "gnorm": 0.3617
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "epoch": 27
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "sen": 110931962
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "cost": 0.43484607
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "time": 448.81
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "rate": 575879.27
+        }
+    },
+    {
+        "step": 269000,
+        "data": {
+            "gnorm": 0.3853
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "sen": 4999993
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "cost": 0.43333212
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "time": 472.54
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "rate": 540814.96
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "gnorm": 0.3806
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "chrf": 56.5498
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "ce_mean_words": 2.22003
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "bleu_detok": 29.199
+        }
+    },
+    {
+        "step": 270000,
+        "data": {
+            "perplexity": 9.20763
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "sen": 16843442
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "cost": 0.43181854
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "time": 468.56
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "rate": 549236.05
+        }
+    },
+    {
+        "step": 271000,
+        "data": {
+            "gnorm": 0.3793
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "sen": 28621276
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "cost": 0.43263769
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "time": 447.09
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "rate": 578085.3
+        }
+    },
+    {
+        "step": 272000,
+        "data": {
+            "gnorm": 0.3658
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "sen": 40383370
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "cost": 0.43260631
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "time": 446.42
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "rate": 578381.71
+        }
+    },
+    {
+        "step": 273000,
+        "data": {
+            "gnorm": 0.3496
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "sen": 52195736
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "cost": 0.43312678
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "time": 448.27
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "rate": 575502.13
+        }
+    },
+    {
+        "step": 274000,
+        "data": {
+            "gnorm": 0.3452
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "sen": 63975505
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "cost": 0.43313354
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "time": 445.63
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "rate": 575680.26
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "gnorm": 0.3681
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "chrf": 56.5346
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "ce_mean_words": 2.2471
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "bleu_detok": 28.91
+        }
+    },
+    {
+        "step": 275000,
+        "data": {
+            "perplexity": 9.46031
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "sen": 75737612
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "cost": 0.43315428
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "time": 468.1
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "rate": 549935.16
+        }
+    },
+    {
+        "step": 276000,
+        "data": {
+            "gnorm": 0.3375
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "sen": 87529871
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "cost": 0.4335297
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "time": 446.44
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "rate": 576992.65
+        }
+    },
+    {
+        "step": 277000,
+        "data": {
+            "gnorm": 0.3603
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "sen": 99369099
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "cost": 0.43320602
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "time": 447.83
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "rate": 577485.32
+        }
+    },
+    {
+        "step": 278000,
+        "data": {
+            "gnorm": 0.3668
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "epoch": 28
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "sen": 111208774
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "cost": 0.43340576
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "time": 446.88
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "rate": 576031.99
+        }
+    },
+    {
+        "step": 279000,
+        "data": {
+            "gnorm": 0.3721
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "sen": 5320405
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "cost": 0.43155792
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "time": 472.77
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "rate": 541450.83
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "gnorm": 0.3848
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "chrf": 56.5685
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "ce_mean_words": 2.25501
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "bleu_detok": 29.0928
+        }
+    },
+    {
+        "step": 280000,
+        "data": {
+            "perplexity": 9.53538
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "sen": 17018921
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "cost": 0.43104631
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "time": 471.84
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "rate": 545314.94
+        }
+    },
+    {
+        "step": 281000,
+        "data": {
+            "gnorm": 0.3787
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "sen": 28826556
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "cost": 0.43086576
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "time": 446.84
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "rate": 577821.66
+        }
+    },
+    {
+        "step": 282000,
+        "data": {
+            "gnorm": 0.3503
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "sen": 40676243
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "cost": 0.43109739
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "time": 448.51
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "rate": 577169.36
+        }
+    },
+    {
+        "step": 283000,
+        "data": {
+            "gnorm": 0.3529
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "sen": 52398047
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "cost": 0.43122756
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "time": 445.18
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "rate": 576531.72
+        }
+    },
+    {
+        "step": 284000,
+        "data": {
+            "gnorm": 0.3502
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "sen": 64168999
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "cost": 0.43178615
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "time": 446.8
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "rate": 575987.76
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "gnorm": 0.3642
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "chrf": 56.5379
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "ce_mean_words": 2.25144
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "bleu_detok": 29.1774
+        }
+    },
+    {
+        "step": 285000,
+        "data": {
+            "perplexity": 9.50138
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "sen": 76046918
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "cost": 0.43129116
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "time": 475.3
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "rate": 546390.35
+        }
+    },
+    {
+        "step": 286000,
+        "data": {
+            "gnorm": 0.3743
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "sen": 87867837
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "cost": 0.43163234
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "time": 447.05
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "rate": 575955.96
+        }
+    },
+    {
+        "step": 287000,
+        "data": {
+            "gnorm": 0.3778
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "sen": 99680043
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "cost": 0.43207401
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "time": 447.17
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "rate": 575954.22
+        }
+    },
+    {
+        "step": 288000,
+        "data": {
+            "gnorm": 0.3831
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "epoch": 29
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "sen": 111495571
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "cost": 0.431321
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "time": 447.49
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "rate": 577890.74
+        }
+    },
+    {
+        "step": 289000,
+        "data": {
+            "gnorm": 0.3636
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "sen": 5639986
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "cost": 0.43085283
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "time": 474.65
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "rate": 539658.35
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "gnorm": 0.3625
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "chrf": 56.0941
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "ce_mean_words": 2.21589
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "bleu_detok": 28.723
+        }
+    },
+    {
+        "step": 290000,
+        "data": {
+            "perplexity": 9.16953
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "sen": 17413967
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "cost": 0.42911133
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "time": 470.8
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "rate": 547544.84
+        }
+    },
+    {
+        "step": 291000,
+        "data": {
+            "gnorm": 0.3706
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "sen": 29212161
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "cost": 0.42959651
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "time": 447.19
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "rate": 577917.74
+        }
+    },
+    {
+        "step": 292000,
+        "data": {
+            "gnorm": 0.3632
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "sen": 41041580
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "cost": 0.43033442
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "time": 446.7
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "rate": 577493.83
+        }
+    },
+    {
+        "step": 293000,
+        "data": {
+            "gnorm": 0.482
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "sen": 52810914
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "cost": 0.43031818
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "time": 447.13
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "rate": 576876.83
+        }
+    },
+    {
+        "step": 294000,
+        "data": {
+            "gnorm": 0.3522
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "sen": 64618578
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "cost": 0.43026277
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "time": 446.71
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "rate": 575671.21
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "gnorm": 0.3904
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "chrf": 56.3707
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "ce_mean_words": 2.19877
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "bleu_detok": 29.0869
+        }
+    },
+    {
+        "step": 295000,
+        "data": {
+            "perplexity": 9.01395
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "sen": 76438646
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "cost": 0.43032601
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "time": 469.71
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "rate": 549699.02
+        }
+    },
+    {
+        "step": 296000,
+        "data": {
+            "gnorm": 0.3679
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "sen": 88190458
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "cost": 0.43040115
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "time": 445.36
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "rate": 577917.33
+        }
+    },
+    {
+        "step": 297000,
+        "data": {
+            "gnorm": 0.3568
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "sen": 99914767
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "cost": 0.43061516
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "time": 444.6
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "rate": 576013.51
+        }
+    },
+    {
+        "step": 298000,
+        "data": {
+            "gnorm": 0.3531
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "epoch": 30
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "sen": 111657624
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "cost": 0.43104616
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "time": 446.54
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "rate": 577072.31
+        }
+    },
+    {
+        "step": 299000,
+        "data": {
+            "gnorm": 0.3763
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "sen": 5864819
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "cost": 0.4288303
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "time": 474.14
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "rate": 543258.19
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "gnorm": 0.372
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "chrf": 56.4823
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "ce_mean_words": 2.23213
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "bleu_detok": 29.092
+        }
+    },
+    {
+        "step": 300000,
+        "data": {
+            "perplexity": 9.31968
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "sen": 17600634
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "cost": 0.42809597
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "time": 466.03
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "rate": 548922.69
+        }
+    },
+    {
+        "step": 301000,
+        "data": {
+            "gnorm": 0.3723
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "sen": 29359476
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "cost": 0.42879906
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "time": 447.34
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "rate": 578324.23
+        }
+    },
+    {
+        "step": 302000,
+        "data": {
+            "gnorm": 0.3757
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "sen": 41165195
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "cost": 0.42915285
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "time": 445.35
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "rate": 576495.29
+        }
+    },
+    {
+        "step": 303000,
+        "data": {
+            "gnorm": 0.3719
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "sen": 52980572
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "cost": 0.42915481
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "time": 447.78
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "rate": 576994.4
+        }
+    },
+    {
+        "step": 304000,
+        "data": {
+            "gnorm": 0.3637
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "sen": 64711381
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "cost": 0.42935294
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "time": 446.05
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "rate": 574329.67
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "gnorm": 0.3596
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "chrf": 56.6732
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "ce_mean_words": 2.21238
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "bleu_detok": 29.4477
+        }
+    },
+    {
+        "step": 305000,
+        "data": {
+            "perplexity": 9.13743
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "sen": 76582390
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "cost": 0.42957613
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "time": 469.71
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "rate": 551135.61
+        }
+    },
+    {
+        "step": 306000,
+        "data": {
+            "gnorm": 0.3766
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "sen": 88348540
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "cost": 0.42923048
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "time": 446.81
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "rate": 576784.4
+        }
+    },
+    {
+        "step": 307000,
+        "data": {
+            "gnorm": 0.3789
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "sen": 100139188
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "cost": 0.42923689
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "time": 447.4
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "rate": 576820.31
+        }
+    },
+    {
+        "step": 308000,
+        "data": {
+            "gnorm": 0.3615
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "epoch": 31
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "sen": 111972400
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "cost": 0.42955807
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "time": 447.09
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "rate": 577301.37
+        }
+    },
+    {
+        "step": 309000,
+        "data": {
+            "gnorm": 0.3781
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "sen": 6196974
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "cost": 0.4276827
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "time": 475.65
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "rate": 541005.82
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "gnorm": 0.396
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "chrf": 56.5889
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "ce_mean_words": 2.23886
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "bleu_detok": 29.2612
+        }
+    },
+    {
+        "step": 310000,
+        "data": {
+            "perplexity": 9.38267
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "sen": 17894088
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "cost": 0.42720792
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "time": 473.11
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "rate": 544137.48
+        }
+    },
+    {
+        "step": 311000,
+        "data": {
+            "gnorm": 0.3563
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "sen": 29728573
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "cost": 0.42738834
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "time": 448.56
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "rate": 576353.69
+        }
+    },
+    {
+        "step": 312000,
+        "data": {
+            "gnorm": 0.3476
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "sen": 41617989
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "cost": 0.42749053
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "time": 448.37
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "rate": 577892.45
+        }
+    },
+    {
+        "step": 313000,
+        "data": {
+            "gnorm": 0.3611
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "sen": 53354358
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "cost": 0.42760217
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "time": 444.28
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "rate": 577997.65
+        }
+    },
+    {
+        "step": 314000,
+        "data": {
+            "gnorm": 0.3784
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "sen": 65135680
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "cost": 0.42803776
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "time": 445.78
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "rate": 577339.89
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "gnorm": 0.3776
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "chrf": 56.5164
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "ce_mean_words": 2.22641
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "bleu_detok": 29.255
+        }
+    },
+    {
+        "step": 315000,
+        "data": {
+            "perplexity": 9.26654
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "sen": 76973315
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "cost": 0.4280864
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "time": 475.23
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "rate": 544422.49
+        }
+    },
+    {
+        "step": 316000,
+        "data": {
+            "gnorm": 0.367
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "sen": 88776638
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "cost": 0.42793134
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "time": 445.62
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "rate": 577957.67
+        }
+    },
+    {
+        "step": 317000,
+        "data": {
+            "gnorm": 0.3693
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "sen": 100591782
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "cost": 0.42817906
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "time": 446.11
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "rate": 577823.14
+        }
+    },
+    {
+        "step": 318000,
+        "data": {
+            "gnorm": 0.3854
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "epoch": 32
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "sen": 112350138
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "cost": 0.42830694
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "time": 446.58
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "rate": 575196.29
+        }
+    },
+    {
+        "step": 319000,
+        "data": {
+            "gnorm": 0.3904
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "sen": 6513271
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "cost": 0.42616892
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "time": 474.48
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "rate": 542619.65
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "gnorm": 0.3726
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "chrf": 56.5815
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "ce_mean_words": 2.22698
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "bleu_detok": 29.2738
+        }
+    },
+    {
+        "step": 320000,
+        "data": {
+            "perplexity": 9.27182
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "sen": 18334107
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "cost": 0.42632654
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "time": 472.61
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "rate": 546867.15
+        }
+    },
+    {
+        "step": 321000,
+        "data": {
+            "gnorm": 0.371
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "sen": 30112839
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "cost": 0.42652088
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "time": 446.72
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "rate": 577362.66
+        }
+    },
+    {
+        "step": 322000,
+        "data": {
+            "gnorm": 0.3773
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "sen": 41899375
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "cost": 0.42698514
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "time": 447.6
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "rate": 575460.9
+        }
+    },
+    {
+        "step": 323000,
+        "data": {
+            "gnorm": 0.369
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "sen": 53644087
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "cost": 0.42709965
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "time": 446.85
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "rate": 574453.29
+        }
+    },
+    {
+        "step": 324000,
+        "data": {
+            "gnorm": 0.3935
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "sen": 65392024
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "cost": 0.4271175
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "time": 446.4
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "rate": 577477.74
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "gnorm": 0.3558
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "chrf": 56.478
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "ce_mean_words": 2.2197
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "bleu_detok": 29.1451
+        }
+    },
+    {
+        "step": 325000,
+        "data": {
+            "perplexity": 9.20456
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "sen": 77264815
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "cost": 0.42709443
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "time": 470.94
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "rate": 548365.73
+        }
+    },
+    {
+        "step": 326000,
+        "data": {
+            "gnorm": 0.386
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "sen": 88993675
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "cost": 0.42676288
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "time": 444.08
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "rate": 577256.96
+        }
+    },
+    {
+        "step": 327000,
+        "data": {
+            "gnorm": 0.3719
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "sen": 100783060
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "cost": 0.42708147
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "time": 446.51
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "rate": 577129.01
+        }
+    },
+    {
+        "step": 328000,
+        "data": {
+            "gnorm": 0.3756
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "epoch": 33
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "sen": 112623519
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "cost": 0.42670077
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "time": 448.53
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "rate": 576014.27
+        }
+    },
+    {
+        "step": 329000,
+        "data": {
+            "gnorm": 0.3722
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "sen": 6741071
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "cost": 0.42518342
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "time": 474.28
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "rate": 542425.03
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "gnorm": 0.3702
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "chrf": 56.6786
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "ce_mean_words": 2.26187
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "bleu_detok": 29.2372
+        }
+    },
+    {
+        "step": 330000,
+        "data": {
+            "perplexity": 9.60103
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "sen": 18482803
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "cost": 0.42507765
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "time": 467.55
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "rate": 547183.86
+        }
+    },
+    {
+        "step": 331000,
+        "data": {
+            "gnorm": 0.3715
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "sen": 30256788
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "cost": 0.42525265
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "time": 446.13
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "rate": 577962.04
+        }
+    },
+    {
+        "step": 332000,
+        "data": {
+            "gnorm": 0.3733
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "sen": 42073350
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "cost": 0.4257713
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "time": 446.39
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "rate": 577583.5
+        }
+    },
+    {
+        "step": 333000,
+        "data": {
+            "gnorm": 0.368
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "sen": 53898682
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "cost": 0.42556387
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "time": 447.04
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "rate": 576291.86
+        }
+    },
+    {
+        "step": 334000,
+        "data": {
+            "gnorm": 0.389
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "sen": 65624079
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "cost": 0.42552322
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "time": 446.0
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "rate": 575282.46
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "gnorm": 0.3747
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "chrf": 56.5903
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "ce_mean_words": 2.22264
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "bleu_detok": 29.3104
+        }
+    },
+    {
+        "step": 335000,
+        "data": {
+            "perplexity": 9.23171
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "sen": 77444474
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "cost": 0.42606494
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "time": 469.25
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "rate": 550088.54
+        }
+    },
+    {
+        "step": 336000,
+        "data": {
+            "gnorm": 0.3598
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "sen": 89170016
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "cost": 0.42636302
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "time": 444.82
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "rate": 577119.32
+        }
+    },
+    {
+        "step": 337000,
+        "data": {
+            "gnorm": 0.3902
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "sen": 100962165
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "cost": 0.42625621
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "time": 447.75
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "rate": 575164.38
+        }
+    },
+    {
+        "step": 338000,
+        "data": {
+            "gnorm": 0.3751
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "epoch": 34
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "sen": 112777429
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "cost": 0.42610222
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "time": 447.35
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "rate": 577276.01
+        }
+    },
+    {
+        "step": 339000,
+        "data": {
+            "gnorm": 0.3912
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "sen": 6818269
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "cost": 0.42467371
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "time": 473.85
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "rate": 539039.25
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "gnorm": 0.367
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "chrf": 56.6415
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "ce_mean_words": 2.22314
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "bleu_detok": 29.3083
+        }
+    },
+    {
+        "step": 340000,
+        "data": {
+            "perplexity": 9.23632
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "sen": 18612510
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "cost": 0.42355597
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "time": 470.46
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "rate": 548459.31
+        }
+    },
+    {
+        "step": 341000,
+        "data": {
+            "gnorm": 0.3626
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "sen": 30497808
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "cost": 0.42442226
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "time": 447.76
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "rate": 576816.45
+        }
+    },
+    {
+        "step": 342000,
+        "data": {
+            "gnorm": 0.3768
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "sen": 42271140
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "cost": 0.42478597
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "time": 446.55
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "rate": 575701.73
+        }
+    },
+    {
+        "step": 343000,
+        "data": {
+            "gnorm": 0.3778
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "sen": 54039446
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "cost": 0.42444637
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "time": 447.6
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "rate": 578046.16
+        }
+    },
+    {
+        "step": 344000,
+        "data": {
+            "gnorm": 0.3718
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "sen": 65913929
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "cost": 0.4246963
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "time": 448.32
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "rate": 577001.73
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "gnorm": 0.3387
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "chrf": 56.653
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "ce_mean_words": 2.22846
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "bleu_detok": 29.313
+        }
+    },
+    {
+        "step": 345000,
+        "data": {
+            "perplexity": 9.28554
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "sen": 77642610
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "cost": 0.4251903
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "time": 468.93
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "rate": 548974.63
+        }
+    },
+    {
+        "step": 346000,
+        "data": {
+            "gnorm": 0.3779
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "sen": 89457379
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "cost": 0.42521256
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "time": 445.85
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "rate": 576707.05
+        }
+    },
+    {
+        "step": 347000,
+        "data": {
+            "gnorm": 0.3746
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "sen": 101291418
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "cost": 0.42481172
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "time": 446.52
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "rate": 576888.21
+        }
+    },
+    {
+        "step": 348000,
+        "data": {
+            "gnorm": 0.385
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "epoch": 35
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "sen": 113041544
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "cost": 0.42521274
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "time": 444.88
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "rate": 580165.28
+        }
+    },
+    {
+        "step": 349000,
+        "data": {
+            "gnorm": 0.3889
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "sen": 7126278
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "cost": 0.42340738
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "time": 472.42
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "rate": 540093.44
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "gnorm": 0.3567
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "chrf": 56.5983
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "ce_mean_words": 2.22951
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "bleu_detok": 29.3574
+        }
+    },
+    {
+        "step": 350000,
+        "data": {
+            "perplexity": 9.29532
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "sen": 18841942
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "cost": 0.42268735
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "time": 471.36
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "rate": 544694.31
+        }
+    },
+    {
+        "step": 351000,
+        "data": {
+            "gnorm": 0.3772
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "sen": 30694707
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "cost": 0.42332387
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "time": 447.26
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "rate": 575120.19
+        }
+    },
+    {
+        "step": 352000,
+        "data": {
+            "gnorm": 0.3621
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "sen": 42498993
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "cost": 0.4235788
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "time": 447.51
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "rate": 578966.59
+        }
+    },
+    {
+        "step": 353000,
+        "data": {
+            "gnorm": 0.359
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "sen": 54303926
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "cost": 0.42345852
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "time": 447.31
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "rate": 578731.39
+        }
+    },
+    {
+        "step": 354000,
+        "data": {
+            "gnorm": 0.3423
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "sen": 66105017
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "cost": 0.42404088
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "time": 447.8
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "rate": 575797.44
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "gnorm": 0.3673
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "chrf": 56.7085
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "ce_mean_words": 2.22736
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "bleu_detok": 29.3785
+        }
+    },
+    {
+        "step": 355000,
+        "data": {
+            "perplexity": 9.27531
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "sen": 77838995
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "cost": 0.42379859
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "time": 470.91
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "rate": 541659.35
+        }
+    },
+    {
+        "step": 356000,
+        "data": {
+            "gnorm": 0.3661
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "sen": 89639610
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "cost": 0.42431182
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "time": 449.29
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "rate": 576665.43
+        }
+    },
+    {
+        "step": 357000,
+        "data": {
+            "gnorm": 0.3466
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "sen": 101466763
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "cost": 0.42413855
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "time": 447.11
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "rate": 576333.92
+        }
+    },
+    {
+        "step": 358000,
+        "data": {
+            "gnorm": 0.3673
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "epoch": 36
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "sen": 113274974
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "cost": 0.42411876
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "time": 447.41
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "rate": 576601.08
+        }
+    },
+    {
+        "step": 359000,
+        "data": {
+            "gnorm": 0.3722
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "sen": 7363031
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "cost": 0.42273402
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "time": 472.9
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "rate": 540706.34
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "gnorm": 0.3654
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "chrf": 56.5368
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "ce_mean_words": 2.23702
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "bleu_detok": 29.2741
+        }
+    },
+    {
+        "step": 360000,
+        "data": {
+            "perplexity": 9.36541
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "sen": 19100723
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "cost": 0.42225498
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "time": 470.19
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "rate": 547825.99
+        }
+    },
+    {
+        "step": 361000,
+        "data": {
+            "gnorm": 0.3723
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "sen": 30951129
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "cost": 0.42232558
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "time": 446.66
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "rate": 577273.68
+        }
+    },
+    {
+        "step": 362000,
+        "data": {
+            "gnorm": 0.3764
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "sen": 42724684
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "cost": 0.42280048
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "time": 446.74
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "rate": 576703.73
+        }
+    },
+    {
+        "step": 363000,
+        "data": {
+            "gnorm": 0.3734
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "sen": 54661299
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "cost": 0.42276621
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "time": 451.17
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "rate": 578131.15
+        }
+    },
+    {
+        "step": 364000,
+        "data": {
+            "gnorm": 0.3645
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "sen": 66439137
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "cost": 0.42285624
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "time": 447.11
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "rate": 576636.14
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "gnorm": 0.3809
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "chrf": 56.6618
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "ce_mean_words": 2.22496
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "bleu_detok": 29.3497
+        }
+    },
+    {
+        "step": 365000,
+        "data": {
+            "perplexity": 9.2531
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "sen": 78211870
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "cost": 0.42318329
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "time": 468.98
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "rate": 545490.11
+        }
+    },
+    {
+        "step": 366000,
+        "data": {
+            "gnorm": 0.3702
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "sen": 89984536
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "cost": 0.42337519
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "time": 447.03
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "rate": 576565.54
+        }
+    },
+    {
+        "step": 367000,
+        "data": {
+            "gnorm": 0.357
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "sen": 101665619
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "cost": 0.42365173
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "time": 444.91
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "rate": 576330.21
+        }
+    },
+    {
+        "step": 368000,
+        "data": {
+            "gnorm": 0.3686
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "epoch": 37
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "sen": 113544568
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "cost": 0.42301959
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "time": 448.82
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "rate": 577190.15
+        }
+    },
+    {
+        "step": 369000,
+        "data": {
+            "gnorm": 0.3601
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "sen": 7642815
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "cost": 0.42135236
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "time": 471.68
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "rate": 539957.95
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "gnorm": 0.3866
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "chrf": 56.4225
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "ce_mean_words": 2.21267
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "bleu_detok": 29.1088
+        }
+    },
+    {
+        "step": 370000,
+        "data": {
+            "perplexity": 9.1401
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "sen": 19333079
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "cost": 0.42108682
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "time": 466.3
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "rate": 550930.3
+        }
+    },
+    {
+        "step": 371000,
+        "data": {
+            "gnorm": 0.363
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "sen": 31276471
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "cost": 0.42146933
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "time": 450.23
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "rate": 577874.43
+        }
+    },
+    {
+        "step": 372000,
+        "data": {
+            "gnorm": 0.3521
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "sen": 43019473
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "cost": 0.42136693
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "time": 445.67
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "rate": 577292.37
+        }
+    },
+    {
+        "step": 373000,
+        "data": {
+            "gnorm": 0.3614
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "sen": 54924730
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "cost": 0.42143333
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "time": 449.69
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "rate": 577615.22
+        }
+    },
+    {
+        "step": 374000,
+        "data": {
+            "gnorm": 0.3539
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "sen": 66698217
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "cost": 0.42232859
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "time": 447.58
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "rate": 575903.15
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "gnorm": 0.3784
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "chrf": 56.5913
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "ce_mean_words": 2.22828
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "bleu_detok": 29.2885
+        }
+    },
+    {
+        "step": 375000,
+        "data": {
+            "perplexity": 9.28391
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "sen": 78484260
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "cost": 0.42247868
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "time": 468.21
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "rate": 549130.04
+        }
+    },
+    {
+        "step": 376000,
+        "data": {
+            "gnorm": 0.364
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "sen": 90329313
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "cost": 0.4222962
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "time": 447.37
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "rate": 576730.53
+        }
+    },
+    {
+        "step": 377000,
+        "data": {
+            "gnorm": 0.3721
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "sen": 101999641
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "cost": 0.42243907
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "time": 444.13
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "rate": 576400.65
+        }
+    },
+    {
+        "step": 378000,
+        "data": {
+            "gnorm": 0.3794
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "epoch": 38
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "sen": 113859870
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "cost": 0.42228359
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "time": 448.65
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "rate": 576610.29
+        }
+    },
+    {
+        "step": 379000,
+        "data": {
+            "gnorm": 0.3643
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "sen": 7943596
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "cost": 0.42053586
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "time": 471.71
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "rate": 540708.54
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "gnorm": 0.3839
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "chrf": 56.6336
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "ce_mean_words": 2.24635
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "bleu_detok": 29.3747
+        }
+    },
+    {
+        "step": 380000,
+        "data": {
+            "perplexity": 9.45316
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "sen": 19632957
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "cost": 0.42063504
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "time": 466.94
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "rate": 549123.89
+        }
+    },
+    {
+        "step": 381000,
+        "data": {
+            "gnorm": 0.3877
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "sen": 31422494
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "cost": 0.42052266
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "time": 445.1
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "rate": 578790.72
+        }
+    },
+    {
+        "step": 382000,
+        "data": {
+            "gnorm": 0.3867
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "sen": 43204330
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "cost": 0.42111155
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "time": 445.57
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "rate": 578451.17
+        }
+    },
+    {
+        "step": 383000,
+        "data": {
+            "gnorm": 0.3734
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "sen": 55022546
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "cost": 0.42119005
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "time": 448.04
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "rate": 576408.55
+        }
+    },
+    {
+        "step": 384000,
+        "data": {
+            "gnorm": 0.372
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "sen": 66882088
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "cost": 0.4215644
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "time": 444.93
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "rate": 579661.15
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "gnorm": 0.3777
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "chrf": 56.6508
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "ce_mean_words": 2.22869
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "bleu_detok": 29.3221
+        }
+    },
+    {
+        "step": 385000,
+        "data": {
+            "perplexity": 9.28774
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "sen": 78688231
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "cost": 0.42125267
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "time": 471.32
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "rate": 549894.71
+        }
+    },
+    {
+        "step": 386000,
+        "data": {
+            "gnorm": 0.3434
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "sen": 90426852
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "cost": 0.42211333
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "time": 443.13
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "rate": 577464.99
+        }
+    },
+    {
+        "step": 387000,
+        "data": {
+            "gnorm": 0.3642
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "sen": 102254488
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "cost": 0.42129838
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "time": 447.5
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "rate": 577707.17
+        }
+    },
+    {
+        "step": 388000,
+        "data": {
+            "gnorm": 0.3899
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "epoch": 39
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "sen": 114034552
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "cost": 0.42163926
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "time": 447.29
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "rate": 576858.3
+        }
+    },
+    {
+        "step": 389000,
+        "data": {
+            "gnorm": 0.3731
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "sen": 8193723
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "cost": 0.42002839
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "time": 475.24
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "rate": 540988.85
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "gnorm": 0.3839
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "chrf": 56.6093
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "ce_mean_words": 2.23138
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "bleu_detok": 29.2654
+        }
+    },
+    {
+        "step": 390000,
+        "data": {
+            "perplexity": 9.31273
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "sen": 19890711
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "cost": 0.41947886
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "time": 469.68
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "rate": 544909.35
+        }
+    },
+    {
+        "step": 391000,
+        "data": {
+            "gnorm": 0.3715
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "sen": 31657413
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "cost": 0.41992235
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "time": 445.82
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "rate": 576603.3
+        }
+    },
+    {
+        "step": 392000,
+        "data": {
+            "gnorm": 0.3763
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "sen": 43449081
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "cost": 0.41992283
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "time": 446.84
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "rate": 577311.63
+        }
+    },
+    {
+        "step": 393000,
+        "data": {
+            "gnorm": 0.376
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "sen": 55250922
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "cost": 0.42044222
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "time": 445.68
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "rate": 577011.86
+        }
+    },
+    {
+        "step": 394000,
+        "data": {
+            "gnorm": 0.3665
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "sen": 67033428
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "cost": 0.42075121
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "time": 445.62
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "rate": 577684.96
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "gnorm": 0.3803
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "epoch": 40
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "chrf": 56.5246
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "ce_mean_words": 2.22034
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "bleu_detok": 29.2253
+        }
+    },
+    {
+        "step": 395000,
+        "data": {
+            "perplexity": 9.21047
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "sen": 22400
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "cost": 0.42945915
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "time": 242.9
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "rate": 1600.9
+        }
+    },
+    {
+        "step": 1,
+        "data": {
+            "gnorm": 0.3028
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "sen": 40800
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "cost": 0.43385255
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "time": 0.69
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "rate": 620093.04
+        }
+    },
+    {
+        "step": 2,
+        "data": {
+            "gnorm": 0.3022
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "sen": 48512
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "cost": 0.44706488
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "time": 0.8
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "rate": 535057.13
+        }
+    },
+    {
+        "step": 3,
+        "data": {
+            "gnorm": 0.319
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "sen": 70912
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "cost": 0.42464179
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "time": 0.58
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "rate": 582540.8
+        }
+    },
+    {
+        "step": 4,
+        "data": {
+            "gnorm": 0.3044
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "sen": 109716
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "cost": 0.43045926
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "time": 0.75
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "rate": 672397.58
+        }
+    },
+    {
+        "step": 5,
+        "data": {
+            "gnorm": 0.3078
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "sen": 132116
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "cost": 0.4244875
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "time": 0.63
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "rate": 640719.38
+        }
+    },
+    {
+        "step": 6,
+        "data": {
+            "gnorm": 0.2979
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "sen": 143860
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "cost": 0.44767788
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "time": 0.73
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "rate": 627707.66
+        }
+    },
+    {
+        "step": 7,
+        "data": {
+            "gnorm": 0.3054
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "sen": 149460
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "cost": 0.46901628
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "time": 0.87
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "rate": 538549.45
+        }
+    },
+    {
+        "step": 8,
+        "data": {
+            "gnorm": 0.3349
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "sen": 161204
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "cost": 0.45137054
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "time": 0.73
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "rate": 653297.11
+        }
+    },
+    {
+        "step": 9,
+        "data": {
+            "gnorm": 0.3298
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "sen": 176724
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "cost": 0.43862325
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "time": 0.67
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "rate": 704617.37
+        }
+    },
+    {
+        "step": 10,
+        "data": {
+            "gnorm": 0.3267
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "sen": 1988245
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "cost": 0.44293833
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "time": 62.12
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "rate": 624799.04
+        }
+    },
+    {
+        "step": 100,
+        "data": {
+            "gnorm": 0.3432
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "sen": 4044783
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "cost": 0.44180658
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "time": 73.8
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "rate": 609363.67
+        }
+    },
+    {
+        "step": 200,
+        "data": {
+            "gnorm": 0.3064
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "sen": 6040776
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "cost": 0.44082555
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "time": 71.74
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "rate": 610456.94
+        }
+    },
+    {
+        "step": 300,
+        "data": {
+            "gnorm": 0.3112
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "sen": 8026819
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "cost": 0.43916216
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "time": 72.22
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "rate": 606176.23
+        }
+    },
+    {
+        "step": 400,
+        "data": {
+            "gnorm": 0.2604
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "sen": 10037885
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "cost": 0.43592939
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "time": 72.29
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "rate": 605841.35
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "gnorm": 0.2231
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "chrf": 56.4569
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "ce_mean_words": 2.2451
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "bleu_detok": 29.1717
+        }
+    },
+    {
+        "step": 500,
+        "data": {
+            "perplexity": 9.44136
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "sen": 12096400
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "cost": 0.43422392
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "time": 100.64
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "rate": 437122.89
+        }
+    },
+    {
+        "step": 600,
+        "data": {
+            "gnorm": 0.2136
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "sen": 14054254
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "cost": 0.43195471
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "time": 73.16
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "rate": 605920.87
+        }
+    },
+    {
+        "step": 700,
+        "data": {
+            "gnorm": 0.2129
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "sen": 16156263
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "cost": 0.42985243
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "time": 74.14
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "rate": 604111.59
+        }
+    },
+    {
+        "step": 800,
+        "data": {
+            "gnorm": 0.1995
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "sen": 18175872
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "cost": 0.42936045
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "time": 73.83
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "rate": 604887.29
+        }
+    },
+    {
+        "step": 900,
+        "data": {
+            "gnorm": 0.1995
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "sen": 20312610
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "cost": 0.42563558
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "time": 74.09
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "rate": 604047.69
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "gnorm": 0.2063
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "chrf": 56.555
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "ce_mean_words": 2.2404
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "bleu_detok": 29.2629
+        }
+    },
+    {
+        "step": 1000,
+        "data": {
+            "perplexity": 9.39711
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "sen": 22232542
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "cost": 0.4270623
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "time": 101.16
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "rate": 437805.26
+        }
+    },
+    {
+        "step": 1100,
+        "data": {
+            "gnorm": 0.1977
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "sen": 24227740
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "cost": 0.42348987
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "time": 72.39
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "rate": 608690.26
+        }
+    },
+    {
+        "step": 1200,
+        "data": {
+            "gnorm": 0.1981
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "sen": 26356719
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "cost": 0.42560452
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "time": 73.28
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "rate": 604304.17
+        }
+    },
+    {
+        "step": 1300,
+        "data": {
+            "gnorm": 0.2061
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "sen": 28394846
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "cost": 0.42287678
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "time": 74.43
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "rate": 609888.13
+        }
+    },
+    {
+        "step": 1400,
+        "data": {
+            "gnorm": 0.1936
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "sen": 30442333
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "cost": 0.42398295
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "time": 72.72
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "rate": 601838.98
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "gnorm": 0.2061
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "chrf": 56.5788
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "ce_mean_words": 2.23758
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "bleu_detok": 29.3035
+        }
+    },
+    {
+        "step": 1500,
+        "data": {
+            "perplexity": 9.37062
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "sen": 32372383
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "cost": 0.42146775
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "time": 100.41
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "rate": 442000.34
+        }
+    },
+    {
+        "step": 1600,
+        "data": {
+            "gnorm": 0.1965
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "sen": 34393940
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "cost": 0.42263454
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "time": 74.12
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "rate": 603001.55
+        }
+    },
+    {
+        "step": 1700,
+        "data": {
+            "gnorm": 0.2015
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "sen": 36388353
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "cost": 0.42409346
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "time": 74.1
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "rate": 597651.19
+        }
+    },
+    {
+        "step": 1800,
+        "data": {
+            "gnorm": 0.2082
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "sen": 38429891
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "cost": 0.42277914
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "time": 72.55
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "rate": 602980.23
+        }
+    },
+    {
+        "step": 1900,
+        "data": {
+            "gnorm": 0.2096
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "sen": 40480830
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "cost": 0.42296642
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "time": 73.11
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "rate": 597591.66
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "gnorm": 0.2105
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "chrf": 56.5645
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "ce_mean_words": 2.23792
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "bleu_detok": 29.2485
+        }
+    },
+    {
+        "step": 2000,
+        "data": {
+            "perplexity": 9.37382
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "sen": 42508592
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "cost": 0.42160124
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "time": 98.94
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "rate": 447976.82
+        }
+    },
+    {
+        "step": 2100,
+        "data": {
+            "gnorm": 0.2102
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "sen": 44446794
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "cost": 0.42323029
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "time": 72.61
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "rate": 598092.04
+        }
+    },
+    {
+        "step": 2200,
+        "data": {
+            "gnorm": 0.2153
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "sen": 46521578
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "cost": 0.4216395
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "time": 72.75
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "rate": 606211.79
+        }
+    },
+    {
+        "step": 2300,
+        "data": {
+            "gnorm": 0.2173
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "sen": 48611127
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "cost": 0.42312729
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "time": 74.05
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "rate": 601908.91
+        }
+    },
+    {
+        "step": 2400,
+        "data": {
+            "gnorm": 0.2175
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "sen": 50616784
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "cost": 0.42202282
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "time": 74.39
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "rate": 608994.22
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "gnorm": 0.215
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "chrf": 56.5788
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "ce_mean_words": 2.23387
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "bleu_detok": 29.2723
+        }
+    },
+    {
+        "step": 2500,
+        "data": {
+            "perplexity": 9.3359
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "sen": 52665109
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "cost": 0.42341959
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "time": 101.21
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "rate": 441377.74
+        }
+    },
+    {
+        "step": 2600,
+        "data": {
+            "gnorm": 0.22
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "sen": 54751029
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "cost": 0.4228147
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "time": 74.07
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "rate": 605778.5
+        }
+    },
+    {
+        "step": 2700,
+        "data": {
+            "gnorm": 0.2325
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "sen": 56697833
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "cost": 0.42488825
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "time": 73.07
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "rate": 592207.41
+        }
+    },
+    {
+        "step": 2800,
+        "data": {
+            "gnorm": 0.234
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "sen": 58710103
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "cost": 0.42300135
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "time": 72.37
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "rate": 603884.52
+        }
+    },
+    {
+        "step": 2900,
+        "data": {
+            "gnorm": 0.2391
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "sen": 60731790
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "cost": 0.42334017
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "time": 73.3
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "rate": 608389.92
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "gnorm": 0.2352
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "chrf": 56.5463
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "ce_mean_words": 2.23301
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "bleu_detok": 29.261
+        }
+    },
+    {
+        "step": 3000,
+        "data": {
+            "perplexity": 9.32788
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "sen": 62814002
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "cost": 0.42631865
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "time": 101.85
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "rate": 433415.18
+        }
+    },
+    {
+        "step": 3100,
+        "data": {
+            "gnorm": 0.2503
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "sen": 64797019
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "cost": 0.42404962
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "time": 74.02
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "rate": 603494.47
+        }
+    },
+    {
+        "step": 3200,
+        "data": {
+            "gnorm": 0.274
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "sen": 66773097
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "cost": 0.42503634
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "time": 72.82
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "rate": 595798.26
+        }
+    },
+    {
+        "step": 3300,
+        "data": {
+            "gnorm": 0.2474
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "sen": 68833093
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "cost": 0.42650777
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "time": 72.5
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "rate": 598267.34
+        }
+    },
+    {
+        "step": 3400,
+        "data": {
+            "gnorm": 0.2536
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "sen": 70871965
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "cost": 0.42652583
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "time": 76.44
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "rate": 596718.85
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "gnorm": 0.2366
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "chrf": 56.6618
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "ce_mean_words": 2.24414
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "bleu_detok": 29.3573
+        }
+    },
+    {
+        "step": 3500,
+        "data": {
+            "perplexity": 9.4323
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "sen": 72899705
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "cost": 0.42629641
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "time": 100.77
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "rate": 434667.64
+        }
+    },
+    {
+        "step": 3600,
+        "data": {
+            "gnorm": 0.2747
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "sen": 74832526
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "cost": 0.42659682
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "time": 72.35
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "rate": 599055.0
+        }
+    },
+    {
+        "step": 3700,
+        "data": {
+            "gnorm": 0.2594
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "sen": 76787743
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "cost": 0.42606211
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "time": 73.33
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "rate": 599140.37
+        }
+    },
+    {
+        "step": 3800,
+        "data": {
+            "gnorm": 0.2525
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "sen": 78859264
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "cost": 0.42699769
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "time": 72.48
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "rate": 600182.04
+        }
+    },
+    {
+        "step": 3900,
+        "data": {
+            "gnorm": 0.2671
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "sen": 80978709
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "cost": 0.42775595
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "time": 74.96
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "rate": 604410.73
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "gnorm": 0.2469
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "chrf": 56.5737
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "ce_mean_words": 2.23578
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "bleu_detok": 29.288
+        }
+    },
+    {
+        "step": 4000,
+        "data": {
+            "perplexity": 9.35376
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "sen": 82981325
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "cost": 0.42928466
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "time": 102.43
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "rate": 435927.11
+        }
+    },
+    {
+        "step": 4100,
+        "data": {
+            "gnorm": 0.25
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "sen": 84999717
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "cost": 0.42870831
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "time": 73.52
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "rate": 600522.94
+        }
+    },
+    {
+        "step": 4200,
+        "data": {
+            "gnorm": 0.2771
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "sen": 87018110
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "cost": 0.42872104
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "time": 74.58
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "rate": 590972.74
+        }
+    },
+    {
+        "step": 4300,
+        "data": {
+            "gnorm": 0.2667
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "sen": 89015220
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "cost": 0.42949602
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "time": 73.35
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "rate": 596353.2
+        }
+    },
+    {
+        "step": 4400,
+        "data": {
+            "gnorm": 0.2754
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "sen": 91035501
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "cost": 0.43040338
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "time": 74.53
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "rate": 594490.93
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "gnorm": 0.2677
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "chrf": 56.5394
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "ce_mean_words": 2.24326
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "bleu_detok": 29.2102
+        }
+    },
+    {
+        "step": 4500,
+        "data": {
+            "perplexity": 9.42398
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "sen": 93082704
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "cost": 0.42988995
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "time": 103.65
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "rate": 428646.73
+        }
+    },
+    {
+        "step": 4600,
+        "data": {
+            "gnorm": 0.2881
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "sen": 95116183
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "cost": 0.43111899
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "time": 75.4
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "rate": 591226.56
+        }
+    },
+    {
+        "step": 4700,
+        "data": {
+            "gnorm": 0.276
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "sen": 97148241
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "cost": 0.43269148
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "time": 73.53
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "rate": 586090.77
+        }
+    },
+    {
+        "step": 4800,
+        "data": {
+            "gnorm": 0.3151
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "sen": 99112142
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "cost": 0.43132946
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "time": 74.32
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "rate": 601209.31
+        }
+    },
+    {
+        "step": 4900,
+        "data": {
+            "gnorm": 0.3033
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "sen": 101103636
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "cost": 0.43485913
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "time": 75.15
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "rate": 583653.43
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "gnorm": 0.3132
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "chrf": 56.6403
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "ce_mean_words": 2.22451
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "bleu_detok": 29.2715
+        }
+    },
+    {
+        "step": 5000,
+        "data": {
+            "perplexity": 9.24899
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "sen": 103154270
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "cost": 0.43177292
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "time": 106.14
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "rate": 426039.12
+        }
+    },
+    {
+        "step": 5100,
+        "data": {
+            "gnorm": 0.2857
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "sen": 105159325
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "cost": 0.43331209
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "time": 74.33
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "rate": 584205.72
+        }
+    },
+    {
+        "step": 5200,
+        "data": {
+            "gnorm": 0.3055
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "sen": 107284045
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "cost": 0.43181026
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "time": 75.11
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "rate": 582902.75
+        }
+    },
+    {
+        "step": 5300,
+        "data": {
+            "gnorm": 0.2991
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "sen": 109224083
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "cost": 0.43384504
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "time": 75.32
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "rate": 588539.5
+        }
+    },
+    {
+        "step": 5400,
+        "data": {
+            "gnorm": 0.3145
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "sen": 111295183
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "cost": 0.43385842
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "time": 76.3
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "rate": 592825.18
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "gnorm": 0.3024
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "chrf": 56.5076
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "ce_mean_words": 2.23651
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "bleu_detok": 29.1567
+        }
+    },
+    {
+        "step": 5500,
+        "data": {
+            "perplexity": 9.3606
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "sen": 113321525
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "cost": 0.43588015
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "time": 104.58
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "rate": 420513.29
+        }
+    },
+    {
+        "step": 5600,
+        "data": {
+            "gnorm": 0.3374
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "sen": 115413794
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "cost": 0.43279886
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "time": 75.69
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "rate": 587461.17
+        }
+    },
+    {
+        "step": 5700,
+        "data": {
+            "gnorm": 0.2974
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "epoch": 1
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "sen": 117391161
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "cost": 0.43686602
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "time": 73.79
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "rate": 596981.17
+        }
+    },
+    {
+        "step": 5800,
+        "data": {
+            "gnorm": 0.3185
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "sen": 1759060
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "cost": 0.43529254
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "time": 106.19
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "rate": 416891.41
+        }
+    },
+    {
+        "step": 5900,
+        "data": {
+            "gnorm": 0.3173
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "sen": 3793502
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "cost": 0.43505535
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "time": 76.37
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "rate": 585816.0
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "gnorm": 0.3628
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "chrf": 56.3588
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "ce_mean_words": 2.23048
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "bleu_detok": 29.01
+        }
+    },
+    {
+        "step": 6000,
+        "data": {
+            "perplexity": 9.30435
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "sen": 5817010
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "cost": 0.4358722
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "time": 102.24
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "rate": 424497.34
+        }
+    },
+    {
+        "step": 6100,
+        "data": {
+            "gnorm": 0.3741
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "sen": 7846391
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "cost": 0.43628591
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "time": 76.76
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "rate": 587200.75
+        }
+    },
+    {
+        "step": 6200,
+        "data": {
+            "gnorm": 0.3199
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "sen": 9911326
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "cost": 0.43842334
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "time": 77.24
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "rate": 581417.8
+        }
+    },
+    {
+        "step": 6300,
+        "data": {
+            "gnorm": 0.3379
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "sen": 11926230
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "cost": 0.43785232
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "time": 74.44
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "rate": 582614.21
+        }
+    },
+    {
+        "step": 6400,
+        "data": {
+            "gnorm": 0.4041
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "sen": 13972690
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "cost": 0.43664911
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "time": 76.55
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "rate": 586749.16
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "gnorm": 0.3411
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "chrf": 56.5684
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "ce_mean_words": 2.24266
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "bleu_detok": 29.2192
+        }
+    },
+    {
+        "step": 6500,
+        "data": {
+            "perplexity": 9.41835
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "sen": 15999950
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "cost": 0.44089934
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "time": 103.88
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "rate": 429050.2
+        }
+    },
+    {
+        "step": 6600,
+        "data": {
+            "gnorm": 0.3799
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "sen": 18006988
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "cost": 0.43976825
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "time": 76.08
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "rate": 581273.13
+        }
+    },
+    {
+        "step": 6700,
+        "data": {
+            "gnorm": 0.3497
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "sen": 20050151
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "cost": 0.43943217
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "time": 75.77
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "rate": 582056.26
+        }
+    },
+    {
+        "step": 6800,
+        "data": {
+            "gnorm": 0.3594
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "sen": 22084756
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "cost": 0.43961427
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "time": 76.36
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "rate": 585126.16
+        }
+    },
+    {
+        "step": 6900,
+        "data": {
+            "gnorm": 0.3427
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "sen": 24084997
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "cost": 0.43950185
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "time": 75.83
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "rate": 583140.96
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "gnorm": 0.3508
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "chrf": 56.5243
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "ce_mean_words": 2.25285
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "bleu_detok": 28.998
+        }
+    },
+    {
+        "step": 7000,
+        "data": {
+            "perplexity": 9.51477
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "sen": 26087338
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "cost": 0.44170338
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "time": 107.98
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "rate": 406419.42
+        }
+    },
+    {
+        "step": 7100,
+        "data": {
+            "gnorm": 0.344
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "sen": 28135428
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "cost": 0.44162363
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "time": 75.54
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "rate": 578628.76
+        }
+    },
+    {
+        "step": 7200,
+        "data": {
+            "gnorm": 0.3666
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "sen": 30179637
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "cost": 0.44242415
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "time": 77.01
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "rate": 580615.65
+        }
+    },
+    {
+        "step": 7300,
+        "data": {
+            "gnorm": 0.3686
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "sen": 32111469
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "cost": 0.4432987
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "time": 74.08
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "rate": 578951.92
+        }
+    },
+    {
+        "step": 7400,
+        "data": {
+            "gnorm": 0.4167
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "sen": 34178837
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "cost": 0.44330108
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "time": 76.84
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "rate": 582295.75
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "gnorm": 0.3482
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "chrf": 56.353
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "ce_mean_words": 2.2666
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "bleu_detok": 28.9778
+        }
+    },
+    {
+        "step": 7500,
+        "data": {
+            "perplexity": 9.64654
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "sen": 36229331
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "cost": 0.44393086
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "time": 105.48
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "rate": 411116.48
+        }
+    },
+    {
+        "step": 7600,
+        "data": {
+            "gnorm": 0.3554
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "sen": 38199675
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "cost": 0.44434705
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "time": 76.49
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "rate": 578888.46
+        }
+    },
+    {
+        "step": 7700,
+        "data": {
+            "gnorm": 0.3605
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "sen": 40259349
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "cost": 0.44409201
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "time": 76.86
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "rate": 581931.44
+        }
+    },
+    {
+        "step": 7800,
+        "data": {
+            "gnorm": 0.3679
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "sen": 42260642
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "cost": 0.441957
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "time": 75.92
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "rate": 583178.74
+        }
+    },
+    {
+        "step": 7900,
+        "data": {
+            "gnorm": 0.3653
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "sen": 44275879
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "cost": 0.45018107
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "time": 74.88
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "rate": 579747.29
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "gnorm": 0.3928
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "chrf": 56.3478
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "ce_mean_words": 2.23399
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "bleu_detok": 28.9121
+        }
+    },
+    {
+        "step": 8000,
+        "data": {
+            "perplexity": 9.33703
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "sen": 46254985
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "cost": 0.44577724
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "time": 106.94
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "rate": 417302.57
+        }
+    },
+    {
+        "step": 8100,
+        "data": {
+            "gnorm": 0.377
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "sen": 48304421
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "cost": 0.44609118
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "time": 75.44
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "rate": 585282.25
+        }
+    },
+    {
+        "step": 8200,
+        "data": {
+            "gnorm": 0.4433
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "sen": 50287261
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "cost": 0.44771793
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "time": 75.85
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "rate": 580812.2
+        }
+    },
+    {
+        "step": 8300,
+        "data": {
+            "gnorm": 0.4062
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "sen": 52320170
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "cost": 0.44723606
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "time": 76.87
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "rate": 585065.01
+        }
+    },
+    {
+        "step": 8400,
+        "data": {
+            "gnorm": 0.3877
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "sen": 54412165
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "cost": 0.45229584
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "time": 74.52
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "rate": 577499.29
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "gnorm": 0.4185
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "chrf": 56.4991
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "ce_mean_words": 2.24763
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "bleu_detok": 29.0003
+        }
+    },
+    {
+        "step": 8500,
+        "data": {
+            "perplexity": 9.46526
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "sen": 56361675
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "cost": 0.44640896
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "time": 105.94
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "rate": 419720.9
+        }
+    },
+    {
+        "step": 8600,
+        "data": {
+            "gnorm": 0.3808
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "sen": 58368646
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "cost": 0.4512361
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "time": 75.49
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "rate": 580507.1
+        }
+    },
+    {
+        "step": 8700,
+        "data": {
+            "gnorm": 0.402
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "sen": 60390401
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "cost": 0.44908383
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "time": 76.66
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "rate": 584864.57
+        }
+    },
+    {
+        "step": 8800,
+        "data": {
+            "gnorm": 0.3837
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "sen": 62456131
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "cost": 0.45019126
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "time": 75.68
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "rate": 577331.51
+        }
+    },
+    {
+        "step": 8900,
+        "data": {
+            "gnorm": 0.3968
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "sen": 64479410
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "cost": 0.45145935
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "time": 75.33
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "rate": 582451.9
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "gnorm": 0.4086
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "chrf": 56.2681
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "ce_mean_words": 2.23824
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "bleu_detok": 28.9621
+        }
+    },
+    {
+        "step": 9000,
+        "data": {
+            "perplexity": 9.37685
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "sen": 66479815
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "cost": 0.45879593
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "time": 105.16
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "rate": 423269.5
+        }
+    },
+    {
+        "step": 9100,
+        "data": {
+            "gnorm": 0.4866
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "sen": 68546239
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "cost": 0.45201558
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "time": 76.35
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "rate": 584531.65
+        }
+    },
+    {
+        "step": 9200,
+        "data": {
+            "gnorm": 0.3865
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "sen": 70643337
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "cost": 0.45301008
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "time": 77.44
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "rate": 577800.46
+        }
+    },
+    {
+        "step": 9300,
+        "data": {
+            "gnorm": 0.4138
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "sen": 72590253
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "cost": 0.45366746
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "time": 75.85
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "rate": 587144.93
+        }
+    },
+    {
+        "step": 9400,
+        "data": {
+            "gnorm": 0.3965
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "sen": 74591158
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "cost": 0.45370144
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "time": 76.1
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "rate": 584992.8
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "gnorm": 0.4483
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "chrf": 56.3308
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "ce_mean_words": 2.2526
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "bleu_detok": 28.9965
+        }
+    },
+    {
+        "step": 9500,
+        "data": {
+            "perplexity": 9.51243
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "sen": 76715472
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "cost": 0.45129025
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "time": 104.23
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "rate": 423844.94
+        }
+    },
+    {
+        "step": 9600,
+        "data": {
+            "gnorm": 0.3917
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "sen": 78675644
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "cost": 0.45458451
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "time": 76.52
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "rate": 589839.64
+        }
+    },
+    {
+        "step": 9700,
+        "data": {
+            "gnorm": 0.4244
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "sen": 80738999
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "cost": 0.45216843
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "time": 76.26
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "rate": 579181.32
+        }
+    },
+    {
+        "step": 9800,
+        "data": {
+            "gnorm": 0.3907
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "sen": 82775047
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "cost": 0.45305732
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "time": 77.05
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "rate": 581495.03
+        }
+    },
+    {
+        "step": 9900,
+        "data": {
+            "gnorm": 0.4023
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "sen": 84843466
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "cost": 0.45518455
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "time": 75.74
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "rate": 581560.29
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "gnorm": 0.4078
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "chrf": 56.4188
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "ce_mean_words": 2.22227
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "bleu_detok": 29.1601
+        }
+    },
+    {
+        "step": 10000,
+        "data": {
+            "perplexity": 9.22822
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "sen": 86907910
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "cost": 0.45677298
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "time": 105.7
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "rate": 425702.18
+        }
+    },
+    {
+        "step": 10100,
+        "data": {
+            "gnorm": 0.4084
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "sen": 88918335
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "cost": 0.46012917
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "time": 75.5
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "rate": 580249.41
+        }
+    },
+    {
+        "step": 10200,
+        "data": {
+            "gnorm": 0.4314
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "sen": 90883750
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "cost": 0.45785868
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "time": 75.8
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "rate": 579047.49
+        }
+    },
+    {
+        "step": 10300,
+        "data": {
+            "gnorm": 0.4459
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "sen": 92972840
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "cost": 0.45930928
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "time": 76.56
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "rate": 584945.36
+        }
+    },
+    {
+        "step": 10400,
+        "data": {
+            "gnorm": 0.4518
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "sen": 94990336
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "cost": 0.45713091
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "time": 76.06
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "rate": 582565.55
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "gnorm": 0.4192
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "chrf": 56.354
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "ce_mean_words": 2.22684
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "bleu_detok": 29.0794
+        }
+    },
+    {
+        "step": 10500,
+        "data": {
+            "perplexity": 9.27049
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "sen": 96955642
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "cost": 0.454353
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "time": 102.61
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "rate": 420785.72
+        }
+    },
+    {
+        "step": 10600,
+        "data": {
+            "gnorm": 0.4133
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "sen": 98969314
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "cost": 0.45708016
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "time": 75.3
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "rate": 585647.33
+        }
+    },
+    {
+        "step": 10700,
+        "data": {
+            "gnorm": 0.4092
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "sen": 101013066
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "cost": 0.45888111
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "time": 76.46
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "rate": 583534.56
+        }
+    },
+    {
+        "step": 10800,
+        "data": {
+            "gnorm": 0.4177
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "sen": 103050464
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "cost": 0.45468414
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "time": 76.57
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "rate": 576351.55
+        }
+    },
+    {
+        "step": 10900,
+        "data": {
+            "gnorm": 0.417
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "sen": 105041454
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "cost": 0.46108475
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "time": 75.5
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "rate": 580819.64
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "gnorm": 0.4326
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "chrf": 56.2931
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "ce_mean_words": 2.21364
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "bleu_detok": 28.9172
+        }
+    },
+    {
+        "step": 11000,
+        "data": {
+            "perplexity": 9.14892
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "sen": 107010069
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "cost": 0.46091339
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "time": 106.86
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "rate": 402902.42
+        }
+    },
+    {
+        "step": 11100,
+        "data": {
+            "gnorm": 0.4309
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "sen": 109047432
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "cost": 0.45988846
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "time": 75.8
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "rate": 582882.59
+        }
+    },
+    {
+        "step": 11200,
+        "data": {
+            "gnorm": 0.437
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "sen": 111057831
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "cost": 0.46027207
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "time": 74.82
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "rate": 583328.64
+        }
+    },
+    {
+        "step": 11300,
+        "data": {
+            "gnorm": 0.4479
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "sen": 113071514
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "cost": 0.46048781
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "time": 78.03
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "rate": 578308.26
+        }
+    },
+    {
+        "step": 11400,
+        "data": {
+            "gnorm": 0.4477
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "sen": 115197748
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "cost": 0.46182981
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "time": 76.42
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "rate": 585154.3
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "gnorm": 0.4314
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "chrf": 55.8254
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "ce_mean_words": 2.22962
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "bleu_detok": 28.6646
+        }
+    },
+    {
+        "step": 11500,
+        "data": {
+            "perplexity": 9.29636
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "epoch": 2
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "sen": 117173558
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "cost": 0.46155766
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "time": 107.09
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "rate": 423447.31
+        }
+    },
+    {
+        "step": 11600,
+        "data": {
+            "gnorm": 0.4168
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "sen": 1671609
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "cost": 0.45964742
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "time": 106.52
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "rate": 416334.51
+        }
+    },
+    {
+        "step": 11700,
+        "data": {
+            "gnorm": 0.4468
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "sen": 3653504
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "cost": 0.46393234
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "time": 76.09
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "rate": 582960.87
+        }
+    },
+    {
+        "step": 11800,
+        "data": {
+            "gnorm": 0.4803
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "sen": 5698176
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "cost": 0.46153855
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "time": 76.11
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "rate": 584973.99
+        }
+    },
+    {
+        "step": 11900,
+        "data": {
+            "gnorm": 0.4442
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "sen": 7727909
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "cost": 0.47250891
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "time": 73.63
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "rate": 576527.28
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "gnorm": 0.4762
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "chrf": 56.2097
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "ce_mean_words": 2.24097
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "bleu_detok": 28.8862
+        }
+    },
+    {
+        "step": 12000,
+        "data": {
+            "perplexity": 9.40242
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "sen": 9717101
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "cost": 0.45884091
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "time": 103.07
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "rate": 435746.93
+        }
+    },
+    {
+        "step": 12100,
+        "data": {
+            "gnorm": 0.4207
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "sen": 11709810
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "cost": 0.46756554
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "time": 75.7
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "rate": 580201.81
+        }
+    },
+    {
+        "step": 12200,
+        "data": {
+            "gnorm": 0.4524
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "sen": 13629920
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "cost": 0.45817339
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "time": 74.93
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "rate": 584348.03
+        }
+    },
+    {
+        "step": 12300,
+        "data": {
+            "gnorm": 0.4205
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "sen": 15712911
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "cost": 0.46949366
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "time": 76.01
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "rate": 582989.77
+        }
+    },
+    {
+        "step": 12400,
+        "data": {
+            "gnorm": 0.4378
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "sen": 17800160
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "cost": 0.46521175
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "time": 75.63
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "rate": 581631.5
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "gnorm": 0.4864
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "chrf": 56.2395
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "ce_mean_words": 2.25929
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "bleu_detok": 28.7866
+        }
+    },
+    {
+        "step": 12500,
+        "data": {
+            "perplexity": 9.57626
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "sen": 19855500
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "cost": 0.47429937
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "time": 103.47
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "rate": 427974.53
+        }
+    },
+    {
+        "step": 12600,
+        "data": {
+            "gnorm": 0.5133
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "sen": 21813808
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "cost": 0.46300033
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "time": 75.68
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "rate": 582535.54
+        }
+    },
+    {
+        "step": 12700,
+        "data": {
+            "gnorm": 0.4308
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "sen": 23797319
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "cost": 0.46415454
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "time": 76.26
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "rate": 584581.66
+        }
+    },
+    {
+        "step": 12800,
+        "data": {
+            "gnorm": 0.4007
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "sen": 25841592
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "cost": 0.46727765
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "time": 76.49
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "rate": 583076.99
+        }
+    },
+    {
+        "step": 12900,
+        "data": {
+            "gnorm": 0.4215
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "sen": 27873942
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "cost": 0.46824524
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "time": 75.51
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "rate": 576615.67
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "gnorm": 0.4561
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "chrf": 56.2765
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "ce_mean_words": 2.23195
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "bleu_detok": 28.9013
+        }
+    },
+    {
+        "step": 13000,
+        "data": {
+            "perplexity": 9.318
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "sen": 29912452
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "cost": 0.46578091
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "time": 104.79
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "rate": 428318.34
+        }
+    },
+    {
+        "step": 13100,
+        "data": {
+            "gnorm": 0.5091
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "sen": 31965701
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "cost": 0.4717367
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "time": 76.51
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "rate": 581037.29
+        }
+    },
+    {
+        "step": 13200,
+        "data": {
+            "gnorm": 0.4398
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "sen": 33974950
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "cost": 0.46848965
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "time": 75.64
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "rate": 585932.89
+        }
+    },
+    {
+        "step": 13300,
+        "data": {
+            "gnorm": 0.4986
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "sen": 35988125
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "cost": 0.4673993
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "time": 75.79
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "rate": 575556.95
+        }
+    },
+    {
+        "step": 13400,
+        "data": {
+            "gnorm": 0.4796
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "sen": 38040025
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "cost": 0.46769854
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "time": 77.39
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "rate": 583679.24
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "gnorm": 0.4217
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "chrf": 56.2621
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "ce_mean_words": 2.25341
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "bleu_detok": 28.817
+        }
+    },
+    {
+        "step": 13500,
+        "data": {
+            "perplexity": 9.52013
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "sen": 40087938
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "cost": 0.47603253
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "time": 108.23
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "rate": 413726.94
+        }
+    },
+    {
+        "step": 13600,
+        "data": {
+            "gnorm": 0.4919
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "sen": 42099953
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "cost": 0.46771187
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "time": 75.54
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "rate": 581784.0
+        }
+    },
+    {
+        "step": 13700,
+        "data": {
+            "gnorm": 0.4588
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "sen": 44113058
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "cost": 0.46890762
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "time": 76.63
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "rate": 577664.25
+        }
+    },
+    {
+        "step": 13800,
+        "data": {
+            "gnorm": 0.4328
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "sen": 46139173
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "cost": 0.48387015
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "time": 74.98
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "rate": 584302.46
+        }
+    },
+    {
+        "step": 13900,
+        "data": {
+            "gnorm": 0.4631
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "sen": 48129537
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "cost": 0.46535188
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "time": 76.59
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "rate": 581935.6
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "gnorm": 0.4233
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "chrf": 56.271
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "ce_mean_words": 2.23359
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "bleu_detok": 29.0086
+        }
+    },
+    {
+        "step": 14000,
+        "data": {
+            "perplexity": 9.33328
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "sen": 50143182
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "cost": 0.47033134
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "time": 105.94
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "rate": 415345.01
+        }
+    },
+    {
+        "step": 14100,
+        "data": {
+            "gnorm": 0.4536
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "sen": 52158574
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "cost": 0.47534651
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "time": 75.07
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "rate": 580570.0
+        }
+    },
+    {
+        "step": 14200,
+        "data": {
+            "gnorm": 0.4307
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "sen": 54179021
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "cost": 0.47154137
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "time": 74.95
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "rate": 574895.05
+        }
+    },
+    {
+        "step": 14300,
+        "data": {
+            "gnorm": 0.4565
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "sen": 56179259
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "cost": 0.46831015
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "time": 76.74
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "rate": 591462.13
+        }
+    },
+    {
+        "step": 14400,
+        "data": {
+            "gnorm": 0.3965
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "sen": 58235967
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "cost": 0.47158495
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "time": 75.35
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "rate": 579913.63
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "gnorm": 0.4274
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "chrf": 56.2104
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "ce_mean_words": 2.2346
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "bleu_detok": 28.6602
+        }
+    },
+    {
+        "step": 14500,
+        "data": {
+            "perplexity": 9.34278
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "sen": 60208386
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "cost": 0.4804472
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "time": 106.99
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "rate": 410852.68
+        }
+    },
+    {
+        "step": 14600,
+        "data": {
+            "gnorm": 0.4894
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "sen": 62338711
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "cost": 0.46734679
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "time": 75.56
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "rate": 580911.73
+        }
+    },
+    {
+        "step": 14700,
+        "data": {
+            "gnorm": 0.4083
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "sen": 64254309
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "cost": 0.47762144
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "time": 75.25
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "rate": 590008.0
+        }
+    },
+    {
+        "step": 14800,
+        "data": {
+            "gnorm": 0.44
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "sen": 66360700
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "cost": 0.4726859
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "time": 77.13
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "rate": 578426.39
+        }
+    },
+    {
+        "step": 14900,
+        "data": {
+            "gnorm": 0.4305
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "sen": 68293053
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "cost": 0.47462302
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "time": 75.35
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "rate": 581211.45
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "gnorm": 0.4436
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "chrf": 56.2248
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "ce_mean_words": 2.21451
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "bleu_detok": 28.8902
+        }
+    },
+    {
+        "step": 15000,
+        "data": {
+            "perplexity": 9.15696
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "sen": 70368915
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "cost": 0.47612333
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "time": 104.59
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "rate": 415710.84
+        }
+    },
+    {
+        "step": 15100,
+        "data": {
+            "gnorm": 0.4889
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "sen": 72299456
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "cost": 0.47654164
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "time": 75.51
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "rate": 583900.81
+        }
+    },
+    {
+        "step": 15200,
+        "data": {
+            "gnorm": 0.4822
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "sen": 74329510
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "cost": 0.46934593
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "time": 75.66
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "rate": 578013.7
+        }
+    },
+    {
+        "step": 15300,
+        "data": {
+            "gnorm": 0.443
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "sen": 76414468
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "cost": 0.46952039
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "time": 77.62
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "rate": 584847.54
+        }
+    },
+    {
+        "step": 15400,
+        "data": {
+            "gnorm": 0.3987
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "sen": 78501375
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "cost": 0.48149359
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "time": 77.31
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "rate": 572085.5
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "gnorm": 0.4704
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "chrf": 56.1592
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "ce_mean_words": 2.26469
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "bleu_detok": 28.5019
+        }
+    },
+    {
+        "step": 15500,
+        "data": {
+            "perplexity": 9.62813
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "sen": 80462406
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "cost": 0.46997869
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "time": 104.51
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "rate": 421935.12
+        }
+    },
+    {
+        "step": 15600,
+        "data": {
+            "gnorm": 0.4147
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "sen": 82517031
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "cost": 0.47373977
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "time": 77.02
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "rate": 582248.19
+        }
+    },
+    {
+        "step": 15700,
+        "data": {
+            "gnorm": 0.4226
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "sen": 84594197
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "cost": 0.48098871
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "time": 77.81
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "rate": 579768.34
+        }
+    },
+    {
+        "step": 15800,
+        "data": {
+            "gnorm": 0.4195
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "sen": 86572298
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "cost": 0.4765307
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "time": 75.78
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "rate": 578139.52
+        }
+    },
+    {
+        "step": 15900,
+        "data": {
+            "gnorm": 0.4516
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "sen": 88596982
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "cost": 0.47467619
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "time": 75.4
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "rate": 583457.22
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "gnorm": 0.4336
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "chrf": 56.3754
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "ce_mean_words": 2.25668
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "bleu_detok": 28.8131
+        }
+    },
+    {
+        "step": 16000,
+        "data": {
+            "perplexity": 9.5513
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "sen": 90731794
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "cost": 0.47113079
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "time": 105.04
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "rate": 425719.06
+        }
+    },
+    {
+        "step": 16100,
+        "data": {
+            "gnorm": 0.3926
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "sen": 92610834
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "cost": 0.48181129
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "time": 75.59
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "rate": 581579.48
+        }
+    },
+    {
+        "step": 16200,
+        "data": {
+            "gnorm": 0.4852
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "sen": 94719324
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "cost": 0.47987059
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "time": 77.32
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "rate": 583982.64
+        }
+    },
+    {
+        "step": 16300,
+        "data": {
+            "gnorm": 0.4526
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "sen": 96765484
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "cost": 0.4798727
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "time": 75.87
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "rate": 589372.74
+        }
+    },
+    {
+        "step": 16400,
+        "data": {
+            "gnorm": 0.4206
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "sen": 98902774
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "cost": 0.47636414
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "time": 77.57
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "rate": 580060.92
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "gnorm": 0.4195
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "chrf": 56.1834
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "ce_mean_words": 2.24804
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "bleu_detok": 28.7244
+        }
+    },
+    {
+        "step": 16500,
+        "data": {
+            "perplexity": 9.46918
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "sen": 100851392
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "cost": 0.48424125
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "time": 104.38
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "rate": 422066.08
+        }
+    },
+    {
+        "step": 16600,
+        "data": {
+            "gnorm": 0.4949
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "sen": 102887582
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "cost": 0.48038274
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "time": 76.02
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "rate": 586214.24
+        }
+    },
+    {
+        "step": 16700,
+        "data": {
+            "gnorm": 0.4304
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "sen": 104951959
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "cost": 0.47021589
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "time": 76.11
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "rate": 582376.28
+        }
+    },
+    {
+        "step": 16800,
+        "data": {
+            "gnorm": 0.3774
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "sen": 106977233
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "cost": 0.48289722
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "time": 77.16
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "rate": 585827.13
+        }
+    },
+    {
+        "step": 16900,
+        "data": {
+            "gnorm": 0.4206
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "sen": 108999629
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "cost": 0.47646508
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "time": 75.58
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "rate": 583125.81
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "gnorm": 0.4517
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "chrf": 56.1015
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "ce_mean_words": 2.26406
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "bleu_detok": 28.2269
+        }
+    },
+    {
+        "step": 17000,
+        "data": {
+            "perplexity": 9.62203
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "sen": 110971203
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "cost": 0.48067573
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "time": 103.05
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "rate": 419748.13
+        }
+    },
+    {
+        "step": 17100,
+        "data": {
+            "gnorm": 0.4701
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "sen": 112999613
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "cost": 0.47870857
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "time": 75.54
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "rate": 584255.14
+        }
+    },
+    {
+        "step": 17200,
+        "data": {
+            "gnorm": 0.4414
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "sen": 115028024
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "cost": 0.47173128
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "time": 75.91
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "rate": 582010.95
+        }
+    },
+    {
+        "step": 17300,
+        "data": {
+            "gnorm": 0.4053
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "epoch": 3
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "sen": 117054127
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "cost": 0.47336337
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "time": 75.67
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "rate": 590901.73
+        }
+    },
+    {
+        "step": 17400,
+        "data": {
+            "gnorm": 0.4202
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "sen": 1480984
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "cost": 0.47692963
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "time": 105.41
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "rate": 421095.29
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "gnorm": 0.4256
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "chrf": 56.2014
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "ce_mean_words": 2.24935
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "bleu_detok": 28.8258
+        }
+    },
+    {
+        "step": 17500,
+        "data": {
+            "perplexity": 9.48157
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "sen": 3526973
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "cost": 0.47091413
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "time": 105.85
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "rate": 424498.69
+        }
+    },
+    {
+        "step": 17600,
+        "data": {
+            "gnorm": 0.4167
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "sen": 5600550
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "cost": 0.47595051
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "time": 76.17
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "rate": 578486.72
+        }
+    },
+    {
+        "step": 17700,
+        "data": {
+            "gnorm": 0.4375
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "sen": 7608083
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "cost": 0.47765484
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "time": 77.81
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "rate": 581657.09
+        }
+    },
+    {
+        "step": 17800,
+        "data": {
+            "gnorm": 0.4512
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "sen": 9699387
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "cost": 0.46951371
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "time": 76.18
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "rate": 582437.9
+        }
+    },
+    {
+        "step": 17900,
+        "data": {
+            "gnorm": 0.3986
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "sen": 11700507
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "cost": 0.47678539
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "time": 77.02
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "rate": 585343.76
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "gnorm": 0.4318
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "chrf": 56.2267
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "ce_mean_words": 2.23314
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "bleu_detok": 28.7161
+        }
+    },
+    {
+        "step": 18000,
+        "data": {
+            "perplexity": 9.32908
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "sen": 13751025
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "cost": 0.48254299
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "time": 103.52
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "rate": 423998.91
+        }
+    },
+    {
+        "step": 18100,
+        "data": {
+            "gnorm": 0.5092
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "sen": 15702908
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "cost": 0.4667525
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "time": 77.14
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "rate": 587624.8
+        }
+    },
+    {
+        "step": 18200,
+        "data": {
+            "gnorm": 0.3814
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "sen": 17787408
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "cost": 0.48447189
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "time": 75.32
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "rate": 573576.01
+        }
+    },
+    {
+        "step": 18300,
+        "data": {
+            "gnorm": 0.4291
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "sen": 19823404
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "cost": 0.47182244
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "time": 75.91
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "rate": 579879.43
+        }
+    },
+    {
+        "step": 18400,
+        "data": {
+            "gnorm": 0.4295
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "sen": 21828848
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "cost": 0.47877741
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "time": 76.55
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "rate": 581015.92
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "gnorm": 0.4354
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "chrf": 56.208
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "ce_mean_words": 2.20725
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "bleu_detok": 28.8047
+        }
+    },
+    {
+        "step": 18500,
+        "data": {
+            "perplexity": 9.0907
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "sen": 23853257
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "cost": 0.47310445
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "time": 104.5
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "rate": 427147.31
+        }
+    },
+    {
+        "step": 18600,
+        "data": {
+            "gnorm": 0.4203
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "sen": 25930086
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "cost": 0.474498
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "time": 76.47
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "rate": 589523.15
+        }
+    },
+    {
+        "step": 18700,
+        "data": {
+            "gnorm": 0.4043
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "sen": 27999905
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "cost": 0.48376888
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "time": 77.64
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "rate": 583551.1
+        }
+    },
+    {
+        "step": 18800,
+        "data": {
+            "gnorm": 0.4815
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "sen": 30013301
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "cost": 0.4735831
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "time": 76.19
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "rate": 579990.18
+        }
+    },
+    {
+        "step": 18900,
+        "data": {
+            "gnorm": 0.3977
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "sen": 32013988
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "cost": 0.47513306
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "time": 75.11
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "rate": 581926.85
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "gnorm": 0.4234
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "chrf": 56.3072
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "ce_mean_words": 2.28479
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "bleu_detok": 28.5701
+        }
+    },
+    {
+        "step": 19000,
+        "data": {
+            "perplexity": 9.82361
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "sen": 34054848
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "cost": 0.47650492
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "time": 108.3
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "rate": 412605.8
+        }
+    },
+    {
+        "step": 19100,
+        "data": {
+            "gnorm": 0.4211
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "sen": 36102336
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "cost": 0.47795889
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "time": 76.72
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "rate": 578273.76
+        }
+    },
+    {
+        "step": 19200,
+        "data": {
+            "gnorm": 0.434
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "sen": 38139526
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "cost": 0.47741884
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "time": 77.59
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "rate": 583233.06
+        }
+    },
+    {
+        "step": 19300,
+        "data": {
+            "gnorm": 0.4443
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "sen": 40198388
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "cost": 0.47990811
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "time": 76.13
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "rate": 579417.2
+        }
+    },
+    {
+        "step": 19400,
+        "data": {
+            "gnorm": 0.4223
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "sen": 42266378
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "cost": 0.47211689
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "time": 77.73
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "rate": 581920.59
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "gnorm": 0.3941
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "chrf": 56.2041
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "ce_mean_words": 2.24613
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "bleu_detok": 28.6743
+        }
+    },
+    {
+        "step": 19500,
+        "data": {
+            "perplexity": 9.45106
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "sen": 44320719
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "cost": 0.47429773
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "time": 107.7
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "rate": 412714.84
+        }
+    },
+    {
+        "step": 19600,
+        "data": {
+            "gnorm": 0.4107
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "sen": 46346736
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "cost": 0.47986162
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "time": 77.39
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "rate": 587669.73
+        }
+    },
+    {
+        "step": 19700,
+        "data": {
+            "gnorm": 0.4507
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "sen": 48423579
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "cost": 0.46999311
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "time": 76.09
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "rate": 583455.61
+        }
+    },
+    {
+        "step": 19800,
+        "data": {
+            "gnorm": 0.3931
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "sen": 50421797
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "cost": 0.47174162
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "time": 74.97
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "rate": 587846.64
+        }
+    },
+    {
+        "step": 19900,
+        "data": {
+            "gnorm": 0.3744
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "sen": 52446439
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "cost": 0.48135871
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "time": 77.42
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "rate": 578774.99
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "gnorm": 0.4504
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "chrf": 55.9614
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "ce_mean_words": 2.22936
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "bleu_detok": 28.8239
+        }
+    },
+    {
+        "step": 20000,
+        "data": {
+            "perplexity": 9.29394
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "sen": 54422958
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "cost": 0.47260919
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "time": 103.18
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "rate": 425495.55
+        }
+    },
+    {
+        "step": 20100,
+        "data": {
+            "gnorm": 0.4287
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "sen": 56485591
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "cost": 0.4735091
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "time": 74.88
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "rate": 583676.83
+        }
+    },
+    {
+        "step": 20200,
+        "data": {
+            "gnorm": 0.4085
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "sen": 58483522
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "cost": 0.47610691
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "time": 76.27
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "rate": 581827.65
+        }
+    },
+    {
+        "step": 20300,
+        "data": {
+            "gnorm": 0.4122
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "sen": 60538595
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "cost": 0.47679818
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "time": 75.26
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "rate": 575451.05
+        }
+    },
+    {
+        "step": 20400,
+        "data": {
+            "gnorm": 0.4673
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "sen": 62462615
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "cost": 0.47036618
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "time": 76.7
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "rate": 587180.8
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "gnorm": 0.3953
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "chrf": 56.3672
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "ce_mean_words": 2.27044
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "bleu_detok": 28.5528
+        }
+    },
+    {
+        "step": 20500,
+        "data": {
+            "perplexity": 9.68364
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "sen": 64600256
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "cost": 0.47821447
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "time": 103.79
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "rate": 417171.41
+        }
+    },
+    {
+        "step": 20600,
+        "data": {
+            "gnorm": 0.449
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "sen": 66588255
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "cost": 0.4805049
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "time": 77.81
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "rate": 583369.32
+        }
+    },
+    {
+        "step": 20700,
+        "data": {
+            "gnorm": 0.4046
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "sen": 68634805
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "cost": 0.4654941
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "time": 74.43
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "rate": 581418.38
+        }
+    },
+    {
+        "step": 20800,
+        "data": {
+            "gnorm": 0.369
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "sen": 70565040
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "cost": 0.48486909
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "time": 75.6
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "rate": 581213.68
+        }
+    },
+    {
+        "step": 20900,
+        "data": {
+            "gnorm": 0.4392
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "sen": 72655658
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "cost": 0.47220075
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "time": 76.68
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "rate": 582675.41
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "gnorm": 0.3753
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "chrf": 56.3232
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "ce_mean_words": 2.25458
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "bleu_detok": 28.8992
+        }
+    },
+    {
+        "step": 21000,
+        "data": {
+            "perplexity": 9.53131
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "sen": 74649401
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "cost": 0.47341245
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "time": 103.82
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "rate": 426394.37
+        }
+    },
+    {
+        "step": 21100,
+        "data": {
+            "gnorm": 0.385
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "sen": 76669158
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "cost": 0.48099446
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "time": 75.16
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "rate": 579878.56
+        }
+    },
+    {
+        "step": 21200,
+        "data": {
+            "gnorm": 0.4155
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "sen": 78623908
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "cost": 0.47789583
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "time": 76.07
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "rate": 577534.62
+        }
+    },
+    {
+        "step": 21300,
+        "data": {
+            "gnorm": 0.4012
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "sen": 80745194
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "cost": 0.4693794
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "time": 77.09
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "rate": 587285.57
+        }
+    },
+    {
+        "step": 21400,
+        "data": {
+            "gnorm": 0.3689
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "sen": 82784565
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "cost": 0.48403752
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "time": 74.8
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "rate": 578175.99
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "gnorm": 0.5415
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "chrf": 55.7172
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "ce_mean_words": 2.29492
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "bleu_detok": 28.1072
+        }
+    },
+    {
+        "step": 21500,
+        "data": {
+            "perplexity": 9.92363
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "sen": 84814669
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "cost": 0.47800669
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "time": 104.36
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "rate": 430076.5
+        }
+    },
+    {
+        "step": 21600,
+        "data": {
+            "gnorm": 0.4189
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "sen": 86845556
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "cost": 0.47247571
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "time": 75.85
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "rate": 584144.8
+        }
+    },
+    {
+        "step": 21700,
+        "data": {
+            "gnorm": 0.4126
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "sen": 88917569
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "cost": 0.47969043
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "time": 77.31
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "rate": 583844.61
+        }
+    },
+    {
+        "step": 21800,
+        "data": {
+            "gnorm": 0.4611
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "sen": 90918780
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "cost": 0.48129776
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "time": 74.89
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "rate": 584033.0
+        }
+    },
+    {
+        "step": 21900,
+        "data": {
+            "gnorm": 0.426
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "sen": 92923469
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "cost": 0.47230512
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "time": 75.68
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "rate": 582390.53
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "gnorm": 0.3925
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "chrf": 56.136
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "ce_mean_words": 2.20273
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "bleu_detok": 28.6788
+        }
+    },
+    {
+        "step": 22000,
+        "data": {
+            "perplexity": 9.0497
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "sen": 94926508
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "cost": 0.49688643
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "time": 104.96
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "rate": 415318.78
+        }
+    },
+    {
+        "step": 22100,
+        "data": {
+            "gnorm": 0.5032
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "sen": 96931722
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "cost": 0.46518004
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "time": 75.28
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "rate": 582106.8
+        }
+    },
+    {
+        "step": 22200,
+        "data": {
+            "gnorm": 0.3573
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "sen": 98932849
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "cost": 0.47355267
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "time": 76.56
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "rate": 581625.94
+        }
+    },
+    {
+        "step": 22300,
+        "data": {
+            "gnorm": 0.3889
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "sen": 100975231
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "cost": 0.49106917
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "time": 74.6
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "rate": 589413.15
+        }
+    },
+    {
+        "step": 22400,
+        "data": {
+            "gnorm": 0.4928
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "sen": 102966851
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "cost": 0.47297055
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "time": 76.26
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "rate": 580897.44
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "gnorm": 0.3873
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "chrf": 56.3469
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "ce_mean_words": 2.21969
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "bleu_detok": 28.9611
+        }
+    },
+    {
+        "step": 22500,
+        "data": {
+            "perplexity": 9.20448
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "sen": 104999634
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "cost": 0.46815878
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "time": 103.52
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "rate": 425960.75
+        }
+    },
+    {
+        "step": 22600,
+        "data": {
+            "gnorm": 0.3813
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "sen": 107008974
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "cost": 0.47777727
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "time": 75.62
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "rate": 584597.08
+        }
+    },
+    {
+        "step": 22700,
+        "data": {
+            "gnorm": 0.4121
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "sen": 109026232
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "cost": 0.47281483
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "time": 74.59
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "rate": 583897.11
+        }
+    },
+    {
+        "step": 22800,
+        "data": {
+            "gnorm": 0.394
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "sen": 111104995
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "cost": 0.4728753
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "time": 76.59
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "rate": 581945.74
+        }
+    },
+    {
+        "step": 22900,
+        "data": {
+            "gnorm": 0.4004
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "sen": 113113340
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "cost": 0.47935024
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "time": 75.67
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "rate": 583807.78
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "gnorm": 0.4562
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "chrf": 55.7366
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "ce_mean_words": 2.25845
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "bleu_detok": 28.1397
+        }
+    },
+    {
+        "step": 23000,
+        "data": {
+            "perplexity": 9.56825
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "sen": 115052724
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "cost": 0.47350657
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "time": 107.78
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "rate": 411354.81
+        }
+    },
+    {
+        "step": 23100,
+        "data": {
+            "gnorm": 0.3719
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "epoch": 4
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "sen": 117125785
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "cost": 0.47413418
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "time": 74.06
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "rate": 588562.84
+        }
+    },
+    {
+        "step": 23200,
+        "data": {
+            "gnorm": 0.3843
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "sen": 1442710
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "cost": 0.47374704
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "time": 104.47
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "rate": 413355.77
+        }
+    },
+    {
+        "step": 23300,
+        "data": {
+            "gnorm": 0.4326
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "sen": 3360755
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "cost": 0.46994328
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "time": 75.06
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "rate": 587849.02
+        }
+    },
+    {
+        "step": 23400,
+        "data": {
+            "gnorm": 0.4069
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "sen": 5470869
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "cost": 0.47480464
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "time": 75.66
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "rate": 579371.16
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "gnorm": 0.4053
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "chrf": 56.09
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "ce_mean_words": 2.25224
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "bleu_detok": 28.7452
+        }
+    },
+    {
+        "step": 23500,
+        "data": {
+            "perplexity": 9.50897
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "sen": 7455041
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "cost": 0.46992564
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "time": 103.52
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "rate": 422248.42
+        }
+    },
+    {
+        "step": 23600,
+        "data": {
+            "gnorm": 0.404
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "sen": 9439355
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "cost": 0.47418058
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "time": 76.81
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "rate": 585134.15
+        }
+    },
+    {
+        "step": 23700,
+        "data": {
+            "gnorm": 0.3896
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "sen": 11545327
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "cost": 0.47194257
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "time": 76.15
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "rate": 577856.65
+        }
+    },
+    {
+        "step": 23800,
+        "data": {
+            "gnorm": 0.4095
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "sen": 13569568
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "cost": 0.47448057
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "time": 75.3
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "rate": 581011.31
+        }
+    },
+    {
+        "step": 23900,
+        "data": {
+            "gnorm": 0.433
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "sen": 15541047
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "cost": 0.46767649
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "time": 76.85
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "rate": 582807.67
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "gnorm": 0.3715
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "chrf": 56.213
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "ce_mean_words": 2.23003
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "bleu_detok": 28.8377
+        }
+    },
+    {
+        "step": 24000,
+        "data": {
+            "perplexity": 9.30011
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "sen": 17648354
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "cost": 0.46975702
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "time": 105.2
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "rate": 425517.91
+        }
+    },
+    {
+        "step": 24100,
+        "data": {
+            "gnorm": 0.3882
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "sen": 19712650
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "cost": 0.4740895
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "time": 77.48
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "rate": 585088.52
+        }
+    },
+    {
+        "step": 24200,
+        "data": {
+            "gnorm": 0.3906
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "sen": 21656075
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "cost": 0.47156057
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "time": 75.18
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "rate": 581693.19
+        }
+    },
+    {
+        "step": 24300,
+        "data": {
+            "gnorm": 0.3781
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "sen": 23739819
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "cost": 0.4710955
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "time": 74.73
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "rate": 577399.82
+        }
+    },
+    {
+        "step": 24400,
+        "data": {
+            "gnorm": 0.3844
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "sen": 25710861
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "cost": 0.4724445
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "time": 76.13
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "rate": 584522.89
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "gnorm": 0.3999
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "chrf": 55.5645
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "ce_mean_words": 2.25807
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "bleu_detok": 28.0782
+        }
+    },
+    {
+        "step": 24500,
+        "data": {
+            "perplexity": 9.56461
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "sen": 27682087
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "cost": 0.47136596
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "time": 103.7
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "rate": 422558.37
+        }
+    },
+    {
+        "step": 24600,
+        "data": {
+            "gnorm": 0.4157
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "sen": 29794073
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "cost": 0.47220996
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "time": 76.27
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "rate": 581401.11
+        }
+    },
+    {
+        "step": 24700,
+        "data": {
+            "gnorm": 0.4015
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "sen": 31845076
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "cost": 0.4813982
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "time": 76.87
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "rate": 586749.37
+        }
+    },
+    {
+        "step": 24800,
+        "data": {
+            "gnorm": 0.4758
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "sen": 33880769
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "cost": 0.47370744
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "time": 75.9
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "rate": 579112.42
+        }
+    },
+    {
+        "step": 24900,
+        "data": {
+            "gnorm": 0.4069
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "sen": 35802786
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "cost": 0.4671416
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "time": 76.13
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "rate": 595378.64
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "gnorm": 0.3616
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "chrf": 56.4697
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "ce_mean_words": 2.24467
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "bleu_detok": 28.9544
+        }
+    },
+    {
+        "step": 25000,
+        "data": {
+            "perplexity": 9.43729
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "sen": 37911065
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "cost": 0.47847483
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "time": 101.61
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "rate": 420550.74
+        }
+    },
+    {
+        "step": 25100,
+        "data": {
+            "gnorm": 0.447
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "sen": 39971069
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "cost": 0.47760281
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "time": 76.47
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "rate": 584996.94
+        }
+    },
+    {
+        "step": 25200,
+        "data": {
+            "gnorm": 0.3945
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "sen": 41999862
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "cost": 0.46821919
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "time": 77.31
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "rate": 585040.86
+        }
+    },
+    {
+        "step": 25300,
+        "data": {
+            "gnorm": 0.3858
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "sen": 43989425
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "cost": 0.48704341
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "time": 74.62
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "rate": 579190.69
+        }
+    },
+    {
+        "step": 25400,
+        "data": {
+            "gnorm": 0.4321
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "sen": 45991401
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "cost": 0.46704391
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "time": 74.99
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "rate": 581691.49
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "gnorm": 0.3745
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "chrf": 56.0064
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "ce_mean_words": 2.22381
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "bleu_detok": 28.5233
+        }
+    },
+    {
+        "step": 25500,
+        "data": {
+            "perplexity": 9.2425
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "sen": 47999845
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "cost": 0.4759658
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "time": 104.34
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "rate": 423921.66
+        }
+    },
+    {
+        "step": 25600,
+        "data": {
+            "gnorm": 0.3862
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "sen": 50040641
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "cost": 0.47374931
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "time": 76.32
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "rate": 583959.84
+        }
+    },
+    {
+        "step": 25700,
+        "data": {
+            "gnorm": 0.3919
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "sen": 52077468
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "cost": 0.47225434
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "time": 76.38
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "rate": 584021.65
+        }
+    },
+    {
+        "step": 25800,
+        "data": {
+            "gnorm": 0.3919
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "sen": 54071276
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "cost": 0.47661442
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "time": 74.72
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "rate": 579013.8
+        }
+    },
+    {
+        "step": 25900,
+        "data": {
+            "gnorm": 0.4617
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "sen": 56089913
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "cost": 0.46921775
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "time": 76.61
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "rate": 581186.64
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "gnorm": 0.3729
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "chrf": 56.3065
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "ce_mean_words": 2.27647
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "bleu_detok": 28.569
+        }
+    },
+    {
+        "step": 26000,
+        "data": {
+            "perplexity": 9.74225
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "sen": 58151204
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "cost": 0.47245178
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "time": 109.36
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "rate": 413567.89
+        }
+    },
+    {
+        "step": 26100,
+        "data": {
+            "gnorm": 0.3767
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "sen": 60230980
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "cost": 0.4715853
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "time": 74.92
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "rate": 583654.74
+        }
+    },
+    {
+        "step": 26200,
+        "data": {
+            "gnorm": 0.3986
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "sen": 62176493
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "cost": 0.47163433
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "time": 76.17
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "rate": 584631.84
+        }
+    },
+    {
+        "step": 26300,
+        "data": {
+            "gnorm": 0.3539
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "sen": 64268047
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "cost": 0.47099233
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "time": 75.74
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "rate": 585092.64
+        }
+    },
+    {
+        "step": 26400,
+        "data": {
+            "gnorm": 0.3793
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "sen": 66368527
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "cost": 0.47744834
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "time": 76.41
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "rate": 581498.06
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "gnorm": 0.4153
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "chrf": 55.9755
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "ce_mean_words": 2.22454
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "bleu_detok": 28.5708
+        }
+    },
+    {
+        "step": 26500,
+        "data": {
+            "perplexity": 9.24925
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "sen": 68290733
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "cost": 0.47429317
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "time": 105.56
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "rate": 416675.8
+        }
+    },
+    {
+        "step": 26600,
+        "data": {
+            "gnorm": 0.4022
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "sen": 70287306
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "cost": 0.47963434
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "time": 75.31
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "rate": 581165.11
+        }
+    },
+    {
+        "step": 26700,
+        "data": {
+            "gnorm": 0.4092
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "sen": 72292638
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "cost": 0.4737342
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "time": 74.84
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "rate": 579396.42
+        }
+    },
+    {
+        "step": 26800,
+        "data": {
+            "gnorm": 0.4052
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "sen": 74246819
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "cost": 0.47709998
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "time": 74.61
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "rate": 582866.61
+        }
+    },
+    {
+        "step": 26900,
+        "data": {
+            "gnorm": 0.4074
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "sen": 76263194
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "cost": 0.46942705
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "time": 77.53
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "rate": 586771.22
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "gnorm": 0.36
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "chrf": 56.2391
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "ce_mean_words": 2.25174
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "bleu_detok": 28.7538
+        }
+    },
+    {
+        "step": 27000,
+        "data": {
+            "perplexity": 9.5043
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "sen": 78361623
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "cost": 0.47348094
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "time": 105.58
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "rate": 417323.03
+        }
+    },
+    {
+        "step": 27100,
+        "data": {
+            "gnorm": 0.3596
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "sen": 80397690
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "cost": 0.46760589
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "time": 75.4
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "rate": 586307.27
+        }
+    },
+    {
+        "step": 27200,
+        "data": {
+            "gnorm": 0.35
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "sen": 82487753
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "cost": 0.47541919
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "time": 76.39
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "rate": 574456.48
+        }
+    },
+    {
+        "step": 27300,
+        "data": {
+            "gnorm": 0.3863
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "sen": 84462139
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "cost": 0.47592857
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "time": 77.43
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "rate": 588286.63
+        }
+    },
+    {
+        "step": 27400,
+        "data": {
+            "gnorm": 0.4163
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "sen": 86489132
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "cost": 0.47397634
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "time": 77.15
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "rate": 576875.31
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "gnorm": 0.3802
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "chrf": 56.1179
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "ce_mean_words": 2.21402
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "bleu_detok": 28.7277
+        }
+    },
+    {
+        "step": 27500,
+        "data": {
+            "perplexity": 9.15246
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "sen": 88444764
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "cost": 0.46742699
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "time": 102.46
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "rate": 423206.42
+        }
+    },
+    {
+        "step": 27600,
+        "data": {
+            "gnorm": 0.388
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "sen": 90442222
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "cost": 0.47142285
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "time": 75.41
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "rate": 583133.77
+        }
+    },
+    {
+        "step": 27700,
+        "data": {
+            "gnorm": 0.3451
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "sen": 92475487
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "cost": 0.47490439
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "time": 76.35
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "rate": 583126.25
+        }
+    },
+    {
+        "step": 27800,
+        "data": {
+            "gnorm": 0.3725
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "sen": 94557890
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "cost": 0.47821912
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "time": 75.07
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "rate": 583428.67
+        }
+    },
+    {
+        "step": 27900,
+        "data": {
+            "gnorm": 0.4125
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "sen": 96610941
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "cost": 0.47505906
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "time": 76.73
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "rate": 590665.27
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "gnorm": 0.3717
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "chrf": 56.0086
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "ce_mean_words": 2.24108
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "bleu_detok": 28.7308
+        }
+    },
+    {
+        "step": 28000,
+        "data": {
+            "perplexity": 9.40343
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "sen": 98632437
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "cost": 0.47137201
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "time": 105.63
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "rate": 425541.53
+        }
+    },
+    {
+        "step": 28100,
+        "data": {
+            "gnorm": 0.3557
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "sen": 100688582
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "cost": 0.47993022
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "time": 75.75
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "rate": 577239.34
+        }
+    },
+    {
+        "step": 28200,
+        "data": {
+            "gnorm": 0.4125
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "sen": 102674365
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "cost": 0.46624178
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "time": 74.5
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "rate": 593026.97
+        }
+    },
+    {
+        "step": 28300,
+        "data": {
+            "gnorm": 0.376
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "sen": 104752728
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "cost": 0.47804269
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "time": 76.89
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "rate": 581731.59
+        }
+    },
+    {
+        "step": 28400,
+        "data": {
+            "gnorm": 0.3787
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "sen": 106732175
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "cost": 0.47637525
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "time": 76.02
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "rate": 584376.41
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "gnorm": 0.3797
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "chrf": 56.2485
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "ce_mean_words": 2.25134
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "bleu_detok": 28.6929
+        }
+    },
+    {
+        "step": 28500,
+        "data": {
+            "perplexity": 9.50043
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "sen": 108833070
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "cost": 0.48193774
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "time": 102.29
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "rate": 417108.99
+        }
+    },
+    {
+        "step": 28600,
+        "data": {
+            "gnorm": 0.4288
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "sen": 110816259
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "cost": 0.47197807
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "time": 75.44
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "rate": 584956.03
+        }
+    },
+    {
+        "step": 28700,
+        "data": {
+            "gnorm": 0.4097
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "sen": 112826414
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "cost": 0.47193605
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "time": 75.94
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "rate": 584788.24
+        }
+    },
+    {
+        "step": 28800,
+        "data": {
+            "gnorm": 0.376
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "sen": 114850871
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "cost": 0.47788286
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "time": 77.78
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "rate": 581796.33
+        }
+    },
+    {
+        "step": 28900,
+        "data": {
+            "gnorm": 0.3974
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "sen": 116926670
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "cost": 0.47548437
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "time": 75.79
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "rate": 587310.44
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "gnorm": 0.4166
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "epoch": 5
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "chrf": 56.3682
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "ce_mean_words": 2.22039
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "bleu_detok": 28.9228
+        }
+    },
+    {
+        "step": 29000,
+        "data": {
+            "perplexity": 9.21096
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "sen": 1333581
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "cost": 0.46966952
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "time": 132.86
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "rate": 335959.86
+        }
+    },
+    {
+        "step": 29100,
+        "data": {
+            "gnorm": 0.395
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "sen": 3293400
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "cost": 0.46503839
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "time": 75.65
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "rate": 581739.62
+        }
+    },
+    {
+        "step": 29200,
+        "data": {
+            "gnorm": 0.3448
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "sen": 5341022
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "cost": 0.47273311
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "time": 75.72
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "rate": 586295.58
+        }
+    },
+    {
+        "step": 29300,
+        "data": {
+            "gnorm": 0.3926
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "sen": 7412116
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "cost": 0.46999809
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "time": 75.72
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "rate": 579008.38
+        }
+    },
+    {
+        "step": 29400,
+        "data": {
+            "gnorm": 0.3573
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "sen": 9375112
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "cost": 0.47253028
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "time": 75.65
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "rate": 587600.22
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "gnorm": 0.3742
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "chrf": 56.18
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "ce_mean_words": 2.23489
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "bleu_detok": 28.9495
+        }
+    },
+    {
+        "step": 29500,
+        "data": {
+            "perplexity": 9.34545
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "sen": 11430517
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "cost": 0.47268033
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "time": 106.88
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "rate": 420453.89
+        }
+    },
+    {
+        "step": 29600,
+        "data": {
+            "gnorm": 0.3631
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "sen": 13463032
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "cost": 0.47030401
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "time": 73.7
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "rate": 578995.1
+        }
+    },
+    {
+        "step": 29700,
+        "data": {
+            "gnorm": 0.3736
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "sen": 15518559
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "cost": 0.47908771
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "time": 77.51
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "rate": 578773.73
+        }
+    },
+    {
+        "step": 29800,
+        "data": {
+            "gnorm": 0.4376
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "sen": 17566166
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "cost": 0.46783257
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "time": 77.46
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "rate": 590623.58
+        }
+    },
+    {
+        "step": 29900,
+        "data": {
+            "gnorm": 0.373
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "sen": 19618174
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "cost": 0.4735083
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "time": 75.63
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "rate": 580181.14
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "gnorm": 0.3677
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "chrf": 56.45
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "ce_mean_words": 2.22873
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "bleu_detok": 28.9423
+        }
+    },
+    {
+        "step": 30000,
+        "data": {
+            "perplexity": 9.2881
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "sen": 21679609
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "cost": 0.47252882
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "time": 106.66
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "rate": 425754.75
+        }
+    },
+    {
+        "step": 30100,
+        "data": {
+            "gnorm": 0.3702
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "sen": 23659774
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "cost": 0.4667708
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "time": 76.25
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "rate": 582840.03
+        }
+    },
+    {
+        "step": 30200,
+        "data": {
+            "gnorm": 0.3432
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "sen": 25654044
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "cost": 0.46850276
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "time": 75.88
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "rate": 587200.7
+        }
+    },
+    {
+        "step": 30300,
+        "data": {
+            "gnorm": 0.3455
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "sen": 27717502
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "cost": 0.47688112
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "time": 75.7
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "rate": 579038.81
+        }
+    },
+    {
+        "step": 30400,
+        "data": {
+            "gnorm": 0.4286
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "sen": 29812420
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "cost": 0.46614942
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "time": 75.78
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "rate": 587626.25
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "gnorm": 0.3636
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "chrf": 56.3002
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "ce_mean_words": 2.24399
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "bleu_detok": 28.8277
+        }
+    },
+    {
+        "step": 30500,
+        "data": {
+            "perplexity": 9.43091
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "sen": 31755383
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "cost": 0.47693065
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "time": 102.43
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "rate": 424767.5
+        }
+    },
+    {
+        "step": 30600,
+        "data": {
+            "gnorm": 0.3646
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "sen": 33800399
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "cost": 0.4712663
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "time": 75.85
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "rate": 581047.14
+        }
+    },
+    {
+        "step": 30700,
+        "data": {
+            "gnorm": 0.3535
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "sen": 35842921
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "cost": 0.47169334
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "time": 77.91
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "rate": 581014.7
+        }
+    },
+    {
+        "step": 30800,
+        "data": {
+            "gnorm": 0.3826
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "sen": 37845367
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "cost": 0.46993446
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "time": 75.98
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "rate": 580652.82
+        }
+    },
+    {
+        "step": 30900,
+        "data": {
+            "gnorm": 0.3431
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "sen": 39926590
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "cost": 0.47394589
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "time": 75.83
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "rate": 581360.6
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "gnorm": 0.3782
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "chrf": 55.8972
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "ce_mean_words": 2.25594
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "bleu_detok": 28.6004
+        }
+    },
+    {
+        "step": 31000,
+        "data": {
+            "perplexity": 9.54424
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "sen": 41864917
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "cost": 0.47722626
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "time": 102.86
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "rate": 423831.29
+        }
+    },
+    {
+        "step": 31100,
+        "data": {
+            "gnorm": 0.3952
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "sen": 43888720
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "cost": 0.46790355
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "time": 75.3
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "rate": 584833.84
+        }
+    },
+    {
+        "step": 31200,
+        "data": {
+            "gnorm": 0.4035
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "sen": 45954632
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "cost": 0.47324082
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "time": 76.97
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "rate": 582367.75
+        }
+    },
+    {
+        "step": 31300,
+        "data": {
+            "gnorm": 0.3993
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "sen": 47999846
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "cost": 0.47412416
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "time": 76.79
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "rate": 586596.96
+        }
+    },
+    {
+        "step": 31400,
+        "data": {
+            "gnorm": 0.3889
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "sen": 50049502
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "cost": 0.46941414
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "time": 77.32
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "rate": 583264.75
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "gnorm": 0.3463
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "chrf": 56.4311
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "ce_mean_words": 2.255
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "bleu_detok": 29.0306
+        }
+    },
+    {
+        "step": 31500,
+        "data": {
+            "perplexity": 9.53533
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "sen": 52118981
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "cost": 0.4683778
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "time": 108.21
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "rate": 411812.35
+        }
+    },
+    {
+        "step": 31600,
+        "data": {
+            "gnorm": 0.3753
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "sen": 54134032
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "cost": 0.4718377
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "time": 75.08
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "rate": 580342.01
+        }
+    },
+    {
+        "step": 31700,
+        "data": {
+            "gnorm": 0.3825
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "sen": 56078442
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "cost": 0.47752008
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "time": 74.22
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "rate": 578162.47
+        }
+    },
+    {
+        "step": 31800,
+        "data": {
+            "gnorm": 0.3862
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "sen": 58111140
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "cost": 0.47620571
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "time": 76.69
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "rate": 582288.38
+        }
+    },
+    {
+        "step": 31900,
+        "data": {
+            "gnorm": 0.3873
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "sen": 60126495
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "cost": 0.47227418
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "time": 76.52
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "rate": 582797.39
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "gnorm": 0.4013
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "epoch": 6
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "chrf": 56.0271
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "ce_mean_words": 2.25177
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "bleu_detok": 28.6194
+        }
+    },
+    {
+        "step": 32000,
+        "data": {
+            "perplexity": 9.50458
+        }
+    }
+]

--- a/tests/test_tracking_cli.py
+++ b/tests/test_tracking_cli.py
@@ -49,30 +49,14 @@ def samples_dir():
 )
 @patch("translations_parser.publishers.wandb")
 def test_taskcluster(wandb_mock, getargs_mock, caplog, samples_dir, tmp_dir):
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.INFO)
     wandb_dir = tmp_dir / "wandb"
     wandb_dir.mkdir(parents=True)
     wandb_mock.init.return_value.dir = wandb_dir
     tc_publish.main()
     assert [(level, message) for _module, level, message in caplog.record_tuples] == [
-        (logging.INFO, "Reading logs stream.")
-    ] + [
-        (
-            logging.DEBUG,
-            f"Skipping line {i} : Headers does not match the filter",
-        )
-        for i in [*range(1, 128), 154, 558, 561, 1056, 1059, 1061, 1064, 1066]
-    ] + [
-        (logging.DEBUG, "Reading Marian version."),
-        (logging.DEBUG, "Reading Marian run description."),
-        (logging.DEBUG, "Reading Marian configuration."),
-    ] + [
-        (
-            logging.DEBUG,
-            f"Skipping line {i} : Headers does not match the filter",
-        )
-        for i in range(1664, 1691)
-    ] + [
+        (logging.INFO, "Reading logs stream."),
+        (logging.INFO, "Detected Marian version 1.10"),
         (logging.INFO, "Successfully parsed 588 lines"),
         (logging.INFO, "Found 102 training entries"),
         (logging.INFO, "Found 34 validation entries"),
@@ -106,6 +90,7 @@ def test_experiments_marian_1_10(wandb_mock, getargs_mock, caplog, samples_dir, 
                 f"Parsing folder {samples_dir}/experiments_1_10/models/en-nl/prod/student",
             ),
             (logging.INFO, "Reading logs stream."),
+            (logging.INFO, "Detected Marian version 1.10"),
             (logging.INFO, "Successfully parsed 1002 lines"),
             (logging.INFO, "Found 550 training entries"),
             (logging.INFO, "Found 108 validation entries"),
@@ -217,6 +202,7 @@ def test_experiments_marian_1_12(wandb_mock, getargs_mock, caplog, samples_dir, 
             (logging.INFO, "Found 4 quantized metrics"),
             (logging.INFO, "Found 8 evaluation metrics"),
             (logging.INFO, "Creating missing run quantized with associated metrics"),
+            (logging.INFO, "Detected Marian version 1.12"),
         ]
     )
     log_calls, metrics_calls = [], []
@@ -274,6 +260,7 @@ def test_taskcluster_wandb_initialization_failure(
     tc_publish.main()
     assert [(level, message) for _module, level, message in caplog.record_tuples] == [
         (logging.INFO, "Reading logs stream."),
+        (logging.INFO, "Detected Marian version 1.10"),
         (
             logging.ERROR,
             "WandB client could not be initialized: Invalid credentials. No data will be published.",
@@ -311,6 +298,7 @@ def test_taskcluster_wandb_log_failures(wandb_mock, getargs_mock, caplog, sample
     tc_publish.main()
     assert [(level, message) for _module, level, message in caplog.record_tuples] == [
         (logging.INFO, "Reading logs stream."),
+        (logging.INFO, "Detected Marian version 1.10"),
     ] + [
         (logging.ERROR, "Error publishing training epoch using WandB: Unexpected failure"),
         (logging.ERROR, "Error publishing training epoch using WandB: Unexpected failure"),

--- a/tests/test_tracking_cli.py
+++ b/tests/test_tracking_cli.py
@@ -44,6 +44,9 @@ def samples_dir():
         wandb_artifacts=None,
         wandb_group="group",
         wandb_run_name="run",
+        tags=[
+            "unittest",
+        ],
         taskcluster_secret=None,
     ),
 )
@@ -245,6 +248,9 @@ def test_experiments_marian_1_12(wandb_mock, getargs_mock, caplog, samples_dir, 
         wandb_artifacts=None,
         wandb_group="group",
         wandb_run_name="run",
+        tags=[
+            "unittest",
+        ],
         taskcluster_secret=None,
     ),
 )
@@ -282,6 +288,9 @@ def test_taskcluster_wandb_initialization_failure(
         wandb_artifacts=None,
         wandb_group="group",
         wandb_run_name="run",
+        tags=[
+            "unittest",
+        ],
         taskcluster_secret=None,
     ),
 )

--- a/tracking/translations_parser/__init__.py
+++ b/tracking/translations_parser/__init__.py
@@ -1,0 +1,6 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[tracking %(levelname)s] %(message)s",
+)

--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -16,10 +16,6 @@ from translations_parser.data import Metric
 from translations_parser.parser import TrainingParser
 from translations_parser.publishers import WandB
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -96,7 +96,7 @@ def get_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
+def boot() -> None:
     args = get_args()
 
     if args.loglevel:
@@ -150,3 +150,19 @@ def main() -> None:
         log_filter=taskcluster_log_filter,
     )
     parser.run()
+
+
+def main() -> None:
+    """
+    Called from Python entrypoint
+    Catch every exception when running in Taskcluster to avoid crashing real training
+    """
+    try:
+        boot()
+    except Exception as e:
+        logger.error(f"Publication failed: {e}")
+        if os.environ.get("MOZ_AUTOMATION") is not None:
+            # Stop cleanly when in taskcluster
+            sys.exit(0)
+        else:
+            raise

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -79,6 +79,13 @@ def get_args() -> argparse.Namespace:
         default=os.environ.get("TASKCLUSTER_SECRET"),
     )
     parser.add_argument(
+        "--tags",
+        help="List of tags to use on Weight & Biases publication",
+        type=str,
+        default=["taskcluster"],
+        nargs="+",
+    )
+    parser.add_argument(
         "--verbose",
         "-v",
         help="Print debug messages.",
@@ -188,7 +195,7 @@ def boot() -> None:
                 group=group_name,
                 name=run_name,
                 artifacts=args.wandb_artifacts,
-                tags=["cli"],
+                tags=args.tags,
                 config={
                     "logs_file": args.input_file,
                 },

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -147,11 +147,6 @@ def boot() -> None:
     if args.loglevel:
         logger.setLevel(args.loglevel)
 
-    # Prevent running when explicitly disabled by operator
-    if os.environ.get("WANDB_PUBLICATION", "true").lower() == "false":
-        logger.info("Skip publication as requested by operator through WANDB_PUBLICATION")
-        return
-
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     lines: TextIOWrapper | Iterator[str]
@@ -180,8 +175,13 @@ def boot() -> None:
         run_name = args.wandb_run_name
 
     # Enable publication on weight and biases when project is set
+    # But prevent running when explicitly disabled by operator
     publishers: list[Publisher] = [CSVExport(output_dir=args.output_dir)]
-    if project_name:
+    if os.environ.get("WANDB_PUBLICATION", "true").lower() == "false":
+        logger.info(
+            "Skip weight & biases publication as requested by operator through WANDB_PUBLICATION"
+        )
+    elif project_name:
         publishers.append(
             WandB(
                 project=project_name,

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -25,11 +25,6 @@ from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import CSVExport, Publisher, WandB
 from translations_parser.utils import taskcluster_log_filter
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
-
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -20,8 +20,6 @@ from collections.abc import Iterator
 from io import TextIOWrapper
 from pathlib import Path
 
-import yaml
-
 import taskcluster
 from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import CSVExport, Publisher, WandB
@@ -136,7 +134,7 @@ def boot() -> None:
 
         try:
             wandb_secret = secrets.get(args.taskcluster_secret)
-            wandb_token = yaml.safe_load(wandb_secret["secret"])["token"]
+            wandb_token = wandb_secret["secret"]["token"]
         except Exception as e:
             raise Exception(
                 f"Weight & Biases secret API Key retrieved from Taskcluster is malformed: {e}"

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -95,6 +95,11 @@ def boot() -> None:
     if args.loglevel:
         logger.setLevel(args.loglevel)
 
+    # Prevent running when explicitly disabled by operator
+    if os.environ.get("WANDB_PUBLICATION", "true").lower() == "false":
+        logger.info("Skip publication as requested by operator through WANDB_PUBLICATION")
+        return
+
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     lines: TextIOWrapper | Iterator[str]

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -142,10 +142,13 @@ def boot() -> None:
 
         os.environ.setdefault("WANDB_API_KEY", wandb_token)
 
+    # Use log filtering when using non-stream (for uploading past experiments)
+    log_filter = taskcluster_log_filter if not args.from_stream else None
+
     parser = TrainingParser(
         lines,
         publishers=publishers,
-        log_filter=taskcluster_log_filter,
+        log_filter=log_filter,
     )
     parser.run()
 

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import taskcluster
 from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import CSVExport, Publisher, WandB
-from translations_parser.utils import taskcluster_log_filter
+from translations_parser.utils import build_task_name, taskcluster_log_filter
 
 
 def get_args() -> argparse.Namespace:
@@ -117,7 +117,7 @@ def get_wandb_names():
     # CI task groups do not expose any configuration, so we must use default values
     queue = taskcluster.Queue({"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]})
     task = queue.task(task_id)
-    task_name = task["metadata"]["name"]
+    _, task_name = build_task_name(task)
     group_id = task["taskGroupId"]
     task_group = queue.task(group_id)
     config = task_group.get("extra", {}).get("action", {}).get("context", {}).get("input")

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -84,7 +84,7 @@ def publish_task(project: str, group: str, name: str, task: dict, metrics: list[
                 project=project,
                 group=group,
                 name=name,
-                tags=["taskcluster"],
+                tags=["taskcluster-offline"],
             )
         ],
         metrics=metrics,

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -23,11 +23,6 @@ from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import WandB
 from translations_parser.utils import parse_tag
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
-
 KIND_TAG_TARGET = ("train", "finetune")
 MULTIPLE_TRAIN_SUFFIX = re.compile(r"(-\d+)/\d+$")
 queue = taskcluster.Queue({"rootUrl": "https://firefox-ci-tc.services.mozilla.com"})

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -7,10 +7,6 @@ from typing import List, Sequence
 
 from translations_parser.utils import parse_tag
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 METRIC_LOG_RE = re.compile(

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -39,10 +39,10 @@ class TrainingEpoch:
 class ValidationEpoch:
     epoch: int
     up: int
-    perplexity: float
     chrf: float
     ce_mean_words: float
     bleu_detok: float
+    perplexity: float = None  # optional
 
 
 @dataclass

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -191,6 +191,9 @@ class TrainingParser:
                 tag = _join(marian_tags)
                 self.indexed_logs[tag].append(text)
 
+            # Display parsed log text on stderr for easier debug
+            logger.debug(f"Marian log: {text.strip()}")
+
             yield headers, text
 
     def parse_marian_context(self, logs_iter: Iterator[tuple[list[tuple[str]], str]]) -> None:

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -237,7 +237,7 @@ class TrainingParser:
         except Exception as e:
             raise Exception(f"Invalid config section: {e}")
 
-        logger.info(f"Detected marian version {self.version}")
+        logger.info(f"Detected Marian version {self.version}")
 
     def parse_data(self, logs_iter: Iterator[tuple[list[tuple[str]], str]]) -> None:
         """

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Sequence
 from datetime import datetime
@@ -192,7 +193,7 @@ class TrainingParser:
                 self.indexed_logs[tag].append(text)
 
             # Display parsed log text on stderr for easier debug
-            logger.debug(f"Marian log: {text.strip()}")
+            print(f"Marian log: {text.strip()}", file=sys.stderr)
 
             yield headers, text
 

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -177,11 +177,18 @@ class TrainingParser:
                 self.run_date = self.get_timestamp(headers)
             text = line[position:]
 
+            def _join(iterable):
+                if not iterable:
+                    return "_"
+                if isinstance(iterable[0], str):
+                    return "_".join(iterable)
+                return _join([_join(item) for item in iterable])
+
             # Record logs depending on Marian headers
             if len(headers) >= 2:
                 # First is task timestamp, second is marian timestamp
                 _, _, *marian_tags = headers
-                tag = "_".join(*marian_tags) if marian_tags else "_"
+                tag = _join(marian_tags)
                 self.indexed_logs[tag].append(text)
 
             yield headers, text
@@ -229,6 +236,8 @@ class TrainingParser:
             self.config = yaml.safe_load(config_yaml)
         except Exception as e:
             raise Exception(f"Invalid config section: {e}")
+
+        logger.info(f"Detected marian version {self.version}")
 
     def parse_data(self, logs_iter: Iterator[tuple[list[tuple[str]], str]]) -> None:
         """

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -202,8 +202,9 @@ class TrainingParser:
         # Consume first lines until we get the Marian header
         while ("marian",) not in headers:
             headers, text = next(logs_iter)
+            logger.debug(f"Marian header not found in: headers={headers} text={text.strip()}")
 
-        logger.debug("Reading Marian version.")
+        logger.debug(f"Reading Marian version from text={text.strip()}")
         _, version, self.version_hash, self.release_date, *_ = text.split()
         version = version.rstrip(";")
         major, minor = map(int, version.lstrip("v").split(".")[:2])

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -12,10 +12,6 @@ import yaml
 from translations_parser.data import Metric, TrainingEpoch, TrainingLog, ValidationEpoch
 from translations_parser.publishers import Publisher
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 HEADER_RE = re.compile(r"(?<=\[)(?P<value>.+?)\] ")
@@ -166,6 +162,10 @@ class TrainingParser:
         Automatically set Marian run date when found.
         """
         for line in self.logs_iter:
+            # When reading stdin stream, propagate raw lines to stdout
+            print(line, file=sys.stdout, end='')
+
+
             self._current_index += 1
             headers, position = self.get_headers(line)
             if self.log_filter and not self.log_filter(headers):
@@ -191,9 +191,6 @@ class TrainingParser:
                 _, _, *marian_tags = headers
                 tag = _join(marian_tags)
                 self.indexed_logs[tag].append(text)
-
-            # Display parsed log text on stderr for easier debug
-            print(f"Marian log: {text.strip()}", file=sys.stderr)
 
             yield headers, text
 

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -136,11 +136,8 @@ class TrainingParser:
         val = ValidationEpoch.__annotations__[key](val)
         entry = self._validation_entries[(epoch, up)]
         entry[key] = val
-        if self.version == "1.10":
-            # perplexity value is not defined in Marian 1.10
-            entry["perplexity"] = None
         # Build a validation epoch from multiple lines
-        expected_keys = set(ValidationEpoch.__annotations__.keys()) - {"epoch", "up"}
+        expected_keys = set(ValidationEpoch.__annotations__.keys()) - {"epoch", "up", "perplexity"}
         if not (expected_keys - set(entry.keys())):
             validation_epoch = ValidationEpoch(epoch=epoch, up=up, **entry)
             self.validation.append(validation_epoch)

--- a/tracking/translations_parser/parser.py
+++ b/tracking/translations_parser/parser.py
@@ -163,8 +163,7 @@ class TrainingParser:
         """
         for line in self.logs_iter:
             # When reading stdin stream, propagate raw lines to stdout
-            print(line, file=sys.stdout, end='')
-
+            print(line, file=sys.stdout, end="")
 
             self._current_index += 1
             headers, position = self.get_headers(line)

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -11,10 +11,6 @@ import yaml
 from translations_parser.data import Metric, TrainingEpoch, TrainingLog, ValidationEpoch
 from translations_parser.utils import parse_tag
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -3,10 +3,6 @@ import re
 from collections.abc import Sequence
 from datetime import datetime
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="[%(levelname)s] %(message)s",
-)
 logger = logging.getLogger(__name__)
 
 # Keywords used to split eval filenames into model and dataset


### PR DESCRIPTION
Refs #333

This PR add code to run `parse_tc_logs` using live logs from teacher trainer task.

The call to the python script is configured through a Taskcluster transform `use-secret` which brings
- Taskcluster proxy
- Taskcluster secret scope
- Taskcluster secret environment variable used by `parse_tc_logs`

When the secret is available and the `parse_tc_logs` has been installed through `pip install ./training`, the command will run against the logs to track & publish metrics.

If the command crashes (invalid or missing credentials for example), it will cleanly exit with exit code 0 to prevent crashing the training too.

Taskcluster header parsing has been disabled when using `--from-stream` as these headers are NOT present when running from inside the task.