### PR TITLE
Use shorter names for dataset URLs

### DIFF
--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -20,7 +20,7 @@ kind-dependencies:
     - toolchain
 
 tasks:
-    "{provider}-{dataset}-{src_locale}-{trg_locale}":
+    "{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}":
         description: teacher evaluation for {dataset} {src_locale}-{trg_locale}
         attributes:
             stage: evaluate-teacher-ensemble

--- a/taskcluster/kinds/evaluate/kind.yml
+++ b/taskcluster/kinds/evaluate/kind.yml
@@ -126,8 +126,8 @@ tasks:
             toolchain:
                 - marian
 
-    teacher-{provider}-{dataset}-{src_locale}-{trg_locale}-{this_chunk}/{total_chunks}:
-        description: teacher evaluation for {dataset} {src_locale}-{trg_locale} {this_chunk}/{total_chunks}
+    teacher-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}-{this_chunk}:
+        description: teacher evaluation for {dataset} {src_locale}-{trg_locale} {this_chunk}
         attributes:
             stage: evaluate-teacher
             dataset-category: test

--- a/taskcluster/translations_taskgraph/util/dataset_helpers.py
+++ b/taskcluster/translations_taskgraph/util/dataset_helpers.py
@@ -1,5 +1,30 @@
-def sanitize_dataset_name(dataset):
-    # Keep in sync with `Dataset` in pipeline/common/datasets.py.
+from pathlib import Path
+from urllib.parse import urlparse
+import hashlib
+
+
+# Important! Keep in sync with `Dataset._escape` in pipeline/common/datasets.py.
+def sanitize_dataset_name(dataset: str) -> str:
+    # URLs can be too large when used as Taskcluster labels. Create a nice identifier for them.
+    # See https://github.com/mozilla/firefox-translations-training/issues/527
+    if dataset.startswith("https://") or dataset.startswith("http://"):
+        url = urlparse(dataset)
+
+        hostname = url.hostname
+        if hostname == "storage.googleapis.com":
+            hostname = "gcp"
+
+        # Get the name of the file from theh path without the extension.
+        file = Path(url.path).stem
+        file = file.replace(".[LANG]", "").replace("[LANG]", "")
+
+        # Compute a hash to avoid any name collisions.
+        md5 = hashlib.md5()
+        md5.update(dataset.encode("utf-8"))
+        hash = md5.hexdigest()[:6]
+
+        dataset = f"{hostname}_{file}_{hash}"
+
     return (
         dataset.replace("://", "_")
         .replace("/", "_")

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -95,10 +95,7 @@ def data_dir():
         ("opus", "ELRC-3075-wikipedia_health_v1"),
         ("flores", "dev"),
         ("sacrebleu", "wmt19"),
-        (
-            "url",
-            "https_storage_googleapis_com_releng-translations-dev_data_en-ru_pytest-dataset__LANG__zst",
-        ),
+        ("url", "gcp_pytest-dataset_a0017e"),
     ],
 )
 def test_basic_corpus_import(importer, dataset, data_dir):
@@ -122,16 +119,12 @@ def test_basic_corpus_import(importer, dataset, data_dir):
     assert len(read_lines(output_trg)) > 0
 
 
-def make_url_dataset(lang: str):
-    return f"https_storage_googleapis_com_releng-translations-dev_data_en-ru_pytest-dataset_{lang}_zst"
-
-
 mono_params = [
-    ("news-crawl", "en", "news_2021", [2, 5, 3, 7, 0, 6, 4, 1]),
-    ("news-crawl", "ru", "news_2021", [2, 5, 3, 7, 0, 6, 4, 1]),
-    ("url", "en", make_url_dataset("en"), [3, 4, 5, 0, 1, 6, 2, 7]),
-    ("url", "ru", make_url_dataset("ru"), [5, 6, 2, 4, 7, 1, 3, 0]),
-]
+    ("news-crawl", "en", "news_2021",                    [2, 5, 3, 7, 0, 6, 4, 1]),
+    ("news-crawl", "ru", "news_2021",                    [2, 5, 3, 7, 0, 6, 4, 1]),
+    ("url",        "en", "gcp_pytest-dataset_en_cdd0d7", [3, 4, 5, 0, 1, 6, 2, 7]),
+    ("url",        "ru", "gcp_pytest-dataset_ru_be3263", [5, 6, 2, 4, 7, 1, 3, 0]),
+]  # fmt: skip
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -45,11 +45,11 @@ comet_score = 0.3268
 comet_skipped = "skipped"
 
 test_data = [
-    # task_name                                                   model_type   model_name
-    ("evaluate-backward-sacrebleu-wmt09-en-ru",                   "base",      "final.model.npz.best-chrf.npz", comet_skipped),
-    ("evaluate-finetuned-student-sacrebleu-wmt09-en-ru",          "base",      "final.model.npz.best-chrf.npz", comet_skipped),
-    ("evaluate-teacher-ensemble-sacrebleu-sacrebleu_wmt09-en-ru", "base",      "model*/*.npz",                  comet_skipped),
-    ("evaluate-quantized-sacrebleu-wmt09-en-ru",                  "quantized", "model.intgemm.alphas.bin",      comet_skipped)
+    # task_name                                          model_type   model_name
+    ("evaluate-backward-sacrebleu-wmt09-en-ru",          "base",      "final.model.npz.best-chrf.npz", comet_skipped),
+    ("evaluate-finetuned-student-sacrebleu-wmt09-en-ru", "base",      "final.model.npz.best-chrf.npz", comet_skipped),
+    ("evaluate-teacher-ensemble-sacrebleu-wmt09-en-ru",  "base",      "model*/*.npz",                  comet_skipped),
+    ("evaluate-quantized-sacrebleu-wmt09-en-ru",         "quantized", "model.intgemm.alphas.bin",      comet_skipped)
 ]  # fmt:skip
 
 


### PR DESCRIPTION
```
evaluate-teacher-url-gcp_pytest-dataset_a0017e-en-ru-1/2
evaluate-teacher-url-gcp_pytest-dataset_a0017e-en-ru-2/2
dataset-url-gcp_pytest-dataset_a0017e-en-ru
clean-mono-url-en-gcp_pytest-dataset_en_cdd0d7-mono-src
```

This PR also includes #606 since the CI failed due to this issue.

Resolves #527.