### PR TITLE
Add a docker marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+  # Run tests outside of docker:
+  #   task test -- -m "not docker_amd64
+  "docker_amd64: These tests require the local docker image."
+]

--- a/tests/test_alignments.py
+++ b/tests/test_alignments.py
@@ -1,8 +1,11 @@
 import os
 import shutil
 
+import pytest
 import sh
 from fixtures import DataDir
+
+pytestmark = [pytest.mark.docker_amd64]
 
 current_folder = os.path.dirname(os.path.abspath(__file__))
 fixtures_path = os.path.join(current_folder, "fixtures")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,6 +5,8 @@ import pytest
 import sentencepiece as spm
 from fixtures import DataDir, en_sample, ru_sample
 
+pytestmark = [pytest.mark.docker_amd64]
+
 current_folder = os.path.dirname(os.path.abspath(__file__))
 fixtures_path = os.path.join(current_folder, "fixtures")
 root_path = os.path.abspath(os.path.join(current_folder, ".."))


### PR DESCRIPTION
Fixes #506.

I opted for the name `docker_amd64`, as I'm experimenting with multiple local docker images right now while working on #503 