### PR TITLE
Update the config generator to remove 404s, and improve the Content-Length lookup

### DIFF
--- a/configs/bs-en-spring-2024.yml
+++ b/configs/bs-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- bs en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: bs

--- a/configs/cs-en-spring-2024.yml
+++ b/configs/cs-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- cs en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: cs
@@ -84,6 +84,8 @@ datasets:
   #  - mtdata_Statmt-news_commentary-14-ces-eng - duplicate with opus
   #  - mtdata_Statmt-news_commentary-15-ces-eng - duplicate with opus
   #  - mtdata_Statmt-news_commentary-16-ces-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-1-ces-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-2-ces-eng - duplicate with opus
   #  - mtdata_Statmt-europarl-10-ces-eng - duplicate with opus
   #  - mtdata_Statmt-ccaligned-1-ces_CZ-eng - duplicate with opus
   #  - mtdata_Tilde-ecb-2017-ces-eng - duplicate with opus
@@ -151,21 +153,19 @@ datasets:
   - opus_ELRC-2404-Czech_Supreme_Audit/v1 #                     403 sentences
   - opus_ELRC_2923/v1 #                                         319 sentences
   - opus_ELRC-2407-Czech_Supreme_Audit/v1 #                     234 sentences
-  - mtdata_ELRC-information_portal_czech_president_czech_castle-1-ces-eng
-  - mtdata_ELRC-electronic_exchange_social_security_information-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2018_reports-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2008_2017_reports-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2003_2017_press_releases-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2018_press_releases-1-ces-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-ces-eng
+  - mtdata_ELRC-information_portal_czech_president_czech_castle-1-ces-eng # ~2,009 sentences (227.1 kB)
+  - mtdata_ELRC-electronic_exchange_social_security_information-1-ces-eng # ~37,876 sentences (4.3 MB)
+  - mtdata_ELRC-czech_supreme_audit_office_2018_reports-1-ces-eng # ~415 sentences (47.0 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2008_2017_reports-1-ces-eng # ~3,154 sentences (356.4 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2003_2017_press_releases-1-ces-eng # ~5,314 sentences (600.5 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2018_press_releases-1-ces-eng # ~275 sentences (31.1 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-ces-eng #     ~14,787 sentences (1.7 MB)
   - mtdata_EU-eac_forms-1-ces-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-ces-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-ces-eng #                            ~533,693 sentences (60.3 MB)
   - mtdata_Statmt-commoncrawl_wmt13-1-ces-eng #         ~8,126,649 sentences (918.3 MB)
   - mtdata_Statmt-europarl_wmt13-7-ces-eng #            ~5,819,755 sentences (657.6 MB)
   - mtdata_Statmt-news_commentary_wmt18-13-ces-eng #    ~1,001,393 sentences (113.2 MB)
-  - mtdata_Statmt-wiki_titles-1-ces-eng #                  ~45,242 sentences (5.1 MB)
-  - mtdata_Statmt-wiki_titles-2-ces-eng #                  ~47,995 sentences (5.4 MB)
   - mtdata_Tilde-eesc-2017-ces-eng #                    ~1,157,475 sentences (130.8 MB)
   - mtdata_Tilde-ema-2016-ces-eng #                       ~244,524 sentences (27.6 MB)
   - mtdata_Tilde-rapid-2019-ces-eng #                     ~255,063 sentences (28.8 MB)

--- a/configs/da-en-spring-2024.yml
+++ b/configs/da-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- da en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: da
@@ -169,18 +169,18 @@ datasets:
   - opus_ELRC-2754-vaccination/v1 #                             462 sentences
   - opus_ELRC-vaccination/v1 #                                  462 sentences
   - opus_ELRC_2923/v1 #                                         389 sentences
-  - mtdata_ELRC-danish_higher_education_science_3-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science_2-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science_4-1-dan-eng
-  - mtdata_ELRC-laegemiddelstyrelsen.dk-1-dan-eng
-  - mtdata_ELRC-www.vikingeskibsmuseet.dk-1-dan-eng
-  - mtdata_ELRC-holstebro_kunstmuseum-1-dan-eng
-  - mtdata_ELRC-denmark_space_institute-1-dan-eng
-  - mtdata_ELRC-danish_working_environment_authority-1-dan-eng
-  - mtdata_ELRC-denmark_prosecution_service-1-dan-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-dan-eng
-  - mtdata_ELRC-nteu_tierb-1-dan-eng
+  - mtdata_ELRC-danish_higher_education_science_3-1-dan-eng # ~12,611 sentences (1.4 MB)
+  - mtdata_ELRC-danish_higher_education_science_2-1-dan-eng # ~13,011 sentences (1.5 MB)
+  - mtdata_ELRC-danish_higher_education_science-1-dan-eng # ~6,646 sentences (751.0 kB)
+  - mtdata_ELRC-danish_higher_education_science_4-1-dan-eng # ~11,765 sentences (1.3 MB)
+  - mtdata_ELRC-laegemiddelstyrelsen.dk-1-dan-eng #        ~16,422 sentences (1.9 MB)
+  - mtdata_ELRC-www.vikingeskibsmuseet.dk-1-dan-eng #       ~9,130 sentences (1.0 MB)
+  - mtdata_ELRC-holstebro_kunstmuseum-1-dan-eng #             ~849 sentences (96.0 kB)
+  - mtdata_ELRC-denmark_space_institute-1-dan-eng #         ~1,887 sentences (213.3 kB)
+  - mtdata_ELRC-danish_working_environment_authority-1-dan-eng # ~865 sentences (97.8 kB)
+  - mtdata_ELRC-denmark_prosecution_service-1-dan-eng #       ~674 sentences (76.2 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-dan-eng #     ~14,223 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-dan-eng #                 ~12,328,227 sentences (1.4 GB)
   - mtdata_EU-eac_forms-1-dan-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-dan-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-dan-eng #                          ~1,040,518 sentences (117.6 MB)

--- a/configs/el-en-spring-2024.yml
+++ b/configs/el-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- el en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: el
@@ -63,8 +63,10 @@ datasets:
   #  - opus_ELRC-403-Rights_Arrested/v1 - not enough data  (22 sentences)
   #  - opus_ELRA-W0301/v1 - not enough data  (16 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
+  #  - mtdata_ELRC-rights_arrested-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-greek_administration-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-greek_law-1-ell-eng - duplicate with opus
+  #  - mtdata_ELRC-expression_interest-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-euipo_2017-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-press_releases_pio-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-constitution_greece-1-ell-eng - duplicate with opus
@@ -175,31 +177,29 @@ datasets:
   - opus_ELRC_2923/v1 #                                         420 sentences
   - opus_ELRC-646-International_Judici/v1 #                     289 sentences
   - opus_ELRA-W0307/v1 #                                        288 sentences
