### PR TITLE
Publish evaluation metrics

### DIFF
--- a/taskcluster/kinds/evaluate-quantized/kind.yml
+++ b/taskcluster/kinds/evaluate-quantized/kind.yml
@@ -45,9 +45,11 @@ tasks:
             substitution-fields:
                 - run.command
                 - fetches
+                - worker.env
             from-parameters:
                 src_locale: training_config.experiment.src
                 trg_locale: training_config.experiment.trg
+                wandb_publication: training_config.wandb-publication
 
         worker-type: b-gpu
         worker:
@@ -60,6 +62,19 @@ tasks:
                 # This is a separate environment variable so tests can override it.
                 BMT_MARIAN: $MOZ_FETCHES_DIR
 
+                # Weight & Biases trigger
+                WANDB_PUBLICATION: "{wandb_publication}"
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
+
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
+
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
 
@@ -70,6 +85,7 @@ tasks:
                 - -c
                 - >-
                     pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    pip install $VCS_PATH/tracking &&
                     export PATH=$PATH:~/.local/bin &&
                     zstd --rm -d $MOZ_FETCHES_DIR/lex.s2t.pruned.zst &&
                     $VCS_PATH/pipeline/eval/eval.py

--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -43,10 +43,13 @@ tasks:
             substitution-fields:
                 - fetches
                 - run.command
+                - worker.env
             from-parameters:
                 best_model: training_config.experiment.best-model
                 src_locale: training_config.experiment.src
                 trg_locale: training_config.experiment.trg
+                wandb_publication: training_config.wandb-publication
+
         worker-type: b-gpu
         worker:
             artifacts:
@@ -57,6 +60,19 @@ tasks:
             env:
                 # This is a separate environment variable so tests can override it.
                 MARIAN: $MOZ_FETCHES_DIR
+
+                # Weight & Biases trigger
+                WANDB_PUBLICATION: "{wandb_publication}"
+
+                # Weight & Biases publication token is stored in that secret
+                TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
+
+            # Taskcluster proxy is required to read secrets
+            taskcluster-proxy: true
+
+        # The task needs to be able to read that secret to publish on Weight & Biases
+        scopes:
+          - secrets:get:project/translations/level-1/weights-and-biases
 
         # Don't run unless explicitly scheduled
         run-on-tasks-for: []
@@ -74,6 +90,7 @@ tasks:
                 - -c
                 - >-
                     pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    pip install $VCS_PATH/tracking &&
                     export PATH=$PATH:~/.local/bin &&
                     sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&

--- a/taskcluster/kinds/evaluate/kind.yml
+++ b/taskcluster/kinds/evaluate/kind.yml
@@ -41,11 +41,13 @@ task-defaults:
     task-context:
         substitution-fields:
             - run.command
+            - worker.env
         from-parameters:
             best_model: training_config.experiment.best-model
             src_locale: training_config.experiment.src
             trg_locale: training_config.experiment.trg
             split_chunks: training_config.experiment.teacher-ensemble
+            wandb_publication: training_config.wandb-publication
     worker-type: b-gpu
     worker:
         artifacts:
@@ -56,6 +58,19 @@ task-defaults:
         env:
             # This is a separate environment variable so tests can override it.
             MARIAN: $MOZ_FETCHES_DIR
+
+            # Weight & Biases trigger
+            WANDB_PUBLICATION: "{wandb_publication}"
+
+            # Weight & Biases publication token is stored in that secret
+            TASKCLUSTER_SECRET: project/translations/level-1/weights-and-biases
+
+        # Taskcluster proxy is required to read secrets
+        taskcluster-proxy: true
+
+    # The task needs to be able to read that secret to publish on Weight & Biases
+    scopes:
+      - secrets:get:project/translations/level-1/weights-and-biases
 
     # Don't run unless explicitly scheduled
     run-on-tasks-for: []
@@ -73,6 +88,7 @@ task-defaults:
             - -c
             - >-
                 pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                pip install $VCS_PATH/tracking &&
                 export PATH=$PATH:~/.local/bin &&
                 sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                 sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -20,10 +20,10 @@ from collections.abc import Iterator
 from io import TextIOWrapper
 from pathlib import Path
 
