### PR TITLE
Update the training continuation docs

### DIFF
--- a/docs/using-pretrained-models.md
+++ b/docs/using-pretrained-models.md
@@ -14,20 +14,44 @@ Utilizing pretrained models can reduce training time and resource usage.
 To download and use models from previous training runs or external sources, use the `pretrained-models` parameter in the training config. The keys in this parameter correspond to the training task `kinds` capable of using pretrained models. This is currently `train-teacher` and `train-backwards`. See [#515](https://github.com/mozilla/firefox-translations-training/issues/515) for `train-student` support.
 
 ```yaml
-pretrained-models:
-  # Continue training a teacher model.
-  train-teacher:
-    urls:
-      - https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/task-id/artifacts/public/build
-    mode: continue
-    type: default
+experiment:
+  pretrained-models:
+    # Continue training a teacher model.
+    train-teacher:
+      urls:
+        - https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/task-id/artifacts/public/build
+      mode: continue
+      type: default
 
-  # Re-use an existing backwards model from a Google Cloud Storage bucket.
-  train-backwards:
-    urls:
-      - https://storage.googleapis.com/bucket-name/models/ru-en/backward
-    mode: use
-    type: default
+    # Re-use an existing backwards model from a Google Cloud Storage bucket. This must
+    # be the original (non-quantized) student model.
+    train-backwards:
+      urls:
+        - https://storage.googleapis.com/releng-translations-dev/models/en-fi/opusmt/student/
+      mode: use
+      type: default
+```
+
+To find models from older training runs see the `gs://releng-translations-dev/models` bucket.
+
+For instance you can see the models available for the following commands:
+
+```sh
+gsutil ls gs://releng-translations-dev/models
+```
+
+And then use the URLs from:
+
+```sh
+gs://releng-translations-dev/models/en-fi/opusmt/student
+```
+
+This directory should contain the various `.npz` and `.decoder.yml` for the models, as well as the `vocab.spm`. If the `vocab.spm` is not present then run something like:
+
+```sh
+gsutil cp \
+  gs://releng-translations-dev/models/en-fi/opusmt/vocab/vocab.spm \
+  gs://releng-translations-dev/models/en-fi/opusmt/student/vocab.spm
 ```
 
 ### The URLs Key

--- a/taskcluster/configs/config.prod.yml
+++ b/taskcluster/configs/config.prod.yml
@@ -57,6 +57,9 @@ experiment:
   # Path to a pretrained vocabulary (optional).
   vocab: NOT-YET-SUPPORTED
 
+  # Continue training see docs/using-pretrained-models.md
+  pretrained-models: {}
+
 # The lists of datasets. Each dataset is defined by a corpus key. This key is formed
 # by "{IMPORTER}_{DATASET}". These datasets and their corpus key can be found through
 #
@@ -161,6 +164,3 @@ taskcluster:
   # After the parallel corpora are merged and de-duplicated, the combined file is
   # then split into an even number of chunks.
   split-chunks: 10
-
-# Continue training see docs/using-pretrained-models.md
-pretrained-models: {}


### PR DESCRIPTION
This fixes the location of the `pretrained-models` and adds information of how to find our models. It also mentions the `vocab.spm` requirement.