-  - mtdata_ELRC-rights_arrested-1-ell-eng
-  - mtdata_ELRC-swedish_social_security-1-ell-eng
-  - mtdata_ELRC-greek_legislation_anticorruption_plan-1-ell-eng
-  - mtdata_ELRC-convention_transfer_sentenced_persons-1-ell-eng
-  - mtdata_ELRC-international_judicial_cooperation_civil_matters-1-ell-eng
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-ell-eng
-  - mtdata_ELRC-macroeconomic_developments-1-ell-eng
-  - mtdata_ELRC-methodological_reconciliation-1-ell-eng
-  - mtdata_ELRC-expression_interest-1-ell-eng
-  - mtdata_ELRC-memorandum_a_esm_programme-1-ell-eng
-  - mtdata_ELRC-convention_against_torture_other_cruel_inhuman_or_degrading_treatment_or_punishment_united_nations-1-ell-eng
-  - mtdata_ELRC-quarterly_reports_parliamentary_budget-1-ell-eng
-  - mtdata_ELRC-collection_reports_greek_power_corporation-1-ell-eng
-  - mtdata_ELRC-hellenic_foreign_affairs_announcements-1-ell-eng
-  - mtdata_ELRC-prime_minister_hellenic-1-ell-eng
-  - mtdata_ELRC-collection_about_cyprus_problem-1-ell-eng
-  - mtdata_ELRC-commitment_property_open-1-ell-eng
-  - mtdata_ELRC-compulsory_expropriation_process_greece-1-ell-eng
-  - mtdata_ELRC-pio_publication_cyprus_has_always_been_europe_2017-1-ell-eng
-  - mtdata_ELRC-pio_publication_window_cyprus-1-ell-eng
-  - mtdata_ELRC-press_information_cyprus-1-ell-eng
-  - mtdata_ELRC-governmental_about_migration_policy-1-ell-eng
-  - mtdata_ELRC-eqf_referencing_report-1-ell-eng
-  - mtdata_ELRC-hellenic_gaming_commission-1-ell-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-ell-eng
+  - mtdata_ELRC-swedish_social_security-1-ell-eng #        ~18,804 sentences (2.1 MB)
+  - mtdata_ELRC-greek_legislation_anticorruption_plan-1-ell-eng # ~4,428 sentences (500.4 kB)
+  - mtdata_ELRC-convention_transfer_sentenced_persons-1-ell-eng # ~131 sentences (14.8 kB)
+  - mtdata_ELRC-international_judicial_cooperation_civil_matters-1-ell-eng # ~427 sentences (48.3 kB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-ell-eng # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-macroeconomic_developments-1-ell-eng #        ~175 sentences (19.8 kB)
+  - mtdata_ELRC-methodological_reconciliation-1-ell-eng #      ~46 sentences (5.3 kB)
+  - mtdata_ELRC-memorandum_a_esm_programme-1-ell-eng #        ~861 sentences (97.3 kB)
+  - mtdata_ELRC-convention_against_torture_other_cruel_inhuman_or_degrading_treatment_or_punishment_united_nations-1-ell-eng # ~452 sentences (51.2 kB)
+  - mtdata_ELRC-quarterly_reports_parliamentary_budget-1-ell-eng # ~11,396 sentences (1.3 MB)
+  - mtdata_ELRC-collection_reports_greek_power_corporation-1-ell-eng # ~20,136 sentences (2.3 MB)
+  - mtdata_ELRC-hellenic_foreign_affairs_announcements-1-ell-eng # ~4,783 sentences (540.5 kB)
+  - mtdata_ELRC-prime_minister_hellenic-1-ell-eng #         ~7,167 sentences (810.0 kB)
+  - mtdata_ELRC-collection_about_cyprus_problem-1-ell-eng # ~2,396 sentences (270.8 kB)
+  - mtdata_ELRC-commitment_property_open-1-ell-eng #           ~36 sentences (4.1 kB)
+  - mtdata_ELRC-compulsory_expropriation_process_greece-1-ell-eng # ~76 sentences (8.7 kB)
+  - mtdata_ELRC-pio_publication_cyprus_has_always_been_europe_2017-1-ell-eng # ~2,018 sentences (228.1 kB)
+  - mtdata_ELRC-pio_publication_window_cyprus-1-ell-eng #   ~3,414 sentences (385.8 kB)
+  - mtdata_ELRC-press_information_cyprus-1-ell-eng #        ~2,335 sentences (263.9 kB)
+  - mtdata_ELRC-governmental_about_migration_policy-1-ell-eng # ~1,473 sentences (166.6 kB)
+  - mtdata_ELRC-eqf_referencing_report-1-ell-eng #          ~2,266 sentences (256.1 kB)
+  - mtdata_ELRC-hellenic_gaming_commission-1-ell-eng #      ~3,866 sentences (437.0 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-ell-eng #     ~17,493 sentences (2.0 MB)
   - mtdata_EU-eac_forms-1-ell-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-ell-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-ell-eng #                          ~1,178,828 sentences (133.2 MB)

--- a/configs/en-bs-spring-2024.yml
+++ b/configs/en-bs-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en bs --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en

--- a/configs/en-cs-spring-2024.yml
+++ b/configs/en-cs-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en cs --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -84,6 +84,8 @@ datasets:
   #  - mtdata_Statmt-news_commentary-14-ces-eng - duplicate with opus
   #  - mtdata_Statmt-news_commentary-15-ces-eng - duplicate with opus
   #  - mtdata_Statmt-news_commentary-16-ces-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-1-ces-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-2-ces-eng - duplicate with opus
   #  - mtdata_Statmt-europarl-10-ces-eng - duplicate with opus
   #  - mtdata_Statmt-ccaligned-1-ces_CZ-eng - duplicate with opus
   #  - mtdata_Tilde-ecb-2017-ces-eng - duplicate with opus
@@ -151,21 +153,19 @@ datasets:
   - opus_ELRC-2404-Czech_Supreme_Audit/v1 #                     403 sentences
   - opus_ELRC_2923/v1 #                                         319 sentences
   - opus_ELRC-2407-Czech_Supreme_Audit/v1 #                     234 sentences
-  - mtdata_ELRC-information_portal_czech_president_czech_castle-1-ces-eng
-  - mtdata_ELRC-electronic_exchange_social_security_information-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2018_reports-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2008_2017_reports-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2003_2017_press_releases-1-ces-eng
-  - mtdata_ELRC-czech_supreme_audit_office_2018_press_releases-1-ces-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-ces-eng
+  - mtdata_ELRC-information_portal_czech_president_czech_castle-1-ces-eng # ~2,009 sentences (227.1 kB)
+  - mtdata_ELRC-electronic_exchange_social_security_information-1-ces-eng # ~37,876 sentences (4.3 MB)
+  - mtdata_ELRC-czech_supreme_audit_office_2018_reports-1-ces-eng # ~415 sentences (47.0 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2008_2017_reports-1-ces-eng # ~3,154 sentences (356.4 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2003_2017_press_releases-1-ces-eng # ~5,314 sentences (600.5 kB)
+  - mtdata_ELRC-czech_supreme_audit_office_2018_press_releases-1-ces-eng # ~275 sentences (31.1 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-ces-eng #     ~14,787 sentences (1.7 MB)
   - mtdata_EU-eac_forms-1-ces-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-ces-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-ces-eng #                            ~533,693 sentences (60.3 MB)
   - mtdata_Statmt-commoncrawl_wmt13-1-ces-eng #         ~8,126,649 sentences (918.3 MB)
   - mtdata_Statmt-europarl_wmt13-7-ces-eng #            ~5,819,755 sentences (657.6 MB)
   - mtdata_Statmt-news_commentary_wmt18-13-ces-eng #    ~1,001,393 sentences (113.2 MB)
-  - mtdata_Statmt-wiki_titles-1-ces-eng #                  ~45,242 sentences (5.1 MB)
-  - mtdata_Statmt-wiki_titles-2-ces-eng #                  ~47,995 sentences (5.4 MB)
   - mtdata_Tilde-eesc-2017-ces-eng #                    ~1,157,475 sentences (130.8 MB)
   - mtdata_Tilde-ema-2016-ces-eng #                       ~244,524 sentences (27.6 MB)
   - mtdata_Tilde-rapid-2019-ces-eng #                     ~255,063 sentences (28.8 MB)

--- a/configs/en-da-spring-2024.yml
+++ b/configs/en-da-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en da --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -169,18 +169,18 @@ datasets:
   - opus_ELRC-2754-vaccination/v1 #                             462 sentences
   - opus_ELRC-vaccination/v1 #                                  462 sentences
   - opus_ELRC_2923/v1 #                                         389 sentences
-  - mtdata_ELRC-danish_higher_education_science_3-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science_2-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science-1-dan-eng
-  - mtdata_ELRC-danish_higher_education_science_4-1-dan-eng
-  - mtdata_ELRC-laegemiddelstyrelsen.dk-1-dan-eng
-  - mtdata_ELRC-www.vikingeskibsmuseet.dk-1-dan-eng
-  - mtdata_ELRC-holstebro_kunstmuseum-1-dan-eng
-  - mtdata_ELRC-denmark_space_institute-1-dan-eng
-  - mtdata_ELRC-danish_working_environment_authority-1-dan-eng
-  - mtdata_ELRC-denmark_prosecution_service-1-dan-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-dan-eng
-  - mtdata_ELRC-nteu_tierb-1-dan-eng
+  - mtdata_ELRC-danish_higher_education_science_3-1-dan-eng # ~12,611 sentences (1.4 MB)
+  - mtdata_ELRC-danish_higher_education_science_2-1-dan-eng # ~13,011 sentences (1.5 MB)
+  - mtdata_ELRC-danish_higher_education_science-1-dan-eng # ~6,646 sentences (751.0 kB)
+  - mtdata_ELRC-danish_higher_education_science_4-1-dan-eng # ~11,765 sentences (1.3 MB)
+  - mtdata_ELRC-laegemiddelstyrelsen.dk-1-dan-eng #        ~16,422 sentences (1.9 MB)
+  - mtdata_ELRC-www.vikingeskibsmuseet.dk-1-dan-eng #       ~9,130 sentences (1.0 MB)
+  - mtdata_ELRC-holstebro_kunstmuseum-1-dan-eng #             ~849 sentences (96.0 kB)
+  - mtdata_ELRC-denmark_space_institute-1-dan-eng #         ~1,887 sentences (213.3 kB)
+  - mtdata_ELRC-danish_working_environment_authority-1-dan-eng # ~865 sentences (97.8 kB)
+  - mtdata_ELRC-denmark_prosecution_service-1-dan-eng #       ~674 sentences (76.2 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-dan-eng #     ~14,223 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-dan-eng #                 ~12,328,227 sentences (1.4 GB)
   - mtdata_EU-eac_forms-1-dan-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-dan-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-dan-eng #                          ~1,040,518 sentences (117.6 MB)

--- a/configs/en-el-spring-2024.yml
+++ b/configs/en-el-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en el --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -63,8 +63,10 @@ datasets:
   #  - opus_ELRC-403-Rights_Arrested/v1 - not enough data  (22 sentences)
   #  - opus_ELRA-W0301/v1 - not enough data  (16 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
