### PR TITLE
Add wokers with more memory for translations alignments

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -135,6 +135,9 @@ local-worker-aliases:
         by-worker-class:
             gcp-standard: 'b-linux-large-gcp-1tb-standard'
             default: 'b-linux-large-gcp-1tb'
+    b-cpu-xxlargedisk:
+        by-worker-class:
+            default: 'b-linux-large-gcp-2tb'
     # Use for quick tasks that need a GPU, eg: evaluate
     b-gpu:
         by-worker-class:


### PR DESCRIPTION
Adding a worker with more memory (2TB) to get around recent OOM issues in alignment tasks.

Depends on [D212447](https://phabricator.services.mozilla.com/D212447)