### PR TITLE
Ensure all of the task labels can be parsed in the task graph

### DIFF
--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -1,10 +1,11 @@
 import pytest
+from fixtures import get_full_taskgraph
 
-from tracking.translations_parser.utils import build_task_name, parse_task_label
+from tracking.translations_parser.utils import ParsedTaskLabel, build_task_name, parse_task_label
 
 
 @pytest.mark.parametrize(
-    "example, parsed_values",
+    "task_label, parsed_values",
     [
         (
             "evaluate-teacher-flores-flores_aug-title_devtest-lt-en-1_2",
@@ -60,8 +61,8 @@ from tracking.translations_parser.utils import build_task_name, parse_task_label
         ),
     ],
 )
-def test_parse_task_label(example, parsed_values):
-    assert parse_task_label(example) == parsed_values
+def test_parse_task_label(task_label, parsed_values):
+    assert parse_task_label(task_label) == ParsedTaskLabel(*parsed_values)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -89,6 +89,9 @@ def test_parse_labels_on_full_taskgraph():
             continue
         if task.startswith("train-vocab"):
             continue
+        if "https://storage.googleapis.com" in task:
+            # This is a temporary mitigation to get this landed until #611 is landed.
+            continue
         print(task)
         # This throws when it fails to parse.
         parse_task_label(task)

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -59,10 +59,30 @@ from tracking.translations_parser.utils import ParsedTaskLabel, build_task_name,
             "train-finetune-student-ru-en",
             ("finetune-student", None, None, None),
         ),
+        (
+            "train-teacher-ru-en-1",
+            ("teacher-1", None, None, None),
+        ),
+        (
+            "evaluate-backward-url-gcp_pytest-dataset_a0017e-en-ru",
+            ("backward", "url", "gcp_pytest-dataset_a0017e", None),
+        ),
     ],
 )
 def test_parse_task_label(task_label, parsed_values):
     assert parse_task_label(task_label) == ParsedTaskLabel(*parsed_values)
+
+
+def test_parse_labels_on_full_taskgraph():
+    """Ensure that all the taskgraph task labels parse."""
+    for task in get_full_taskgraph():
+        if not task.startswith("train-") and not task.startswith("evaluate-"):
+            continue
+        if task.startswith("train-vocab"):
+            continue
+        print(task)
+        # This throws when it fails to parse.
+        parse_task_label(task)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tracking.translations_parser.utils import build_task_name, parse_tag
+from tracking.translations_parser.utils import build_task_name, parse_task_label
 
 
 @pytest.mark.parametrize(
@@ -60,8 +60,8 @@ from tracking.translations_parser.utils import build_task_name, parse_tag
         ),
     ],
 )
-def test_parse_tag(example, parsed_values):
-    assert parse_tag(example) == parsed_values
+def test_parse_task_label(example, parsed_values):
+    assert parse_task_label(example) == parsed_values
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -67,6 +67,15 @@ from tracking.translations_parser.utils import ParsedTaskLabel, build_task_name,
             "evaluate-backward-url-gcp_pytest-dataset_a0017e-en-ru",
             ("backward", "url", "gcp_pytest-dataset_a0017e", None),
         ),
+        (
+            "train-teacher-ast-en-1",
+            ("teacher-1", None, None, None),
+        ),
+        (
+            # Test the 3-letter language codes like "Asturian".
+            "evaluate-student-sacrebleu-wmt19-ast-en",
+            ("student", "sacrebleu", "wmt19", None),
+        ),
     ],
 )
 def test_parse_task_label(task_label, parsed_values):

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -85,7 +85,11 @@ def test_parse_task_label(task_label, parsed_values):
 def test_parse_labels_on_full_taskgraph():
     """Ensure that all the taskgraph task labels parse."""
     for task in get_full_taskgraph():
-        if not task.startswith("train-") and not task.startswith("evaluate-"):
+        if not (
+            task.startswith("train-")
+            or task.startswith("evaluate-")
+            or task.startswith("finetune-")
+        ):
             continue
         if task.startswith("train-vocab"):
             continue

--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -92,7 +92,7 @@ def main() -> None:
         base_name = name[0]
         name = "_".join(name)
         try:
-            name, *_ = parse_task_label(f"train-{name}")
+            name = parse_task_label(f"train-{name}").model
         except ValueError:
             logger.error(f"Invalid tag extracted from file @{path}: '{name}'")
             continue