+  #  - mtdata_ELRC-rights_arrested-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-greek_administration-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-greek_law-1-ell-eng - duplicate with opus
+  #  - mtdata_ELRC-expression_interest-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-euipo_2017-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-press_releases_pio-1-ell-eng - duplicate with opus
   #  - mtdata_ELRC-constitution_greece-1-ell-eng - duplicate with opus
@@ -175,31 +177,29 @@ datasets:
   - opus_ELRC_2923/v1 #                                         420 sentences
   - opus_ELRC-646-International_Judici/v1 #                     289 sentences
   - opus_ELRA-W0307/v1 #                                        288 sentences
-  - mtdata_ELRC-rights_arrested-1-ell-eng
-  - mtdata_ELRC-swedish_social_security-1-ell-eng
-  - mtdata_ELRC-greek_legislation_anticorruption_plan-1-ell-eng
-  - mtdata_ELRC-convention_transfer_sentenced_persons-1-ell-eng
-  - mtdata_ELRC-international_judicial_cooperation_civil_matters-1-ell-eng
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-ell-eng
-  - mtdata_ELRC-macroeconomic_developments-1-ell-eng
-  - mtdata_ELRC-methodological_reconciliation-1-ell-eng
-  - mtdata_ELRC-expression_interest-1-ell-eng
-  - mtdata_ELRC-memorandum_a_esm_programme-1-ell-eng
-  - mtdata_ELRC-convention_against_torture_other_cruel_inhuman_or_degrading_treatment_or_punishment_united_nations-1-ell-eng
-  - mtdata_ELRC-quarterly_reports_parliamentary_budget-1-ell-eng
-  - mtdata_ELRC-collection_reports_greek_power_corporation-1-ell-eng
-  - mtdata_ELRC-hellenic_foreign_affairs_announcements-1-ell-eng
-  - mtdata_ELRC-prime_minister_hellenic-1-ell-eng
-  - mtdata_ELRC-collection_about_cyprus_problem-1-ell-eng
-  - mtdata_ELRC-commitment_property_open-1-ell-eng
-  - mtdata_ELRC-compulsory_expropriation_process_greece-1-ell-eng
-  - mtdata_ELRC-pio_publication_cyprus_has_always_been_europe_2017-1-ell-eng
-  - mtdata_ELRC-pio_publication_window_cyprus-1-ell-eng
-  - mtdata_ELRC-press_information_cyprus-1-ell-eng
-  - mtdata_ELRC-governmental_about_migration_policy-1-ell-eng
-  - mtdata_ELRC-eqf_referencing_report-1-ell-eng
-  - mtdata_ELRC-hellenic_gaming_commission-1-ell-eng
-  - mtdata_ELRC-eu_publications_medical_v2-1-ell-eng
+  - mtdata_ELRC-swedish_social_security-1-ell-eng #        ~18,804 sentences (2.1 MB)
+  - mtdata_ELRC-greek_legislation_anticorruption_plan-1-ell-eng # ~4,428 sentences (500.4 kB)
+  - mtdata_ELRC-convention_transfer_sentenced_persons-1-ell-eng # ~131 sentences (14.8 kB)
+  - mtdata_ELRC-international_judicial_cooperation_civil_matters-1-ell-eng # ~427 sentences (48.3 kB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-ell-eng # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-macroeconomic_developments-1-ell-eng #        ~175 sentences (19.8 kB)
+  - mtdata_ELRC-methodological_reconciliation-1-ell-eng #      ~46 sentences (5.3 kB)
+  - mtdata_ELRC-memorandum_a_esm_programme-1-ell-eng #        ~861 sentences (97.3 kB)
+  - mtdata_ELRC-convention_against_torture_other_cruel_inhuman_or_degrading_treatment_or_punishment_united_nations-1-ell-eng # ~452 sentences (51.2 kB)
+  - mtdata_ELRC-quarterly_reports_parliamentary_budget-1-ell-eng # ~11,396 sentences (1.3 MB)
+  - mtdata_ELRC-collection_reports_greek_power_corporation-1-ell-eng # ~20,136 sentences (2.3 MB)
+  - mtdata_ELRC-hellenic_foreign_affairs_announcements-1-ell-eng # ~4,783 sentences (540.5 kB)
+  - mtdata_ELRC-prime_minister_hellenic-1-ell-eng #         ~7,167 sentences (810.0 kB)
+  - mtdata_ELRC-collection_about_cyprus_problem-1-ell-eng # ~2,396 sentences (270.8 kB)
+  - mtdata_ELRC-commitment_property_open-1-ell-eng #           ~36 sentences (4.1 kB)
+  - mtdata_ELRC-compulsory_expropriation_process_greece-1-ell-eng # ~76 sentences (8.7 kB)
+  - mtdata_ELRC-pio_publication_cyprus_has_always_been_europe_2017-1-ell-eng # ~2,018 sentences (228.1 kB)
+  - mtdata_ELRC-pio_publication_window_cyprus-1-ell-eng #   ~3,414 sentences (385.8 kB)
+  - mtdata_ELRC-press_information_cyprus-1-ell-eng #        ~2,335 sentences (263.9 kB)
+  - mtdata_ELRC-governmental_about_migration_policy-1-ell-eng # ~1,473 sentences (166.6 kB)
+  - mtdata_ELRC-eqf_referencing_report-1-ell-eng #          ~2,266 sentences (256.1 kB)
+  - mtdata_ELRC-hellenic_gaming_commission-1-ell-eng #      ~3,866 sentences (437.0 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-ell-eng #     ~17,493 sentences (2.0 MB)
   - mtdata_EU-eac_forms-1-ell-eng #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-ell-eng #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-ell-eng #                          ~1,178,828 sentences (133.2 MB)

--- a/configs/en-fi-spring-2024.yml
+++ b/configs/en-fi-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en fi --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -55,6 +55,9 @@ datasets:
   #  - opus_ELRA-W0305/v1 - not enough data  (15 sentences)
   #  - opus_MultiHPLT/v1.1 - ignored datasets (0 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
+  #  - mtdata_ELRC-swedish_labour_part2-1-eng-fin - duplicate with opus
+  #  - mtdata_ELRC-swedish_labour_part1-1-eng-fin - duplicate with opus
+  #  - mtdata_ELRC-swedish_food-1-eng-fin - duplicate with opus
   #  - mtdata_ELRC-hallituskausi_2007_2011-1-eng-fin - duplicate with opus
   #  - mtdata_ELRC-hallituskausi_2011_2015-1-eng-fin - duplicate with opus
   #  - mtdata_ELRC-www.norden.org-1-eng-fin - duplicate with opus
@@ -168,13 +171,10 @@ datasets:
   - opus_ELRC-3045-wikipedia_health/v1 #                        334 sentences
   - opus_ELRC-wikipedia_health/v1 #                             334 sentences
   - opus_ELRC_2922/v1 #                                         333 sentences
-  - mtdata_ELRC-swedish_labour_part2-1-eng-fin
-  - mtdata_ELRC-swedish_labour_part1-1-eng-fin
-  - mtdata_ELRC-swedish_social_security-1-eng-fin
-  - mtdata_ELRC-swedish_food-1-eng-fin
-  - mtdata_ELRC-finnish_information_bank-1-eng-fin
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-fin
-  - mtdata_ELRC-nteu_tierb-1-eng-fin
+  - mtdata_ELRC-swedish_social_security-1-eng-fin #        ~18,804 sentences (2.1 MB)
+  - mtdata_ELRC-finnish_information_bank-1-eng-fin #        ~4,816 sentences (544.2 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-fin #     ~14,375 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-fin #                 ~11,482,934 sentences (1.3 GB)
   - mtdata_EU-eac_forms-1-eng-fin #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-fin #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-fin #                          ~1,039,474 sentences (117.5 MB)

--- a/configs/en-hr-spring-2024.yml
+++ b/configs/en-hr-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en hr --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -48,6 +48,7 @@ datasets:
   #  - mtdata_ELRC-agriculture-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-hrv - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-hrv - Error fetching (https://elrc-share.eu/repository/download/aa0aef588de811ea913100155d02670612a2e7d375fe4b139f1d93c27364672d/)
   #  - mtdata_ELRC-antibiotic-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-hrv - duplicate with opus
@@ -147,24 +148,23 @@ datasets:
   - opus_ELRC_2922/v1 #                                         485 sentences
   - opus_ELRC-3284-EUROPARL_covid/v1 #                          475 sentences
   - opus_ELRC_2923/v1 #                                         288 sentences
