### PR TITLE
Switch CPU tasks to generic-worker/d2g images (fixes #473)

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -65,28 +65,28 @@ workers:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp'
+            worker-type: 'b-linux-large-gcp-d2g'
         # Use for tasks that don't require GPUs, but need lots of disk space
         # eg: dataset cleaning & merging
         b-cpu-largedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-300gb'
+            worker-type: 'b-linux-large-gcp-d2g-300gb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # eg: alignments
         b-cpu-xlargedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-1tb'
+            worker-type: 'b-linux-large-gcp-d2g-1tb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # and higher reliability
         b-cpu-xlargedisk-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-1tb-standard'
+            worker-type: 'b-linux-large-gcp-d2g-1tb-standard'
         # Use for quick tasks that need a GPU, eg: evaluate
         b-gpu:
             provisioner: '{trust-domain}-{level}'

--- a/taskcluster/docker/train/Dockerfile
+++ b/taskcluster/docker/train/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -qq \
                           wget \
     && apt-get clean
 
-# Required to download sacrebleu datasets
+# Required to download sacrebleu datasets.
 RUN pip install sacrebleu
 
 VOLUME /builds/worker/checkouts


### PR DESCRIPTION
This switches us from the deprecated docker-worker to generic-worker. generic-worker provides a translation layer for docker-worker tasks that avoids the need to change any payloads. (It will download specified images and run payload commands in them, rather than on the host machine.)

Upgrading to this new image will give us memory monitoring capabilities on the CPU workers because the new image has the GCP Ops Agent installed on it.