### PR TITLE
Re-enable generic-worker for CPU tasks

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -65,28 +65,28 @@ workers:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp'
+            worker-type: 'b-linux-large-gcp-d2g'
         # Use for tasks that don't require GPUs, but need lots of disk space
         # eg: dataset cleaning & merging
         b-cpu-largedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-300gb'
+            worker-type: 'b-linux-large-gcp-d2g-300gb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # eg: alignments
         b-cpu-xlargedisk:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-1tb'
+            worker-type: 'b-linux-large-gcp-d2g-1tb'
         # Use for tasks that don't require GPUs, but need immense amounts of disk space
         # and higher reliability
         b-cpu-xlargedisk-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'b-linux-large-gcp-1tb-standard'
+            worker-type: 'b-linux-large-gcp-d2g-1tb-standard'
         # Use for quick tasks that need a GPU, eg: evaluate
         b-gpu:
             provisioner: '{trust-domain}-{level}'


### PR DESCRIPTION
Analysis done in https://github.com/mozilla/firefox-translations-training/issues/538#issuecomment-2079685137 shows that the problems are intermittent, and largely related to spot terminations. We're seeing the latter in the existing workers anyways, so unless we find more serious issues with generic-worker for CPU tasks, we may as well go ahead with this.