-  - mtdata_ELRC-government_websites_croatian-1-eng-hrv
-  - mtdata_ELRC-croatian_swedish_crime_victim_compensation_support_authority-1-eng-hrv
-  - mtdata_ELRC-statistical_reports_studies_croatian_bureau_statistics-1-eng-hrv
-  - mtdata_ELRC-studies_challenges_croatian_accession_union_croatian_institute_finance-1-eng-hrv
-  - mtdata_ELRC-journal_croatian_association_civil_engineers-1-eng-hrv
-  - mtdata_ELRC-government_cooperation_ngos-1-eng-hrv
-  - mtdata_ELRC-embassy_finland_zagreb-1-eng-hrv
-  - mtdata_ELRC-foreign_affairs_croatia-1-eng-hrv
-  - mtdata_ELRC-croatian_journal_fisheries-1-eng-hrv
-  - mtdata_ELRC-rural_development_programme_period_2014_2020_croatian_rural_development_programme-1-eng-hrv
-  - mtdata_ELRC-nature_protection_strategy_croatia-1-eng-hrv
-  - mtdata_ELRC-university_library_zagreb-1-eng-hrv
-  - mtdata_ELRC-acts_biological_landscape_diversity_environmental_protection-1-eng-hrv
-  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-hrv
-  - mtdata_ELRC-regional_development_funds-1-eng-hrv
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hrv
-  - mtdata_ELRC-wikipedia_health-1-eng-hrv
-  - mtdata_ELRC-nteu_tierb-1-eng-hrv
+  - mtdata_ELRC-government_websites_croatian-1-eng-hrv #   ~24,015 sentences (2.7 MB)
+  - mtdata_ELRC-croatian_swedish_crime_victim_compensation_support_authority-1-eng-hrv # ~579 sentences (65.5 kB)
+  - mtdata_ELRC-statistical_reports_studies_croatian_bureau_statistics-1-eng-hrv # ~14,093 sentences (1.6 MB)
+  - mtdata_ELRC-studies_challenges_croatian_accession_union_croatian_institute_finance-1-eng-hrv # ~15,627 sentences (1.8 MB)
+  - mtdata_ELRC-journal_croatian_association_civil_engineers-1-eng-hrv # ~16,779 sentences (1.9 MB)
+  - mtdata_ELRC-government_cooperation_ngos-1-eng-hrv #     ~1,423 sentences (160.9 kB)
+  - mtdata_ELRC-embassy_finland_zagreb-1-eng-hrv #          ~2,023 sentences (228.7 kB)
+  - mtdata_ELRC-foreign_affairs_croatia-1-eng-hrv #         ~3,064 sentences (346.3 kB)
+  - mtdata_ELRC-croatian_journal_fisheries-1-eng-hrv #      ~2,903 sentences (328.1 kB)
+  - mtdata_ELRC-rural_development_programme_period_2014_2020_croatian_rural_development_programme-1-eng-hrv # ~5,189 sentences (586.4 kB)
+  - mtdata_ELRC-nature_protection_strategy_croatia-1-eng-hrv # ~1,121 sentences (126.7 kB)
+  - mtdata_ELRC-university_library_zagreb-1-eng-hrv #       ~3,294 sentences (372.3 kB)
+  - mtdata_ELRC-acts_biological_landscape_diversity_environmental_protection-1-eng-hrv # ~2,721 sentences (307.5 kB)
+  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-hrv # ~863 sentences (97.6 kB)
+  - mtdata_ELRC-regional_development_funds-1-eng-hrv #      ~7,471 sentences (844.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hrv #     ~14,220 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-hrv #                  ~1,846,267 sentences (208.6 MB)
   - mtdata_EU-eac_reference-1-eng-hrv #                    ~31,162 sentences (3.5 MB)
   - mtdata_Tilde-eesc-2017-eng-hrv #                      ~216,663 sentences (24.5 MB)
   - mtdata_Tilde-ema-2016-eng-hrv #                       ~209,283 sentences (23.6 MB)

--- a/configs/en-hu-spring-2024.yml
+++ b/configs/en-hu-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en hu --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -119,7 +119,7 @@ datasets:
   - opus_ELRC-wikipedia_health/v1 #                             401 sentences
   - opus_ELRC_2922/v1 #                                         400 sentences
   - opus_ELRC_2923/v1 #                                         211 sentences
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hun
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hun #     ~15,298 sentences (1.7 MB)
   - mtdata_EU-eac_forms-1-eng-hun #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-hun #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-hun #                            ~546,644 sentences (61.8 MB)

--- a/configs/en-id-spring-2024.yml
+++ b/configs/en-id-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en id --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en

--- a/configs/en-lt-spring-2024.yml
+++ b/configs/en-lt-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en lt --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -52,6 +52,7 @@ datasets:
   #  - mtdata_ELRC-euipo_2017-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-lit - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-lit - duplicate with opus
@@ -125,10 +126,9 @@ datasets:
   - opus_ELRC-2740-vaccination/v1 #                             546 sentences
   - opus_ELRC-vaccination/v1 #                                  546 sentences
   - opus_ELRC_2923/v1 #                                         384 sentences
-  - mtdata_ELRC-lithuanian_legislation_seimas_lithuania-1-eng-lit
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lit
-  - mtdata_ELRC-wikipedia_health-1-eng-lit
-  - mtdata_ELRC-nteu_tierb-1-eng-lit
+  - mtdata_ELRC-lithuanian_legislation_seimas_lithuania-1-eng-lit # ~611,715 sentences (69.1 MB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lit #     ~13,874 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-lit #                  ~6,946,588 sentences (785.0 MB)
   - mtdata_EU-eac_forms-1-eng-lit #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-lit #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-lit #                            ~510,025 sentences (57.6 MB)

--- a/configs/en-lv-spring-2024.yml
+++ b/configs/en-lv-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en lv --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -48,11 +48,13 @@ datasets:
   #  - opus_ELRA-W0301/v1 - not enough data  (20 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
   #  - mtdata_ELRC-mfa_latvia-1-eng-lav - duplicate with opus
+  #  - mtdata_ELRC-rights_arrested-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-state_latvian-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-www.visitestonia.com-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-euipo_2017-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-lav - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-covid19.gov.lv-1-eng-lav - duplicate with opus
@@ -126,13 +128,11 @@ datasets:
   - opus_ELRC_2923/v1 #                                         580 sentences
   - opus_ELRC-2741-vaccination/v1 #                             521 sentences
   - opus_ELRC-vaccination/v1 #                                  521 sentences
-  - mtdata_ELRC-international_agreements-1-eng-lav
-  - mtdata_ELRC-rights_arrested-1-eng-lav
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-lav
-  - mtdata_ELRC-finance_economics_bank_latvia-1-eng-lav
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lav
-  - mtdata_ELRC-wikipedia_health-1-eng-lav
-  - mtdata_ELRC-nteu_tierb-1-eng-lav
+  - mtdata_ELRC-international_agreements-1-eng-lav #      ~167,379 sentences (18.9 MB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-lav # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-finance_economics_bank_latvia-1-eng-lav #  ~12,153 sentences (1.4 MB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lav #     ~14,470 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-lav #                  ~6,930,262 sentences (783.1 MB)
   - mtdata_EU-eac_forms-1-eng-lav #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-lav #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-lav #                            ~524,054 sentences (59.2 MB)

--- a/configs/en-ro-spring-2024.yml
+++ b/configs/en-ro-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en ro --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -48,6 +48,7 @@ datasets:
   #  - opus_tldr-pages/v2023-08-29 - not enough data  (9 sentences)
   #  - opus_ELRC-417-Swedish_Work_Environ/v1 - not enough data  (8 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
+  #  - mtdata_ELRC-rights_arrested-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_literature-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_wikipedia-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_news-1-eng-ron - duplicate with opus
@@ -144,14 +145,13 @@ datasets:
   - opus_ELRC-2750-vaccination/v1 #                             496 sentences
   - opus_ELRC-vaccination/v1 #                                  496 sentences
   - opus_ELRC_2923/v1 #                                         319 sentences
-  - mtdata_ELRC-rights_arrested-1-eng-ron
-  - mtdata_ELRC-swedish_work_environment-1-eng-ron
-  - mtdata_ELRC-romanian_new_criminal_procedure_code-1-eng-ron
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-ron
-  - mtdata_ELRC-romanian_ombudsman_archive-1-eng-ron
-  - mtdata_ELRC-studies_reports_statistical_culture_institute_cultural_research_training-1-eng-ron
-  - mtdata_ELRC-rural_development_programme_romania-1-eng-ron
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-ron
+  - mtdata_ELRC-swedish_work_environment-1-eng-ron #       ~13,557 sentences (1.5 MB)
+  - mtdata_ELRC-romanian_new_criminal_procedure_code-1-eng-ron # ~23,368 sentences (2.6 MB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-ron # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-romanian_ombudsman_archive-1-eng-ron #      ~4,888 sentences (552.4 kB)
+  - mtdata_ELRC-studies_reports_statistical_culture_institute_cultural_research_training-1-eng-ron # ~11,961 sentences (1.4 MB)
+  - mtdata_ELRC-rural_development_programme_romania-1-eng-ron # ~4,635 sentences (523.8 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-ron #     ~14,807 sentences (1.7 MB)
   - mtdata_EU-eac_forms-1-eng-ron #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-ron #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-ron #                            ~389,297 sentences (44.0 MB)

--- a/configs/en-ru-spring-2024.yml
+++ b/configs/en-ru-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en ru --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -23,7 +23,6 @@ experiment:
 datasets:
   devtest:
   - mtdata_Neulab-tedtalks_dev-1-eng-rus