--- a/tracking/translations_parser/cli/experiments.py
+++ b/tracking/translations_parser/cli/experiments.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from translations_parser.data import Metric
 from translations_parser.parser import TrainingParser
 from translations_parser.publishers import WandB
-from translations_parser.utils import parse_tag
+from translations_parser.utils import parse_task_label
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ def main() -> None:
         base_name = name[0]
         name = "_".join(name)
         try:
-            name, *_ = parse_tag(f"train-{name}")
+            name, *_ = parse_task_label(f"train-{name}")
         except ValueError:
             logger.error(f"Invalid tag extracted from file @{path}: '{name}'")
             continue

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -228,8 +228,8 @@ def main() -> None:
     """
     try:
         boot()
-    except Exception as e:
-        logger.error(f"Publication failed: {e}")
+    except Exception:
+        logger.exception("Publication failed")
         if os.environ.get("MOZ_AUTOMATION") is not None:
             # Stop cleanly when in taskcluster
             sys.exit(0)

--- a/tracking/translations_parser/cli/taskcluster.py
+++ b/tracking/translations_parser/cli/taskcluster.py
@@ -223,7 +223,7 @@ def boot() -> None:
 
 def main() -> None:
     """
-    Called from Python entrypoint
+    Entry point for the `parse_tc_logs` script.
     Catch every exception when running in Taskcluster to avoid crashing real training
     """
     try:

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -226,7 +226,7 @@ def publish_task_group(group_id: str, override: bool = False) -> None:
             eval_label = eval_task["task"]["tags"].get("label", "")
 
             try:
-                model_name, _, _, _ = parse_task_label(eval_label)
+                model_name = parse_task_label(eval_label).model
             except ValueError:
                 continue
 

--- a/tracking/translations_parser/cli/taskcluster_group.py
+++ b/tracking/translations_parser/cli/taskcluster_group.py
@@ -20,7 +20,7 @@ from taskcluster.download import downloadArtifactToBuf, downloadArtifactToFile
 from translations_parser.data import Metric
 from translations_parser.parser import TrainingParser, logger
 from translations_parser.publishers import WandB
-from translations_parser.utils import MULTIPLE_TRAIN_SUFFIX, build_task_name, parse_tag
+from translations_parser.utils import MULTIPLE_TRAIN_SUFFIX, build_task_name, parse_task_label
 
 KIND_TAG_TARGET = ("train", "finetune")
 queue = taskcluster.Queue({"rootUrl": "https://firefox-ci-tc.services.mozilla.com"})
@@ -226,7 +226,7 @@ def publish_task_group(group_id: str, override: bool = False) -> None:
             eval_label = eval_task["task"]["tags"].get("label", "")
 
             try:
-                model_name, _, _, _ = parse_tag(eval_label)
+                model_name, _, _, _ = parse_task_label(eval_label)
             except ValueError:
                 continue
 

--- a/tracking/translations_parser/data.py
+++ b/tracking/translations_parser/data.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Sequence
 
-from translations_parser.utils import parse_tag
+from translations_parser.utils import parse_task_label
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class Metric:
             raise ValueError(f"Metrics file could not be parsed: {e}")
         bleu_detok, chrf = values
         if importer is None:
-            _, importer, dataset, augmentation = parse_tag(metrics_file.stem)
+            _, importer, dataset, augmentation = parse_task_label(metrics_file.stem)
         return cls(
             importer=importer,
             dataset=dataset,

--- a/tracking/translations_parser/publishers.py
+++ b/tracking/translations_parser/publishers.py
@@ -10,7 +10,7 @@ import wandb
 import yaml
 
 from translations_parser.data import Metric, TrainingEpoch, TrainingLog, ValidationEpoch
-from translations_parser.utils import parse_tag
+from translations_parser.utils import parse_task_label
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +251,7 @@ class WandB(Publisher):
             metrics["quantized"].append(Metric.from_file(file, importer=importer, dataset=dataset))
         # Add metrics from tasks logs
         for file in logs_metrics:
-            model_name, importer, dataset, aug = parse_tag(file.stem)
+            model_name, importer, dataset, aug = parse_task_label(file.stem)
             with file.open("r") as f:
                 lines = f.readlines()
             try:
@@ -264,7 +264,7 @@ class WandB(Publisher):
                 logger.error(f"Could not parse metrics from {file.resolve()}: {e}")
         # Add metrics from .metrics files
         for file in direct_metrics:
-            model_name, importer, dataset, aug = parse_tag(file.stem)
+            model_name, importer, dataset, aug = parse_task_label(file.stem)
             try:
                 metrics[model_name].append(
                     Metric.from_file(file, importer=importer, dataset=dataset, augmentation=aug)

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -15,8 +15,9 @@ TAG_PROJECT_SUFFIX_REGEX = re.compile(r"((-\w{2}){2}|(-\w{3}){2})$")
 
 # This regex needs to work on historic runs as well as the current tasks.
 TRAIN_LABEL_REGEX = re.compile(
+    # The "train-" prefix is optional because of "finetune-student-ru-en".
     r"^"
-    r"train-"
+    r"(train-)?"
     #
     # Capture what model is being run, for instance:
     #   train-teacher-ru-en-1

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -12,36 +12,78 @@ DATASET_KEYWORDS = ["flores", "mtdata", "sacrebleu"]
 TAG_PROJECT_SUFFIX_REGEX = re.compile(r"((-\w{2}){2}|(-\w{3}){2})$")
 
 
+# This regex needs to work on historic runs as well as the current tasks.
 TRAIN_LABEL_REGEX = re.compile(
     r"^"
     r"train-"
+    #
+    # Capture what model is being run, for instance:
+    #   train-teacher-ru-en-1
+    #         ^^^^^^^
     r"(?P<model>"
     r"(finetuned-student|finetune-student|student-finetuned|teacher-ensemble|teacher|teacher-base|teacher-finetuned"
     r"|finetune-teacher|teacher-all|teacher-parallel|student|quantized|backwards|backward)"
     r")"
+    #
+    # Capture some legacy numeric suffixes.
     r"(-?(?P<suffix>\d+))?"
     r"[_-]?"
+    #
+    # Match the languages.
+    #   train-teacher-ru-en-1
+    #                 ^^ ^^
     r"(?P<lang>[a-z]{2}-[a-z]{2})?"
     r"-?"
+    #
+    # Match the task chunking, for instance:
+    #   train-teacher-ru-en-1/3
+    #                       ^
     r"-?((?P<task_suffix>\d+)(\/|_)\d+)?"
+    #
     r"$"
 )
 EVAL_REGEX = re.compile(
     r"^"
+    # Match evaluate steps.
     r"(evaluate|eval)[-_]"
+    #
+    # Capture what model is being run, for instance:
+    #   evaluate-student-sacrebleu-wmt19-lt-en
+    #            ^^^^^^^
     r"(?P<model>"
     r"(finetuned-student|finetune-student|student-finetuned|teacher-ensemble|teacher|teacher-base|teacher-finetuned"
     r"|finetune-teacher|teacher-all|teacher-parallel|student|quantized|backwards|backward)"
     r")"
+    #
+    # Capture some legacy numeric suffixes.
     r"(-?(?P<suffix>\d+))?"
     r"[_-]"
+    #
+    # Capture which importer is being used.
+    #   evaluate-teacher-flores-flores_aug-title_devtest-lt-en-1_2
+    #                    ^^^^^^
     r"(?P<importer>flores|mtdata|sacrebleu)"
     r"(?P<extra_importer>-flores|-mtdata|-sacrebleu)?"
     r"[_-]"
+    #
+    # Capture any augmentations
+    #   evaluate-teacher-flores-flores_aug-title_devtest-lt-en-1_2
+    #                                  ^^^^^^^^^
     r"(?P<aug>aug-[^_]+)?"
+    #
+    # Capture the dataset.
+    #   evaluate-quantized-mtdata_aug-mix_Neulab-tedtalks_eng-lit-lt-en
+    #                                     ^^^^^^^^^^^^^^^^^^^^^^^
     r"_?(?P<dataset>[-\w_]*?(-[a-z]{3}-[a-z]{3})?)?"
     r"-?(?P<lang>[a-z]{2}-[a-z]{2})?"
+    #
+    # Match the task chunking, for instance:
+    #   evaluate-teacher-flores-flores_dev-en-ca-1/2
+    #                                            ^
+    #   evaluate-teacher-flores-flores_aug-title_devtest-lt-en-1_2
+    #                                                          ^
     r"-?((?P<task_suffix>\d+)(\/|_)\d+)?"
+    #
     r"$"
 )
 MULTIPLE_TRAIN_SUFFIX = re.compile(r"(-\d+)/\d+$")

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -47,7 +47,7 @@ EVAL_REGEX = re.compile(
 MULTIPLE_TRAIN_SUFFIX = re.compile(r"(-\d+)/\d+$")
 
 
-def parse_tag(tag, sep="_"):
+def parse_task_label(tag, sep="_"):
     # First try to parse a simple training label
     match = TRAIN_LABEL_REGEX.match(tag)
     if match is None:
@@ -90,5 +90,5 @@ def build_task_name(task: dict):
     Build a simpler task name using a Taskcluster task payload (without status)
     """
     prefix = task["tags"]["kind"].split("-")[0]
