### PR TITLE
Revert change to generic-worker for CPU tasks

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -65,28 +65,28 @@ workers:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-d2g'
+            worker-type: 'b-linux-large-gcp'
         # Use for tasks that don't require GPUs, but need lots of disk space
         # eg: dataset cleaning & merging
         b-cpu-largedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-d2g-300gb'
+            worker-type: 'b-linux-large-gcp-300gb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # eg: alignments
         b-cpu-xlargedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-d2g-1tb'
+            worker-type: 'b-linux-large-gcp-1tb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # and higher reliability
         b-cpu-xlargedisk-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-d2g-1tb-standard'
+            worker-type: 'b-linux-large-gcp-1tb-standard'
         # Use for quick tasks that need a GPU, eg: evaluate
         b-gpu:
             provisioner: '{trust-domain}-{level}'


### PR DESCRIPTION
We're hitting some odd issues with caches that need to be worked out. Eg: error: cache /builds/worker/checkouts is not empty and is missing a .cacherequires file; the cache names for this task are likely mis-configured or TASKCLUSTER_CACHES is not set properly

(from https://firefox-ci-tc.services.mozilla.com/tasks/IvbeCQBuRuKIOaeOIGEfHg/runs/7)