-  - mtdata_UN-un_dev-1-eng-rus
   - flores_aug-mix_dev
   - sacrebleu_aug-mix_mtedx/test
   - sacrebleu_aug-mix_wmt20
@@ -33,7 +32,6 @@ datasets:
   - sacrebleu_aug-mix_wmt14/full
   test:
   - mtdata_Neulab-tedtalks_test-1-eng-rus
-  - mtdata_UN-un_test-1-eng-rus
   - flores_devtest
   - flores_aug-mix_devtest
   - flores_aug-title_devtest
@@ -66,7 +64,11 @@ datasets:
   #  - mtdata_Statmt-news_commentary-14-eng-rus - duplicate with opus
   #  - mtdata_Statmt-news_commentary-15-eng-rus - duplicate with opus
   #  - mtdata_Statmt-news_commentary-16-eng-rus - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-1-rus-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-2-rus-eng - duplicate with opus
   #  - mtdata_Statmt-ccaligned-1-eng-rus_RU - duplicate with opus
+  #  - mtdata_UN-un_dev-1-eng-rus - Error fetching (https://drive.google.com/uc?export=download&id=13GI1F1hvwpMUGBSa0QC6ov4eE57GC_Zx)
+  #  - mtdata_UN-un_test-1-eng-rus - Error fetching (https://drive.google.com/uc?export=download&id=13GI1F1hvwpMUGBSa0QC6ov4eE57GC_Zx)
   train:
   - opus_NLLB/v1  #                                      139,937,785 sentences
   - opus_OpenSubtitles/v2018 #                           25,910,105 sentences
@@ -106,8 +108,6 @@ datasets:
   - opus_tldr-pages/v2023-08-29 #                             1,037 sentences
   - mtdata_Statmt-commoncrawl_wmt13-1-rus-eng #         ~8,126,649 sentences (918.3 MB)
   - mtdata_Statmt-news_commentary_wmt18-13-rus-eng #    ~1,001,393 sentences (113.2 MB)
-  - mtdata_Statmt-wiki_titles-1-rus-eng #                 ~179,637 sentences (20.3 MB)
-  - mtdata_Statmt-wiki_titles-2-rus-eng #                 ~193,345 sentences (21.8 MB)
   - mtdata_Tilde-airbaltic-1-eng-rus #                      ~1,288 sentences (145.6 kB)
   - mtdata_Tilde-czechtourism-1-eng-rus #                   ~7,561 sentences (854.5 kB)
   - mtdata_Tilde-worldbank-1-eng-rus #                     ~33,049 sentences (3.7 MB)

--- a/configs/en-sk-spring-2024.yml
+++ b/configs/en-sk-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en sk --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -49,6 +49,7 @@ datasets:
   #  - mtdata_ELRC-euipo_2017-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-slk - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-slk - duplicate with opus
@@ -120,12 +121,11 @@ datasets:
   - opus_ELRC-2745-vaccination/v1 #                             510 sentences
   - opus_ELRC-vaccination/v1 #                                  510 sentences
   - opus_ELRC_2923/v1 #                                         448 sentences
-  - mtdata_ELRC-annual_reports_immigration_asylum_policies_emn_contact_point_slovak-1-eng-slk
-  - mtdata_ELRC-annual_reports_slovak_centre_human_rights-1-eng-slk
-  - mtdata_ELRC-annual_reports_statistical_slovak-1-eng-slk
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slk
-  - mtdata_ELRC-wikipedia_health-1-eng-slk
-  - mtdata_ELRC-nteu_tierb-1-eng-slk
+  - mtdata_ELRC-annual_reports_immigration_asylum_policies_emn_contact_point_slovak-1-eng-slk # ~8,514 sentences (962.1 kB)
+  - mtdata_ELRC-annual_reports_slovak_centre_human_rights-1-eng-slk # ~7,131 sentences (805.9 kB)
+  - mtdata_ELRC-annual_reports_statistical_slovak-1-eng-slk # ~5,839 sentences (659.8 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slk #     ~14,669 sentences (1.7 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-slk #                  ~7,114,356 sentences (803.9 MB)
   - mtdata_EU-eac_forms-1-eng-slk #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-slk #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-slk #                            ~548,757 sentences (62.0 MB)

--- a/configs/en-sl-spring-2024.yml
+++ b/configs/en-sl-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en sl --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -122,12 +122,12 @@ datasets:
   - opus_ELRC-2737-vaccination/v1 #                             492 sentences
   - opus_ELRC-vaccination/v1 #                                  492 sentences
   - opus_ELRC_2923/v1 #                                         451 sentences
-  - mtdata_ELRC-secretariat_general_part1-1-eng-slv
-  - mtdata_ELRC-secretariat_general_part2-1-eng-slv
-  - mtdata_ELRC-chapters_youth_2010_social_profile_young_people_slovenia_publication-1-eng-slv
-  - mtdata_ELRC-statistical_reports_statistical_slovenia-1-eng-slv
-  - mtdata_ELRC-agriculture_forestry_food_slovenia-1-eng-slv
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slv
+  - mtdata_ELRC-secretariat_general_part1-1-eng-slv #      ~57,111 sentences (6.5 MB)
+  - mtdata_ELRC-secretariat_general_part2-1-eng-slv #      ~63,784 sentences (7.2 MB)
+  - mtdata_ELRC-chapters_youth_2010_social_profile_young_people_slovenia_publication-1-eng-slv # ~5,514 sentences (623.2 kB)
+  - mtdata_ELRC-statistical_reports_statistical_slovenia-1-eng-slv # ~10,753 sentences (1.2 MB)
+  - mtdata_ELRC-agriculture_forestry_food_slovenia-1-eng-slv # ~1,754 sentences (198.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slv #     ~14,302 sentences (1.6 MB)
   - mtdata_EU-eac_forms-1-eng-slv #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-slv #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-slv #                            ~539,490 sentences (61.0 MB)

--- a/configs/en-sr-spring-2024.yml
+++ b/configs/en-sr-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en sr --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -71,7 +71,7 @@ datasets:
   - opus_EUbookshop/v2 #                                      1,608 sentences
   - opus_ELRC-3041-wikipedia_health/v1 #                        744 sentences
   - opus_ELRC_2922/v1 #                                         743 sentences
-  - mtdata_ELRC-swedish_social_security-1-eng-srp
+  - mtdata_ELRC-swedish_social_security-1-eng-srp #        ~18,804 sentences (2.1 MB)
   - mtdata_Tilde-worldbank-1-eng-srp #                      ~2,533 sentences (286.3 kB)
 
   # The monolingual data contains:

--- a/configs/en-sv-spring-2024.yml
+++ b/configs/en-sv-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en sv --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en
@@ -169,19 +169,19 @@ datasets:
   - opus_ELRC_2923/v1 #                                         499 sentences
   - opus_ELRC-2752-vaccination/v1 #                             497 sentences
   - opus_ELRC-vaccination/v1 #                                  497 sentences
-  - mtdata_ELRC-swedish_social_security-1-eng-swe
-  - mtdata_ELRC-swedish_work_environment-1-eng-swe
-  - mtdata_ELRC-social_insurance_försäkringskassan-1-eng-swe
-  - mtdata_ELRC-finnish_information_bank-1-eng-swe
-  - mtdata_ELRC-swedish_competition_authority_konkurrensverket-1-eng-swe
-  - mtdata_ELRC-swedish_audit_riksrevisionen-1-eng-swe
-  - mtdata_ELRC-swedish_swedish_crime_victim_compensation_support_authority-1-eng-swe
-  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-swe
-  - mtdata_ELRC-swedish_economic_regional_growth_tillväxtverket-1-eng-swe
-  - mtdata_ELRC-annual_reports_swedish_pension_system-1-eng-swe
-  - mtdata_ELRC-sweden_a_pocket_guide_book-1-eng-swe
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-swe
-  - mtdata_ELRC-nteu_tierb-1-eng-swe
+  - mtdata_ELRC-swedish_social_security-1-eng-swe #        ~18,804 sentences (2.1 MB)
+  - mtdata_ELRC-swedish_work_environment-1-eng-swe #       ~13,557 sentences (1.5 MB)
+  - mtdata_ELRC-social_insurance_försäkringskassan-1-eng-swe # ~1,048 sentences (118.5 kB)
+  - mtdata_ELRC-finnish_information_bank-1-eng-swe #        ~3,398 sentences (384.0 kB)
+  - mtdata_ELRC-swedish_competition_authority_konkurrensverket-1-eng-swe # ~6,096 sentences (688.9 kB)
+  - mtdata_ELRC-swedish_audit_riksrevisionen-1-eng-swe #   ~22,683 sentences (2.6 MB)
+  - mtdata_ELRC-swedish_swedish_crime_victim_compensation_support_authority-1-eng-swe # ~1,039 sentences (117.5 kB)
+  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-swe # ~4,718 sentences (533.2 kB)
+  - mtdata_ELRC-swedish_economic_regional_growth_tillväxtverket-1-eng-swe # ~529 sentences (59.8 kB)
+  - mtdata_ELRC-annual_reports_swedish_pension_system-1-eng-swe # ~6,041 sentences (682.7 kB)
+  - mtdata_ELRC-sweden_a_pocket_guide_book-1-eng-swe #      ~1,524 sentences (172.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-swe #     ~14,048 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-swe #                 ~11,192,105 sentences (1.3 GB)
   - mtdata_EU-eac_forms-1-eng-swe #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-swe #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-swe #                            ~980,674 sentences (110.8 MB)

