### PR TITLE
Add file overrides to the training continuation, and refactor the implementation

### DIFF
--- a/docs/using-pretrained-models.md
+++ b/docs/using-pretrained-models.md
@@ -46,12 +46,20 @@ And then use the URLs from:
 gs://releng-translations-dev/models/en-fi/opusmt/student
 ```
 
-This directory should contain the various `.npz` and `.decoder.yml` for the models, as well as the `vocab.spm`. If the `vocab.spm` is not present then run something like:
+This directory should contain the various `.npz` and `.decoder.yml` for the models, as well as the `vocab.spm`. If the `vocab.spm` is not present then add a file override to the config, for instance:
 
-```sh
-gsutil cp \
-  gs://releng-translations-dev/models/en-fi/opusmt/vocab/vocab.spm \
-  gs://releng-translations-dev/models/en-fi/opusmt/student/vocab.spm
+```yml
+experiment:
+  pretrained-models:
+    train-backwards:
+      urls:
+        - https://storage.googleapis.com/releng-translations-dev/models/en-fi/opusmt/student/
+      overrides:
+        - {
+          "vocab.spm": "https://storage.googleapis.com/releng-translations-dev/models/en-fi/opusmt/vocab/vocab.spm"
+        }
+      mode: use
+      type: default
 ```
 
 ### The URLs Key

--- a/taskcluster/translations_taskgraph/transforms/training_continuation.py
+++ b/taskcluster/translations_taskgraph/transforms/training_continuation.py
@@ -1,8 +1,17 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
 from taskgraph.transforms.base import TransformSequence
 from urllib.parse import urljoin
 import os
 
