### PR TITLE
Add a preflight check for URL mounts

### DIFF
--- a/pipeline/translate/bestbleu.py
+++ b/pipeline/translate/bestbleu.py
@@ -21,7 +21,7 @@ def main():
 
         score_function = compute_sacrebleu
     elif args.metric == "chrf":
-        global sacrebleu  
+        global sacrebleu
         import sacrebleu
 
         score_function = compute_chrf

--- a/pipeline/translate/bestbleu.py
+++ b/pipeline/translate/bestbleu.py
@@ -16,12 +16,12 @@ def main():
     if args.metric == "bleu":
         score_function = compute_bleu
     elif args.metric == "sacrebleu":
-        global sacrebleu  # noqa: PLW0603
+        global sacrebleu
         import sacrebleu
 
         score_function = compute_sacrebleu
     elif args.metric == "chrf":
-        global sacrebleu  # noqa: PLW0603
+        global sacrebleu  
         import sacrebleu
 
         score_function = compute_chrf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ ignore = [
   "E741",      # ambiguous-variable-name
   "PLR09",     # too-many-return-statements, too-many-branches, too-many-arguments, too-many-statements
   "PLR2004",   # magic-value-comparison
+  "PLW0603",   # global-statement
 
   # These are handled by black.
   "E1", "E4", "E5", "W2", "W5"

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -221,7 +221,7 @@ def get_full_taskgraph():
     Generates the full taskgraph and stores it for re-use. It uses the config.pytest.yml
     in this directory.
     """
-    global _full_taskgraph  # noqa: PLW0603
+    global _full_taskgraph
     if _full_taskgraph:
         return _full_taskgraph
     current_folder = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_find_corpus.py
+++ b/tests/test_find_corpus.py
@@ -84,9 +84,9 @@ def test_opus(mock_opus_data, capsys):
         └──────────────────────────────┘
 
         Dataset   Code              Sentences Size     URL
-        ───────── ───────────────── ───────── ──────── ─────────────────────────────────────
-        CCAligned opus_CCAligned/v1 5802549   535.4 MB https://opus.nlpl.eu/CCAligned-v1.php
-        Books     opus_Books/v1     4605      335.9 kB https://opus.nlpl.eu/Books-v1.php
+        ───────── ───────────────── ───────── ──────── ─────────────────────────────────────────────────
+        CCAligned opus_CCAligned/v1 5802549   535.4 MB https://opus.nlpl.eu/CCAligned/ca&en/v1/CCAligned
+        Books     opus_Books/v1     4605      335.9 kB https://opus.nlpl.eu/Books/ca&en/v1/Books
 
         YAML:
             - opus_Books/v1

--- a/utils/preflight_check.py
+++ b/utils/preflight_check.py
@@ -398,7 +398,7 @@ class ServeArtifactFile(http.server.BaseHTTPRequestHandler):
         except Exception as exception:
             print("Failed to serve the file", exception)
             pass
-        global waiting_for_request  # noqa: PLW0603
+        global waiting_for_request
         waiting_for_request = False
 
 


### PR DESCRIPTION
I had my training fail because of this, so I thought it would be nice to add a preflight check for bad URLs for pretrained models.

I included a drive-by that disables the PLW0603 ruff rule, as I found it was mostly causing false positives where I was using global scopes in a way that I felt was reasonable. We had a few suppressions in the codebase, and everything felt like valid code to me. If you disagree with this I can remove the commit and add a suppression to my global statement.