--- a/configs/en-tr-spring-2024.yml
+++ b/configs/en-tr-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en tr --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en

--- a/configs/en-uk-spring-2024.yml
+++ b/configs/en-uk-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en uk --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en

--- a/configs/en-vi-spring-2024.yml
+++ b/configs/en-vi-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- en vi --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: en

--- a/configs/hr-en-spring-2024.yml
+++ b/configs/hr-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- hr en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: hr
@@ -48,6 +48,7 @@ datasets:
   #  - mtdata_ELRC-agriculture-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-hrv - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-hrv - Error fetching (https://elrc-share.eu/repository/download/aa0aef588de811ea913100155d02670612a2e7d375fe4b139f1d93c27364672d/)
   #  - mtdata_ELRC-antibiotic-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-hrv - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-hrv - duplicate with opus
@@ -147,24 +148,23 @@ datasets:
   - opus_ELRC_2922/v1 #                                         485 sentences
   - opus_ELRC-3284-EUROPARL_covid/v1 #                          475 sentences
   - opus_ELRC_2923/v1 #                                         288 sentences
-  - mtdata_ELRC-government_websites_croatian-1-eng-hrv
-  - mtdata_ELRC-croatian_swedish_crime_victim_compensation_support_authority-1-eng-hrv
-  - mtdata_ELRC-statistical_reports_studies_croatian_bureau_statistics-1-eng-hrv
-  - mtdata_ELRC-studies_challenges_croatian_accession_union_croatian_institute_finance-1-eng-hrv
-  - mtdata_ELRC-journal_croatian_association_civil_engineers-1-eng-hrv
-  - mtdata_ELRC-government_cooperation_ngos-1-eng-hrv
-  - mtdata_ELRC-embassy_finland_zagreb-1-eng-hrv
-  - mtdata_ELRC-foreign_affairs_croatia-1-eng-hrv
-  - mtdata_ELRC-croatian_journal_fisheries-1-eng-hrv
-  - mtdata_ELRC-rural_development_programme_period_2014_2020_croatian_rural_development_programme-1-eng-hrv
-  - mtdata_ELRC-nature_protection_strategy_croatia-1-eng-hrv
-  - mtdata_ELRC-university_library_zagreb-1-eng-hrv
-  - mtdata_ELRC-acts_biological_landscape_diversity_environmental_protection-1-eng-hrv
-  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-hrv
-  - mtdata_ELRC-regional_development_funds-1-eng-hrv
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hrv
-  - mtdata_ELRC-wikipedia_health-1-eng-hrv
-  - mtdata_ELRC-nteu_tierb-1-eng-hrv
+  - mtdata_ELRC-government_websites_croatian-1-eng-hrv #   ~24,015 sentences (2.7 MB)
+  - mtdata_ELRC-croatian_swedish_crime_victim_compensation_support_authority-1-eng-hrv # ~579 sentences (65.5 kB)
+  - mtdata_ELRC-statistical_reports_studies_croatian_bureau_statistics-1-eng-hrv # ~14,093 sentences (1.6 MB)
+  - mtdata_ELRC-studies_challenges_croatian_accession_union_croatian_institute_finance-1-eng-hrv # ~15,627 sentences (1.8 MB)
+  - mtdata_ELRC-journal_croatian_association_civil_engineers-1-eng-hrv # ~16,779 sentences (1.9 MB)
+  - mtdata_ELRC-government_cooperation_ngos-1-eng-hrv #     ~1,423 sentences (160.9 kB)
+  - mtdata_ELRC-embassy_finland_zagreb-1-eng-hrv #          ~2,023 sentences (228.7 kB)
+  - mtdata_ELRC-foreign_affairs_croatia-1-eng-hrv #         ~3,064 sentences (346.3 kB)
+  - mtdata_ELRC-croatian_journal_fisheries-1-eng-hrv #      ~2,903 sentences (328.1 kB)
+  - mtdata_ELRC-rural_development_programme_period_2014_2020_croatian_rural_development_programme-1-eng-hrv # ~5,189 sentences (586.4 kB)
+  - mtdata_ELRC-nature_protection_strategy_croatia-1-eng-hrv # ~1,121 sentences (126.7 kB)
+  - mtdata_ELRC-university_library_zagreb-1-eng-hrv #       ~3,294 sentences (372.3 kB)
+  - mtdata_ELRC-acts_biological_landscape_diversity_environmental_protection-1-eng-hrv # ~2,721 sentences (307.5 kB)
+  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-hrv # ~863 sentences (97.6 kB)
+  - mtdata_ELRC-regional_development_funds-1-eng-hrv #      ~7,471 sentences (844.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-hrv #     ~14,220 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-hrv #                  ~1,846,267 sentences (208.6 MB)
   - mtdata_EU-eac_reference-1-eng-hrv #                    ~31,162 sentences (3.5 MB)
   - mtdata_Tilde-eesc-2017-eng-hrv #                      ~216,663 sentences (24.5 MB)
   - mtdata_Tilde-ema-2016-eng-hrv #                       ~209,283 sentences (23.6 MB)

--- a/configs/id-en-spring-2024.yml
+++ b/configs/id-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- id en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: id

--- a/configs/lt-en-spring-2024.yml
+++ b/configs/lt-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- lt en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: lt
@@ -52,6 +52,7 @@ datasets:
   #  - mtdata_ELRC-euipo_2017-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-lit - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-lit - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-lit - duplicate with opus
@@ -125,10 +126,9 @@ datasets:
   - opus_ELRC-2740-vaccination/v1 #                             546 sentences
   - opus_ELRC-vaccination/v1 #                                  546 sentences
   - opus_ELRC_2923/v1 #                                         384 sentences
-  - mtdata_ELRC-lithuanian_legislation_seimas_lithuania-1-eng-lit
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lit
-  - mtdata_ELRC-wikipedia_health-1-eng-lit
-  - mtdata_ELRC-nteu_tierb-1-eng-lit
+  - mtdata_ELRC-lithuanian_legislation_seimas_lithuania-1-eng-lit # ~611,715 sentences (69.1 MB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lit #     ~13,874 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-lit #                  ~6,946,588 sentences (785.0 MB)
   - mtdata_EU-eac_forms-1-eng-lit #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-lit #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-lit #                            ~510,025 sentences (57.6 MB)

--- a/configs/lv-en-spring-2024.yml
+++ b/configs/lv-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- lv en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: lv
@@ -48,11 +48,13 @@ datasets:
   #  - opus_ELRA-W0301/v1 - not enough data  (20 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
   #  - mtdata_ELRC-mfa_latvia-1-eng-lav - duplicate with opus
+  #  - mtdata_ELRC-rights_arrested-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-state_latvian-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-www.visitestonia.com-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-euipo_2017-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-lav - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-lav - duplicate with opus
   #  - mtdata_ELRC-covid19.gov.lv-1-eng-lav - duplicate with opus
@@ -126,13 +128,11 @@ datasets:
   - opus_ELRC_2923/v1 #                                         580 sentences
   - opus_ELRC-2741-vaccination/v1 #                             521 sentences
   - opus_ELRC-vaccination/v1 #                                  521 sentences
-  - mtdata_ELRC-international_agreements-1-eng-lav
-  - mtdata_ELRC-rights_arrested-1-eng-lav
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-lav
-  - mtdata_ELRC-finance_economics_bank_latvia-1-eng-lav
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lav
-  - mtdata_ELRC-wikipedia_health-1-eng-lav
-  - mtdata_ELRC-nteu_tierb-1-eng-lav
+  - mtdata_ELRC-international_agreements-1-eng-lav #      ~167,379 sentences (18.9 MB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-lav # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-finance_economics_bank_latvia-1-eng-lav #  ~12,153 sentences (1.4 MB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-lav #     ~14,470 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-lav #                  ~6,930,262 sentences (783.1 MB)
   - mtdata_EU-eac_forms-1-eng-lav #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-lav #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-lav #                            ~524,054 sentences (59.2 MB)

--- a/configs/ro-en-spring-2024.yml
+++ b/configs/ro-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- ro en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: ro
@@ -48,6 +48,7 @@ datasets:
   #  - opus_tldr-pages/v2023-08-29 - not enough data  (9 sentences)
   #  - opus_ELRC-417-Swedish_Work_Environ/v1 - not enough data  (8 sentences)
   #  - opus_Ubuntu/v14.10 - not enough data  (0 sentences)