-CONTINUE_TRAINING_ARTIFACTS = (
+"""
+Transform jobs to be able to use pre-trained models.
+
+See docs/using-pretrained-models.md
+"""
+
+CONTINUE_TRAINING_ARTIFACTS = [
     "devset.out",
     "model.npz",
     "model.npz.best-bleu-detok.npz",
@@ -20,33 +29,75 @@ CONTINUE_TRAINING_ARTIFACTS = (
     "train.log",
     "valid.log",
     "vocab.spm",
-)
+]
 
-INITIALIZE_MODEL_ARTIFACTS = (
+INITIALIZE_MODEL_ARTIFACTS = [
     "model.npz.best-bleu-detok.npz",
     "model.npz.best-ce-mean-words.npz",
     "final.model.npz.best-chrf.npz",
     "model.npz.best-chrf.npz",
+]
+
+ModelMode = Enum(
+    "ModelMode",
+    [
+        "init",
+        "continue",
+        "use",
+    ],
 )
 
 
-def get_artifact_mount(url, directory, artifact_name):
-    normalized_url = f"{url}/" if not url.endswith("/") else url
-    artifact_url = urljoin(normalized_url, artifact_name)
-    return {
-        "content": {
-            "url": artifact_url,
-        },
-        "file": os.path.join(directory, artifact_name),
-    }
+@dataclass
+class PretrainedModel:
+    """
+    The YAML object that represents a pre-trained model.
+    """
+
+    urls: list[str]
+    mode: ModelMode
+    type: Literal["npz"]  # In the future "opusmt" may be supported.
+
+    def get_artifact_names(self) -> list[str]:
+        artifacts = {
+            "init": INITIALIZE_MODEL_ARTIFACTS,
+            "continue": CONTINUE_TRAINING_ARTIFACTS,
+            "use": CONTINUE_TRAINING_ARTIFACTS,
+        }
+        return artifacts[self.mode]
 
 
-def get_artifact_mounts(urls, directory, artifact_names):
-    for url in urls:
-        artifact_mounts = []
-        for artifact_name in artifact_names:
-            artifact_mounts.append(get_artifact_mount(url, directory, artifact_name))
-        yield artifact_mounts
+def get_artifact_mounts(pretrained_model: PretrainedModel, directory: str):
+    """
+    Build a list of artifact mounts that will mount a remote URL file to the tasks local
+    file system.
+
+    For instance, given: "https://example.com/en-ru"
+
+    This will download files such as:
+      "https://example.com/en-ru/model.npz.best-bleu-detok.npz"
+      "https://example.com/en-ru/model.npz.best-ce-mean-words.npz",
+      etc.
+    """
+
+    if len(pretrained_model.urls) != 1:
+        raise Exception(
+            "Multiple URLs are currently not supported for pretrained models. See Issue #542"
+        )
+
+    url = pretrained_model.urls[0]
+    artifact_mounts = []
+
+    for artifact_name in pretrained_model.get_artifact_names():
+        # Ensure the url ends with a "/"
+        normalized_url = f"{url}/" if not url.endswith("/") else url
+        artifact_mounts.append(
+            {
+                "content": {"url": urljoin(normalized_url, artifact_name)},
+                "file": os.path.join(directory, "{this_chunk}", artifact_name),
+            }
+        )
+    return artifact_mounts
 
 
 transforms = TransformSequence()
@@ -54,30 +105,45 @@ transforms = TransformSequence()
 
 @transforms.add
 def add_pretrained_model_mounts(config, jobs):
-    pretrained_models = config.params["training_config"]["experiment"].get("pretrained-models", {})
+    """
+    The transform for modifying the task graph to use pre-trained models.
+
+    See docs/using-pretrained-models.md
+    """
+
+    # Example training config.
+    #
+    # experiment:
+    #   pretrained-models:
+    #     train-backwards:
+    #       urls: [https://storage.googleapis.com/bucket-name/models/ru-en/backward]
+    #       mode: "use"
+    #       type: "default"
+    pretrained_model_dict = (
+        config.params["training_config"]["experiment"]
+        .get("pretrained-models", {})
+        .get(config.kind, None)
+    )
+
     for job in jobs:
-        pretrained_models_training_artifact_mounts = {
-            pretrained_model: get_artifact_mounts(
-                pretrained_models[pretrained_model]["urls"],
-                "./artifacts",
-                INITIALIZE_MODEL_ARTIFACTS
-                if pretrained_models[pretrained_model]["mode"] == "init"
-                else CONTINUE_TRAINING_ARTIFACTS,
-            )
-            for pretrained_model in pretrained_models
-        }
-        pretrained_model_training_artifact_mounts = next(
-            pretrained_models_training_artifact_mounts.get(config.kind, iter((None,)))
-        )
-        if pretrained_model_training_artifact_mounts:
-            mounts = job["worker"].get("mounts", [])
-            mounts.extend(pretrained_model_training_artifact_mounts)
-            job["worker"]["mounts"] = mounts
+        if pretrained_model_dict:
+            pretrained_model = PretrainedModel(**pretrained_model_dict)
+
+            # Add the pretrained artifacts to the mounts.
+            job["worker"]["mounts"] = [
+                *job["worker"].get("mounts", []),
+                *get_artifact_mounts(
+                    pretrained_model,
+                    directory="./artifacts",
+                ),
+            ]
+
+            # Remove any vocab training, as this is using a pre-existing vocab.
             job["dependencies"].pop("train-vocab")
             job["fetches"].pop("train-vocab")
 
-            if pretrained_models[config.kind]["mode"] == "use":
-                # In use mode, no upstream dependencies of the training job are needed - the
+            if pretrained_model.mode == "use":
+                # In "use" mode, no upstream dependencies of the training job are needed - the
                 # task simply republishes the pretrained artifacts.
                 job["dependencies"] = {}
                 job["fetches"] = {}

--- a/taskcluster/translations_taskgraph/transforms/training_continuation.py
+++ b/taskcluster/translations_taskgraph/transforms/training_continuation.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Literal, Optional
 from taskgraph.transforms.base import TransformSequence
 from urllib.parse import urljoin
 import os
@@ -57,6 +57,7 @@ class PretrainedModel:
     urls: list[str]
     mode: ModelMode
     type: Literal["npz"]  # In the future "opusmt" may be supported.
+    overrides: Optional[list[dict[str, str]]]
 
     def get_artifact_names(self) -> list[str]:
         artifacts = {
@@ -85,15 +86,23 @@ def get_artifact_mounts(pretrained_model: PretrainedModel, directory: str):
             "Multiple URLs are currently not supported for pretrained models. See Issue #542"
         )
 
-    url = pretrained_model.urls[0]
+    base_url = pretrained_model.urls[0]
+    # Ensure the url ends with a "/"
+    base_url = f"{base_url}/" if not base_url.endswith("/") else base_url
+
+    overrides = {}
+    if pretrained_model.overrides and len(pretrained_model.overrides) == 1:
+        overrides = pretrained_model.overrides[0]
+
     artifact_mounts = []
 
     for artifact_name in pretrained_model.get_artifact_names():
-        # Ensure the url ends with a "/"
-        normalized_url = f"{url}/" if not url.endswith("/") else url
+        override = overrides.get(artifact_name, None)
+        url = override if override else urljoin(base_url, artifact_name)
+
         artifact_mounts.append(
             {
-                "content": {"url": urljoin(normalized_url, artifact_name)},
+                "content": {"url": url},
                 "file": os.path.join(directory, "{this_chunk}", artifact_name),
             }
         )

--- a/taskcluster/translations_taskgraph/transforms/training_continuation.py
+++ b/taskcluster/translations_taskgraph/transforms/training_continuation.py
@@ -103,7 +103,7 @@ def get_artifact_mounts(pretrained_model: PretrainedModel, directory: str):
         artifact_mounts.append(
             {
                 "content": {"url": url},
-                "file": os.path.join(directory, "{this_chunk}", artifact_name),
+                "file": os.path.join(directory, artifact_name),
             }
         )
     return artifact_mounts


### PR DESCRIPTION
Edit: I added file overrides for this, to support vocabs and other file name mismatches. For instance in `en-fi` the final model was not a `best-chrf` but a `best-perplexity`. This allows for working around problems in the config itself.

<hr>

I was looking into how training continuation was working, and was confused by some of the mis-direction in the code with iterators and dict comprehension. I refactored the code a bit to understand how things were working. I added some more validation with type-friendly dataclass and enum. I also wrote a few more docs on what was going on.

I didn't end up finishing a test for this, as I didn't want to spend more time on it, but I manually checked the artifacts/full-task-graph.json after running `task preflight-check`.

The code produces the equivalent mounts as the original code. I also filed #542 as I realized that ensemble training wasn't actually working.