-import taskcluster
 from translations_parser.parser import TrainingParser, logger
-from translations_parser.publishers import CSVExport, Publisher, WandB
-from translations_parser.utils import build_task_name, taskcluster_log_filter
+from translations_parser.publishers import CSVExport, Publisher
+from translations_parser.utils import taskcluster_log_filter
+from translations_parser.wandb import add_wandb_arguments, get_wandb_publisher
 
 
 def get_args() -> argparse.Namespace:
@@ -52,46 +52,6 @@ def get_args() -> argparse.Namespace:
         default=Path(__file__).parent.parent / "output",
     )
     parser.add_argument(
-        "--wandb-project",
-        help="Publish the training run to a Weight & Biases project.",
-        default=None,
-    )
-    parser.add_argument(
-        "--wandb-artifacts",
-        help="Directory containing training artifacts to publish on Weight & Biases.",
-        type=Path,
-        default=None,
-    )
-    parser.add_argument(
-        "--wandb-group",
-        help="Add the training run to a Weight & Biases group e.g. by language pair or experiment.",
-        default=None,
-    )
-    parser.add_argument(
-        "--wandb-run-name",
-        help="Use a custom name for the Weight & Biases run.",
-        default=None,
-    )
-    parser.add_argument(
-        "--wandb-publication",
-        action="store_true",
-        help="Trigger publication on Weight & Biases. Disabled by default. Can be set though env variable WANDB_PUBLICATION=true|false",
-        default=os.environ.get("WANDB_PUBLICATION", "false").lower() == "true",
-    )
-    parser.add_argument(
-        "--taskcluster-secret",
-        help="Taskcluster secret name used to store the Weight & Biases secret API Key.",
-        type=str,
-        default=os.environ.get("TASKCLUSTER_SECRET"),
-    )
-    parser.add_argument(
-        "--tags",
-        help="List of tags to use on Weight & Biases publication",
-        type=str,
-        default=["taskcluster"],
-        nargs="+",
-    )
-    parser.add_argument(
         "--verbose",
         "-v",
         help="Print debug messages.",
@@ -99,59 +59,11 @@ def get_args() -> argparse.Namespace:
         dest="loglevel",
         const=logging.DEBUG,
     )
+
+    # Extend parser with Weight & Biases CLI args
+    add_wandb_arguments(parser)
+
     return parser.parse_args()