+  #  - mtdata_ELRC-rights_arrested-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_literature-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_wikipedia-1-eng-ron - duplicate with opus
   #  - mtdata_ELRC-romanian_news-1-eng-ron - duplicate with opus
@@ -144,14 +145,13 @@ datasets:
   - opus_ELRC-2750-vaccination/v1 #                             496 sentences
   - opus_ELRC-vaccination/v1 #                                  496 sentences
   - opus_ELRC_2923/v1 #                                         319 sentences
-  - mtdata_ELRC-rights_arrested-1-eng-ron
-  - mtdata_ELRC-swedish_work_environment-1-eng-ron
-  - mtdata_ELRC-romanian_new_criminal_procedure_code-1-eng-ron
-  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-ron
-  - mtdata_ELRC-romanian_ombudsman_archive-1-eng-ron
-  - mtdata_ELRC-studies_reports_statistical_culture_institute_cultural_research_training-1-eng-ron
-  - mtdata_ELRC-rural_development_programme_romania-1-eng-ron
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-ron
+  - mtdata_ELRC-swedish_work_environment-1-eng-ron #       ~13,557 sentences (1.5 MB)
+  - mtdata_ELRC-romanian_new_criminal_procedure_code-1-eng-ron # ~23,368 sentences (2.6 MB)
+  - mtdata_ELRC-letter_rights_persons_arrested_or_detained-1-eng-ron # ~2,078 sentences (234.8 kB)
+  - mtdata_ELRC-romanian_ombudsman_archive-1-eng-ron #      ~4,888 sentences (552.4 kB)
+  - mtdata_ELRC-studies_reports_statistical_culture_institute_cultural_research_training-1-eng-ron # ~11,961 sentences (1.4 MB)
+  - mtdata_ELRC-rural_development_programme_romania-1-eng-ron # ~4,635 sentences (523.8 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-ron #     ~14,807 sentences (1.7 MB)
   - mtdata_EU-eac_forms-1-eng-ron #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-ron #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-ron #                            ~389,297 sentences (44.0 MB)

--- a/configs/ru-en-spring-2024.yml
+++ b/configs/ru-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- ru en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: ru
@@ -28,7 +28,6 @@ experiment:
 datasets:
   devtest:
   - mtdata_Neulab-tedtalks_dev-1-eng-rus
-  - mtdata_UN-un_dev-1-eng-rus
   - flores_aug-mix_dev
   - sacrebleu_aug-mix_mtedx/test
   - sacrebleu_aug-mix_wmt20
@@ -38,7 +37,6 @@ datasets:
   - sacrebleu_aug-mix_wmt14/full
   test:
   - mtdata_Neulab-tedtalks_test-1-eng-rus
-  - mtdata_UN-un_test-1-eng-rus
   - flores_devtest
   - flores_aug-mix_devtest
   - flores_aug-title_devtest
@@ -71,7 +69,11 @@ datasets:
   #  - mtdata_Statmt-news_commentary-14-eng-rus - duplicate with opus
   #  - mtdata_Statmt-news_commentary-15-eng-rus - duplicate with opus
   #  - mtdata_Statmt-news_commentary-16-eng-rus - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-1-rus-eng - duplicate with opus
+  #  - mtdata_Statmt-wiki_titles-2-rus-eng - duplicate with opus
   #  - mtdata_Statmt-ccaligned-1-eng-rus_RU - duplicate with opus
+  #  - mtdata_UN-un_dev-1-eng-rus - Error fetching (https://drive.google.com/uc?export=download&id=13GI1F1hvwpMUGBSa0QC6ov4eE57GC_Zx)
+  #  - mtdata_UN-un_test-1-eng-rus - Error fetching (https://drive.google.com/uc?export=download&id=13GI1F1hvwpMUGBSa0QC6ov4eE57GC_Zx)
   train:
   - opus_NLLB/v1  #                                      139,937,785 sentences
   - opus_OpenSubtitles/v2018 #                           25,910,105 sentences
@@ -111,8 +113,6 @@ datasets:
   - opus_tldr-pages/v2023-08-29 #                             1,037 sentences
   - mtdata_Statmt-commoncrawl_wmt13-1-rus-eng #         ~8,126,649 sentences (918.3 MB)
   - mtdata_Statmt-news_commentary_wmt18-13-rus-eng #    ~1,001,393 sentences (113.2 MB)
-  - mtdata_Statmt-wiki_titles-1-rus-eng #                 ~179,637 sentences (20.3 MB)
-  - mtdata_Statmt-wiki_titles-2-rus-eng #                 ~193,345 sentences (21.8 MB)
   - mtdata_Tilde-airbaltic-1-eng-rus #                      ~1,288 sentences (145.6 kB)
   - mtdata_Tilde-czechtourism-1-eng-rus #                   ~7,561 sentences (854.5 kB)
   - mtdata_Tilde-worldbank-1-eng-rus #                     ~33,049 sentences (3.7 MB)

--- a/configs/sk-en-spring-2024.yml
+++ b/configs/sk-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- sk en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: sk
@@ -49,6 +49,7 @@ datasets:
   #  - mtdata_ELRC-euipo_2017-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-emea-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-vaccination-1-eng-slk - duplicate with opus
+  #  - mtdata_ELRC-wikipedia_health-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-antibiotic-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-europarl_covid-1-eng-slk - duplicate with opus
   #  - mtdata_ELRC-ec_europa_covid-1-eng-slk - duplicate with opus
@@ -120,12 +121,11 @@ datasets:
   - opus_ELRC-2745-vaccination/v1 #                             510 sentences
   - opus_ELRC-vaccination/v1 #                                  510 sentences
   - opus_ELRC_2923/v1 #                                         448 sentences
-  - mtdata_ELRC-annual_reports_immigration_asylum_policies_emn_contact_point_slovak-1-eng-slk
-  - mtdata_ELRC-annual_reports_slovak_centre_human_rights-1-eng-slk
-  - mtdata_ELRC-annual_reports_statistical_slovak-1-eng-slk
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slk
-  - mtdata_ELRC-wikipedia_health-1-eng-slk
-  - mtdata_ELRC-nteu_tierb-1-eng-slk
+  - mtdata_ELRC-annual_reports_immigration_asylum_policies_emn_contact_point_slovak-1-eng-slk # ~8,514 sentences (962.1 kB)
+  - mtdata_ELRC-annual_reports_slovak_centre_human_rights-1-eng-slk # ~7,131 sentences (805.9 kB)
+  - mtdata_ELRC-annual_reports_statistical_slovak-1-eng-slk # ~5,839 sentences (659.8 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slk #     ~14,669 sentences (1.7 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-slk #                  ~7,114,356 sentences (803.9 MB)
   - mtdata_EU-eac_forms-1-eng-slk #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-slk #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-slk #                            ~548,757 sentences (62.0 MB)

--- a/configs/sl-en-spring-2024.yml
+++ b/configs/sl-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- sl en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: sl
@@ -122,12 +122,12 @@ datasets:
   - opus_ELRC-2737-vaccination/v1 #                             492 sentences
   - opus_ELRC-vaccination/v1 #                                  492 sentences
   - opus_ELRC_2923/v1 #                                         451 sentences
-  - mtdata_ELRC-secretariat_general_part1-1-eng-slv
-  - mtdata_ELRC-secretariat_general_part2-1-eng-slv
-  - mtdata_ELRC-chapters_youth_2010_social_profile_young_people_slovenia_publication-1-eng-slv
-  - mtdata_ELRC-statistical_reports_statistical_slovenia-1-eng-slv
-  - mtdata_ELRC-agriculture_forestry_food_slovenia-1-eng-slv
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slv
+  - mtdata_ELRC-secretariat_general_part1-1-eng-slv #      ~57,111 sentences (6.5 MB)
+  - mtdata_ELRC-secretariat_general_part2-1-eng-slv #      ~63,784 sentences (7.2 MB)
+  - mtdata_ELRC-chapters_youth_2010_social_profile_young_people_slovenia_publication-1-eng-slv # ~5,514 sentences (623.2 kB)
+  - mtdata_ELRC-statistical_reports_statistical_slovenia-1-eng-slv # ~10,753 sentences (1.2 MB)
+  - mtdata_ELRC-agriculture_forestry_food_slovenia-1-eng-slv # ~1,754 sentences (198.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-slv #     ~14,302 sentences (1.6 MB)
   - mtdata_EU-eac_forms-1-eng-slv #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-slv #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-slv #                            ~539,490 sentences (61.0 MB)

--- a/configs/sr-en-spring-2024.yml
+++ b/configs/sr-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- sr en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: sr
@@ -71,7 +71,7 @@ datasets:
   - opus_EUbookshop/v2 #                                      1,608 sentences
   - opus_ELRC-3041-wikipedia_health/v1 #                        744 sentences
   - opus_ELRC_2922/v1 #                                         743 sentences
-  - mtdata_ELRC-swedish_social_security-1-eng-srp
+  - mtdata_ELRC-swedish_social_security-1-eng-srp #        ~18,804 sentences (2.1 MB)
   - mtdata_Tilde-worldbank-1-eng-srp #                      ~2,533 sentences (286.3 kB)
 
   # The monolingual data contains:

