### PR TITLE
chore: upgrade to Taskgraph 9

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -225,7 +225,7 @@ tasks:
                               features:
                                   taskclusterProxy: true
     
-                              image: mozillareleases/taskgraph:decision-v8.2.0@sha256:86c8f0d2e9558707b393edc0b9feb9869e6d41659c1592e94192d24856c97949
+                              image: mozillareleases/taskgraph:decision-v9.0.0@sha256:e56c7e5cd467c2ce497c344b358f68cc84a4f73f3422e507a97b397d4e617fbd
                               maxRunTime: 1800
                               onExitStatus:
                                 retry:

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -1,1 +1,1 @@
-taskcluster-taskgraph>=8
+taskcluster-taskgraph>=9

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -303,9 +303,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==8.2.0 \
-    --hash=sha256:410e9c9ef43eac1d0676f16867137de90f77eb0b4e0cbe746fe5512d1a626822 \
-    --hash=sha256:af146323402c2d5f67c65e3c232eda953da1ce319e465069e4d5c7aeb212b66e
+taskcluster-taskgraph==9.0.0 \
+    --hash=sha256:306366c70da7353cc198406a36630b28ecc77ded32f7e4ca0187913d56c40713 \
+    --hash=sha256:3ebc1a07c31168c19159e71507341b40fc33ae3e652c7c80d8871904855021d1
     # via -r taskcluster/requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
This is primarily to pick up https://github.com/taskcluster/taskgraph/pull/514, which will be needed for #466.