### PR TITLE
Make mono shuffling deterministic to fix caching issues

### DIFF
--- a/pipeline/clean/merge-mono.sh
+++ b/pipeline/clean/merge-mono.sh
@@ -32,6 +32,15 @@ datasets=( "${@:3}" )
 
 COMPRESSION_CMD="${COMPRESSION_CMD:-pigz}"
 
+# https://stackoverflow.com/questions/41962359/shuffling-numbers-in-bash-using-seed
+# Deterministic shuffling
+get_seeded_random()
+{
+  seed="$1"
+  openssl enc -aes-256-ctr -pass pass:"$seed" -nosalt \
+    </dev/zero 2>/dev/null
+}
+
 echo "### Merging the following datasets:"
 ls $datasets
 
@@ -40,7 +49,7 @@ mkdir -p "${dir}"
 
 ${COMPRESSION_CMD} -dc "${datasets[@]}" |
   ${BIN}/dedupe |
-  shuf -n "${max_sentences}" |
+  shuf -n "${max_sentences}" --random-source=<(get_seeded_random 42) |
   ${COMPRESSION_CMD} >"${output}"
 
 

--- a/taskcluster/translations_taskgraph/parameters.py
+++ b/taskcluster/translations_taskgraph/parameters.py
@@ -38,7 +38,7 @@ def get_defaults(_):
             },
             "marian-args": {
                 "training-backward": {
-                    "disp-freq": "1",
+                    "disp-freq": "2",
                     "save-freq": "25",
                     "valid-freq": "50",
                     "after": "50u",


### PR DESCRIPTION
We use the same code here, so it should work:

https://github.com/mozilla/firefox-translations-training/blob/fd2f7da7a47eaeb9dde92a47f250afb000edb465/pipeline/translate/merge-corpus.sh#L57

I also checked randomization in other places of the pipeline and we have seeds set there.


fixes #669 