--- a/configs/sv-en-spring-2024.yml
+++ b/configs/sv-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- sv en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: sv
@@ -22,7 +22,6 @@ experiment:
   pretrained-models: {}
 datasets:
   devtest:
-  - mtdata_Lindat-khresmoi_summary_dev-2-eng-swe
   - mtdata_Neulab-tedtalks_dev-1-eng-swe
   - flores_aug-mix_dev
   test:
@@ -67,6 +66,7 @@ datasets:
   #  - mtdata_ELRC-nteu_tiera-1-eng-swe - duplicate with opus
   #  - mtdata_EU-ecdc-1-eng-swe - duplicate with opus
   #  - mtdata_Facebook-wikimatrix-1-eng-swe - duplicate with opus
+  #  - mtdata_Lindat-khresmoi_summary_dev-2-eng-swe - Error fetching (https://lindat.mff.cuni.cz/repository/xmlui/bitstream/handle/11234/1-2122/khresmoi-summary-test-set-2.0.zip)
   #  - mtdata_LinguaTools-wikititles-2014-eng-swe - duplicate with opus
   #  - mtdata_Neulab-tedtalks_train-1-eng-swe - duplicate with opus
   #  - mtdata_ParaCrawl-paracrawl-6-eng-swe - duplicate with opus
@@ -169,19 +169,19 @@ datasets:
   - opus_ELRC_2923/v1 #                                         499 sentences
   - opus_ELRC-2752-vaccination/v1 #                             497 sentences
   - opus_ELRC-vaccination/v1 #                                  497 sentences
-  - mtdata_ELRC-swedish_social_security-1-eng-swe
-  - mtdata_ELRC-swedish_work_environment-1-eng-swe
-  - mtdata_ELRC-social_insurance_försäkringskassan-1-eng-swe
-  - mtdata_ELRC-finnish_information_bank-1-eng-swe
-  - mtdata_ELRC-swedish_competition_authority_konkurrensverket-1-eng-swe
-  - mtdata_ELRC-swedish_audit_riksrevisionen-1-eng-swe
-  - mtdata_ELRC-swedish_swedish_crime_victim_compensation_support_authority-1-eng-swe
-  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-swe
-  - mtdata_ELRC-swedish_economic_regional_growth_tillväxtverket-1-eng-swe
-  - mtdata_ELRC-annual_reports_swedish_pension_system-1-eng-swe
-  - mtdata_ELRC-sweden_a_pocket_guide_book-1-eng-swe
-  - mtdata_ELRC-eu_publications_medical_v2-1-eng-swe
-  - mtdata_ELRC-nteu_tierb-1-eng-swe
+  - mtdata_ELRC-swedish_social_security-1-eng-swe #        ~18,804 sentences (2.1 MB)
+  - mtdata_ELRC-swedish_work_environment-1-eng-swe #       ~13,557 sentences (1.5 MB)
+  - mtdata_ELRC-social_insurance_försäkringskassan-1-eng-swe # ~1,048 sentences (118.5 kB)
+  - mtdata_ELRC-finnish_information_bank-1-eng-swe #        ~3,398 sentences (384.0 kB)
+  - mtdata_ELRC-swedish_competition_authority_konkurrensverket-1-eng-swe # ~6,096 sentences (688.9 kB)
+  - mtdata_ELRC-swedish_audit_riksrevisionen-1-eng-swe #   ~22,683 sentences (2.6 MB)
+  - mtdata_ELRC-swedish_swedish_crime_victim_compensation_support_authority-1-eng-swe # ~1,039 sentences (117.5 kB)
+  - mtdata_ELRC-swedish_migration_board_migrationsverket-1-eng-swe # ~4,718 sentences (533.2 kB)
+  - mtdata_ELRC-swedish_economic_regional_growth_tillväxtverket-1-eng-swe # ~529 sentences (59.8 kB)
+  - mtdata_ELRC-annual_reports_swedish_pension_system-1-eng-swe # ~6,041 sentences (682.7 kB)
+  - mtdata_ELRC-sweden_a_pocket_guide_book-1-eng-swe #      ~1,524 sentences (172.3 kB)
+  - mtdata_ELRC-eu_publications_medical_v2-1-eng-swe #     ~14,048 sentences (1.6 MB)
+  - mtdata_ELRC-nteu_tierb-1-eng-swe #                 ~11,192,105 sentences (1.3 GB)
   - mtdata_EU-eac_forms-1-eng-swe #                        ~31,162 sentences (3.5 MB)
   - mtdata_EU-eac_reference-1-eng-swe #                    ~31,162 sentences (3.5 MB)
   - mtdata_EU-dcep-1-eng-swe #                            ~980,674 sentences (110.8 MB)

--- a/configs/tr-en-spring-2024.yml
+++ b/configs/tr-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- tr en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: tr

--- a/configs/vi-en-spring-2024.yml
+++ b/configs/vi-en-spring-2024.yml
@@ -2,7 +2,7 @@
 # task config-generator -- vi en --name spring-2024
 #
 # The documentation for this config can be found here:
-# https://github.com/mozilla/firefox-translations-training/blob/fac7511f0f84af352c90502132a162a52009cee3/taskcluster/configs/config.prod.yml
+# https://github.com/mozilla/firefox-translations-training/blob/b5ee6eeced6c113aaa413fa2f693ccfc340e1d2c/taskcluster/configs/config.prod.yml
 experiment:
   name: spring-2024
   src: vi
@@ -25,7 +25,6 @@ datasets:
   - mtdata_Neulab-tedtalks_dev-1-eng-vie
   - flores_aug-mix_dev
   test:
-  - mtdata_Neulab-tedtalks_test-1-eng-vie
   - flores_devtest
   - flores_aug-mix_devtest
   - flores_aug-title_devtest
@@ -45,6 +44,7 @@ datasets:
   #  - mtdata_ELRC-wikipedia_health-1-eng-vie - duplicate with opus
   #  - mtdata_Facebook-wikimatrix-1-eng-vie - duplicate with opus
   #  - mtdata_Neulab-tedtalks_train-1-eng-vie - duplicate with opus
+  #  - mtdata_Neulab-tedtalks_test-1-eng-vie - Error fetching (http://phontron.com/data/ted_talks.tar.gz)
   #  - mtdata_Statmt-ccaligned-1-eng-vie_VN - duplicate with opus
   train:
   - opus_NLLB/v1  #                                       50,092,444 sentences

--- a/utils/config_generator.py
+++ b/utils/config_generator.py
@@ -133,6 +133,8 @@ def add_train_data(
 
     for dataset in opus_datasets:
         sentences = dataset.alignment_pairs or 0
+        visited_corpora.add(normalize_corpus_name(dataset.corpus))
+
         # Some datasets are ignored or too small to be included.
         if dataset.corpus in skip_datasets:
             skipped_datasets.append(
@@ -145,7 +147,6 @@ def add_train_data(
             )
             continue
 
-        visited_corpora.add(normalize_corpus_name(dataset.corpus))
         total_sentences += sentences
         corpus_key = dataset.corpus_key()
         datasets["train"].append(corpus_key)
@@ -175,17 +176,31 @@ def add_train_data(
                 skipped_datasets.append(f"{entry.did.name} - ignored datasets")
                 continue
 
-        dataset.append(corpus_key)
-        if not fast and entry.did.name not in bad_mtdata_sizes:
+        if fast:
+            # Just add the dataset when in fast mode.
+            dataset.append(corpus_key)
+        else:
             byte_size, display_size = get_remote_file_size(entry.url)
-            if byte_size:
-                # Don't add the sentences to the total, as these will be commented out by default.
+            if byte_size is None:
+                # There was a network error, skip the dataset.
+                skipped_datasets.append(f"{corpus_key} - Error fetching ({entry.url})")
+            else:
+                # Don't add the sentences to the total_sentences, as mtdata is less reliable
+                # compared to opus.
                 sentences = estimate_sentence_size(byte_size)
-                dataset.yaml_add_eol_comment(
-                    f"~{sentences:,} sentences ".rjust(70 - len(corpus_key), " ")
-                    + f"({display_size})",
-                    len(datasets["train"]) - 1,
-                )
+                dataset.append(corpus_key)
+                if byte_size:
+                    dataset.yaml_add_eol_comment(
+                        f"~{sentences:,} sentences ".rjust(70 - len(corpus_key), " ")
+                        + f"({display_size})",
+                        len(datasets["train"]) - 1,
+                    )
+                else:
+                    dataset.yaml_add_eol_comment(
+                        "No Content-Length reported ".rjust(70 - len(corpus_key), " ")
+                        + f"({entry.url})",
+                        len(datasets["train"]) - 1,
+                    )
 
     comments = [
         "The training data contains:",


### PR DESCRIPTION
Resolves #642.

* Skips mtdata datasets that have a 404
* Improves the Content-Length lookup, by performing a GET fallback.
* Improves the de-duplication of mtdata datasets.