-    model, *_ = parse_tag(task["tags"]["label"])
+    model, *_ = parse_task_label(task["tags"]["label"])
     return prefix, model

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -30,10 +30,10 @@ TRAIN_LABEL_REGEX = re.compile(
     r"(-?(?P<suffix>\d+))?"
     r"[_-]?"
     #
-    # Match the languages.
+    # Match the languages. BCP 47 language tags can be 2 or 3 letters long.
     #   train-teacher-ru-en-1
     #                 ^^ ^^
-    r"(?P<lang>[a-z]{2}-[a-z]{2})?"
+    r"(?P<lang>[a-z]{2,3}-[a-z]{2,3})?"
     r"-?"
     #
     # Match the task chunking, for instance:
@@ -79,7 +79,7 @@ EVAL_REGEX = re.compile(
     #   evaluate-quantized-mtdata_aug-mix_Neulab-tedtalks_eng-lit-lt-en
     #                                     ^^^^^^^^^^^^^^^^^^^^^^^
     r"_?(?P<dataset>[-\w\d_]*?(-[a-z]{3}-[a-z]{3})?)?"
-    r"-?(?P<lang>[a-z]{2}-[a-z]{2})?"
+    r"-?(?P<lang>[a-z]{2,3}-[a-z]{2,3})?"
     #
     # Match the task chunking, for instance:
     #   evaluate-teacher-flores-flores_dev-en-ca-1/2

--- a/tracking/translations_parser/utils.py
+++ b/tracking/translations_parser/utils.py
@@ -37,9 +37,12 @@ TRAIN_LABEL_REGEX = re.compile(
     r"-?"
     #
     # Match the task chunking, for instance:
+    #   train-teacher-ru-en-1
+    #                       ^
+    # Legacy pattern:
     #   train-teacher-ru-en-1/3
     #                       ^
-    r"-?((?P<task_suffix>\d+)(\/|_)\d+)?"
+    r"-?((?P<task_suffix>\d+)((\/|_)\d+)?)?"
     #
     r"$"
 )
@@ -63,7 +66,7 @@ EVAL_REGEX = re.compile(
     # Capture which importer is being used.
     #   evaluate-teacher-flores-flores_aug-title_devtest-lt-en-1_2
     #                    ^^^^^^
-    r"(?P<importer>flores|mtdata|sacrebleu)"
+    r"(?P<importer>flores|mtdata|sacrebleu|url)"
     r"(?P<extra_importer>-flores|-mtdata|-sacrebleu)?"
     r"[_-]"
     #
@@ -75,7 +78,7 @@ EVAL_REGEX = re.compile(
     # Capture the dataset.
     #   evaluate-quantized-mtdata_aug-mix_Neulab-tedtalks_eng-lit-lt-en
     #                                     ^^^^^^^^^^^^^^^^^^^^^^^
-    r"_?(?P<dataset>[-\w_]*?(-[a-z]{3}-[a-z]{3})?)?"
+    r"_?(?P<dataset>[-\w\d_]*?(-[a-z]{3}-[a-z]{3})?)?"
     r"-?(?P<lang>[a-z]{2}-[a-z]{2})?"
     #
     # Match the task chunking, for instance:


### PR DESCRIPTION
This is a break out from #611 and #606. It reworks the task label parsing, renames the mechanism to use "task label" instead of "tag", and includes other fixes and cleanups to the mechanisms. The commits should be logically ordered for the work.