-
-
-def get_wandb_token(secret_name):
-    """
-    Retrieve the Weight & Biases token from Taskcluster secret
-    """
-    secrets = taskcluster.Secrets({"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]})
-
-    try:
-        wandb_secret = secrets.get(secret_name)
-        return wandb_secret["secret"]["token"]
-    except Exception as e:
-        raise Exception(
-            f"Weight & Biases secret API Key retrieved from Taskcluster is malformed: {e}"
-        )
-
-
-def get_wandb_names():
-    """
-    Find the various names needed to publish on Weight & Biases using
-    the taskcluster task & group payloads
-    """
-    task_id = os.environ.get("TASK_ID")
-    if not task_id:
-        raise Exception("Weight & Biases name detection can only run in taskcluster")
-
-    # Load task & group definition
-    # CI task groups do not expose any configuration, so we must use default values
-    queue = taskcluster.Queue({"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]})
-    task = queue.task(task_id)
-    _, task_name = build_task_name(task)
-    group_id = task["taskGroupId"]
-    task_group = queue.task(group_id)
-    config = task_group.get("extra", {}).get("action", {}).get("context", {}).get("input")
-    if config is None:
-        logger.warn(
-            f"Experiment configuration missing on {group_id} @ extra/action/context/input, fallback to CI values"
-        )
-        experiment = {
-            "src": "ru",
-            "trg": "en",
-            "name": "ci",
-        }
-    else:
-        experiment = config["experiment"]
-
-    # Build project, group and run names
-    return (
-        f'{experiment["src"]}-{experiment["trg"]}',
-        f'{experiment["name"]}_{group_id}',
-        task_name,
-    )
 
 
 def boot() -> None:
@@ -171,44 +83,19 @@ def boot() -> None:
         with args.input_file.open("r") as f:
             lines = (line.strip() for line in f.readlines())
 
-    # Load secret from Taskcluster and auto-configure naming
-    if args.taskcluster_secret:
-        assert os.environ.get(
-            "TASKCLUSTER_PROXY_URL"
-        ), "When using `--taskcluster-secret`, `TASKCLUSTER_PROXY_URL` environment variable must be set too."
-
-        # Weight and Biases client use environment variable to read the token
-        os.environ.setdefault("WANDB_API_KEY", get_wandb_token(args.taskcluster_secret))
-
-        project_name, group_name, run_name = get_wandb_names()
-    else:
-        # Fallback to CLI args for names
-        project_name = args.wandb_project
-        group_name = args.wandb_group
-        run_name = args.wandb_run_name
-
-    # Enable publication on weight and biases when project is set
-    # But prevent running when explicitly disabled by operator
+    # Build publisher output, CSV is always enabled, Weight & Biases upon operator choice
     publishers: list[Publisher] = [CSVExport(output_dir=args.output_dir)]
-    if not args.wandb_publication:
-        logger.info(
-            "Skip weight & biases publication as requested by operator through WANDB_PUBLICATION"
-        )
-    elif not project_name:
-        logger.info("Skip weight & biases publication as project name is not set")
-    else:
-        publishers.append(
-            WandB(
-                project=project_name,
-                group=group_name,
-                name=run_name,
-                artifacts=args.wandb_artifacts,
-                tags=args.tags,
-                config={
-                    "logs_file": args.input_file,
-                },
-            )
-        )
+    wandb_publisher = get_wandb_publisher(
+        project_name=args.wandb_project,
+        group_name=args.wandb_group,
+        run_name=args.wandb_run_name,
+        taskcluster_secret=args.taskcluster_secret,
+        logs_file=args.input_file,
+        artifacts=args.wandb_artifacts,
+        publication=args.wandb_publication,
+    )
+    if wandb_publisher:
+        publishers.append(wandb_publisher)
 
     # Use log filtering when using non-stream (for uploading past experiments)
     log_filter = taskcluster_log_filter if not args.from_stream else None

--- a/tracking/translations_parser/wandb.py
+++ b/tracking/translations_parser/wandb.py
@@ -1,0 +1,149 @@
+import os
+from pathlib import Path
+
+import taskcluster
+from translations_parser.parser import logger
+from translations_parser.publishers import WandB
+from translations_parser.utils import build_task_name
+
+
+def add_wandb_arguments(parser):
+    parser.add_argument(
+        "--wandb-project",
+        help="Publish the training run to a Weight & Biases project.",
+        default=None,
+    )
+    parser.add_argument(
+        "--wandb-artifacts",
+        help="Directory containing training artifacts to publish on Weight & Biases.",
+        type=Path,
+        default=None,
+    )
+    parser.add_argument(
+        "--wandb-group",
+        help="Add the training run to a Weight & Biases group e.g. by language pair or experiment.",
+        default=None,
+    )
+    parser.add_argument(
+        "--wandb-run-name",
+        help="Use a custom name for the Weight & Biases run.",
+        default=None,
+    )
+    parser.add_argument(
+        "--wandb-publication",
+        action="store_true",
+        help="Trigger publication on Weight & Biases. Disabled by default. Can be set though env variable WANDB_PUBLICATION=true|false",
+        default=os.environ.get("WANDB_PUBLICATION", "false").lower() == "true",
+    )
+    parser.add_argument(
+        "--taskcluster-secret",
+        help="Taskcluster secret name used to store the Weight & Biases secret API Key.",
+        type=str,
+        default=os.environ.get("TASKCLUSTER_SECRET"),
+    )
+    parser.add_argument(
+        "--tags",
+        help="List of tags to use on Weight & Biases publication",
+        type=str,
+        default=["taskcluster"],
+        nargs="+",
+    )
+
+
+def get_wandb_token(secret_name):
+    """
+    Retrieve the Weight & Biases token from Taskcluster secret
+    """
+    secrets = taskcluster.Secrets({"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]})
+
+    try:
+        wandb_secret = secrets.get(secret_name)
+        return wandb_secret["secret"]["token"]
+    except Exception as e:
+        raise Exception(
+            f"Weight & Biases secret API Key retrieved from Taskcluster is malformed: {e}"
+        )
+
+
+def get_wandb_names():
+    """
+    Find the various names needed to publish on Weight & Biases using
+    the taskcluster task & group payloads
+    """
+    task_id = os.environ.get("TASK_ID")
+    if not task_id:
+        raise Exception("Weight & Biases name detection can only run in taskcluster")
+
+    # Load task & group definition
+    # CI task groups do not expose any configuration, so we must use default values
+    queue = taskcluster.Queue({"rootUrl": os.environ["TASKCLUSTER_PROXY_URL"]})
+    task = queue.task(task_id)
+    _, task_name = build_task_name(task)
+    group_id = task["taskGroupId"]
+    task_group = queue.task(group_id)
+    config = task_group.get("extra", {}).get("action", {}).get("context", {}).get("input")
+    if config is None:
+        logger.warn(
+            f"Experiment configuration missing on {group_id} @ extra/action/context/input, fallback to CI values"
+        )
+        experiment = {
+            "src": "ru",
+            "trg": "en",
+            "name": "ci",
+        }
+    else:
+        experiment = config["experiment"]
+
+    # Build project, group and run names
+    return (
+        f'{experiment["src"]}-{experiment["trg"]}',
+        f'{experiment["name"]}_{group_id}',
+        task_name,
+    )
+
+
+def get_wandb_publisher(
+    project_name=None,
+    group_name=None,
+    run_name=None,
+    taskcluster_secret=None,
+    artifacts=[],
+    tags=[],
+    logs_file=None,
+    publication=False,
+):
+    # Load secret from Taskcluster and auto-configure naming
+    if taskcluster_secret:
+        assert os.environ.get(
+            "TASKCLUSTER_PROXY_URL"
+        ), "When using `--taskcluster-secret`, `TASKCLUSTER_PROXY_URL` environment variable must be set too."
+
+        # Weight and Biases client use environment variable to read the token
+        os.environ.setdefault("WANDB_API_KEY", get_wandb_token(taskcluster_secret))
+
+        project_name, group_name, run_name = get_wandb_names()
+
+    # Enable publication on weight and biases when project is set
+    # But prevent running when explicitly disabled by operator
+    if not publication:
+        logger.info(
+            "Skip weight & biases publication as requested by operator through WANDB_PUBLICATION"
+        )
+        return
+    if not project_name:
+        logger.info("Skip weight & biases publication as project name is not set")
+        return
+
+    # Build optional configuration with log file
+    config = {}
+    if logs_file:
+        config["logs_file"] = logs_file
+
+    return WandB(
+        project=project_name,
+        group=group_name,
+        name=run_name,
+        artifacts=artifacts,
+        tags=tags,
+        config=config,
+    )

--- a/tracking/translations_parser/wandb.py
+++ b/tracking/translations_parser/wandb.py
@@ -112,6 +112,12 @@ def get_wandb_publisher(
     logs_file=None,
     publication=False,
 ):
+    if not publication:
+        logger.info(
+            "Skip weight & biases publication as requested by operator through WANDB_PUBLICATION"
+        )
+        return
+
     # Load secret from Taskcluster and auto-configure naming
     if taskcluster_secret:
         assert os.environ.get(
@@ -125,11 +131,6 @@ def get_wandb_publisher(
 
     # Enable publication on weight and biases when project is set
     # But prevent running when explicitly disabled by operator
-    if not publication:
-        logger.info(
-            "Skip weight & biases publication as requested by operator through WANDB_PUBLICATION"
-        )
-        return
     if not project_name:
         logger.info("Skip weight & biases publication as project name is not set")
         return


### PR DESCRIPTION
Closes #519 

- Setup `evaluate-*` taskcluster kinds with TC proxy, secret access, publication trigger
- Generic W&B bootstrap code from training publication so it's usable from evaluation code