### PR TITLE
allow for more than 99 training datasets (fixes #653)

### DIFF
--- a/taskcluster/kinds/bicleaner-taskgraph-merge/kind.yml
+++ b/taskcluster/kinds/bicleaner-taskgraph-merge/kind.yml
@@ -1,0 +1,69 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - translations_taskgraph.transforms.worker_selection
+    - taskgraph.transforms.task_context
+    - taskgraph.transforms.from_deps
+    - translations_taskgraph.transforms.dependency_dummies
+    - taskgraph.transforms.run:transforms
+    - translations_taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - bicleaner
+
+tasks:
+    bicleaner:
+        description: This noop task merges the taskgraph after bicleaner runs to reduce the number of dependencies that tasks further downstream will need.
+        attributes:
+            stage: bicleaner
+            cleaning-type: bicleaner-ai
+            src_locale: "{src_locale}"
+            trg_locale: "{trg_locale}"
+            cache:
+                type: bicleaner-ai
+                resources: []
+
+        task-context:
+            from-parameters:
+                src_locale: training_config.experiment.src
+                trg_locale: training_config.experiment.trg
+            substitution-fields:
+                - attributes
+
+        run-on-tasks-for: []
+        worker-type: b-cpu-largedisk
+        worker:
+            docker-image: {"in-tree": "base"}
+            max-run-time: 86400
+            artifacts:
+                - name: public/build
+                  path: /builds/worker/artifacts
+                  type: directory
+            # 128 happens when cloning this repository fails
+            retry-exit-status: [128]
+
+        run:
+            using: run-task
+            # The only thing we care about doing here is republishing artifacts fetched
+            # from the upstream bicleaner tasks.
+            command:
+                - bash
+                - -c
+                - mv fetches/* artifacts
+
+        from-deps:
+            unique-kinds: false
+            group-by: all
+            set-name: null
+            fetches:
+                bicleaner:
+                    - artifact: "{dataset_sanitized}.{src_locale}.zst"
+                      extract: false
+                    - artifact: "{dataset_sanitized}.{trg_locale}.zst"
+                      extract: false

--- a/taskcluster/kinds/merge-corpus/kind.yml
+++ b/taskcluster/kinds/merge-corpus/kind.yml
@@ -17,66 +17,6 @@ kind-dependencies:
     - bicleaner
     - toolchain
 
-task-defaults:
-    attributes:
-        src_locale: "{src_locale}"
-        trg_locale: "{trg_locale}"
-        cache:
-            resources:
-                - pipeline/clean/merge-corpus.sh
-    task-context:
-        from-parameters:
-            src_locale: training_config.experiment.src
-            trg_locale: training_config.experiment.trg
-        substitution-fields:
-            - name
-            - label
-            - description
-            - worker.env
-            - dependencies
-            - fetches
-            - attributes
-            - run.command
-    upstreams-config:
-        upstream-artifacts:
-            - "{dataset_sanitized}.{src_locale}.zst"
-            - "{dataset_sanitized}.{trg_locale}.zst"
-    worker-type: b-cpu-largedisk
-    worker:
-        docker-image: {"in-tree": "train"}
-        max-run-time: 86400
-        artifacts:
-            - name: public/build
-              path: /builds/worker/artifacts
-              type: directory
-        env:
-            SRC: "{src_locale}"
-            TRG: "{trg_locale}"
-            COMPRESSION_CMD: zstdmt
-            ARTIFACT_EXT: zst
-        # 128 happens when cloning this repository fails
-        retry-exit-status: [128]
-
-    # Don't run unless explicitly scheduled
-    run-on-tasks-for: []
-
-    run:
-        using: run-task
-        command:
-            - bash
-            - -c
-            # Arguments are:
-            # 1) output prefix
-            # 2) input files
-            - >-
-                export BIN=$MOZ_FETCHES_DIR &&
-                $VCS_PATH/pipeline/clean/merge-corpus.sh
-                artifacts/{artifact_prefix}
-                $MOZ_FETCHES_DIR/*.zst
-    fetches:
-        toolchain:
-            - preprocess
-
 tasks:
     merge-corpus:
         label: merge-corpus-{src_locale}-{trg_locale}
@@ -84,15 +24,70 @@ tasks:
         attributes:
             dataset-category: train
             stage: merge-corpus
+            src_locale: "{src_locale}"
+            trg_locale: "{trg_locale}"
             cache:
                 type: merge-corpus
+                resources:
+                    - pipeline/clean/merge-corpus.sh
+
+        task-context:
+            from-parameters:
+                src_locale: training_config.experiment.src
+                trg_locale: training_config.experiment.trg
+            from-object:
+                artifact_prefix: corpus
+            substitution-fields:
+                - name
+                - label
+                - description
+                - worker.env
+                - dependencies
+                - fetches
+                - attributes
+                - run.command
 
         upstreams-config:
+            upstream-artifacts:
+                - "{dataset_sanitized}.{src_locale}.zst"
+                - "{dataset_sanitized}.{trg_locale}.zst"
             upstream-task-attributes:
                 cleaning-type:
                     by-cleaning-type:
                         bicleaner-ai: bicleaner-ai
 
-        task-context:
-            from-object:
-                artifact_prefix: corpus
+        worker-type: b-cpu-largedisk
+        worker:
+            docker-image: {"in-tree": "train"}
+            max-run-time: 86400
+            artifacts:
+                - name: public/build
+                  path: /builds/worker/artifacts
+                  type: directory
+            env:
+                SRC: "{src_locale}"
+                TRG: "{trg_locale}"
+                COMPRESSION_CMD: zstdmt
+                ARTIFACT_EXT: zst
+            # 128 happens when cloning this repository fails
+            retry-exit-status: [128]
+
+        # Don't run unless explicitly scheduled
+        run-on-tasks-for: []
+
+        run:
+            using: run-task
+            command:
+                - bash
+                - -c
+                # Arguments are:
+                # 1) output prefix
+                # 2) input files
+                - >-
+                    export BIN=$MOZ_FETCHES_DIR &&
+                    $VCS_PATH/pipeline/clean/merge-corpus.sh
+                    artifacts/{artifact_prefix}
+                    $MOZ_FETCHES_DIR/*.zst
+        fetches:
+            toolchain:
+                - preprocess

--- a/taskcluster/kinds/merge-corpus/kind.yml
+++ b/taskcluster/kinds/merge-corpus/kind.yml
@@ -7,14 +7,15 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - translations_taskgraph.transforms.worker_selection
-    - translations_taskgraph.transforms.find_upstreams:by_locales
     - taskgraph.transforms.task_context
+    - taskgraph.transforms.from_deps
+    - translations_taskgraph.transforms.fetches_from_upstream
     - taskgraph.transforms.run:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - bicleaner
+    - bicleaner-taskgraph-merge
     - toolchain
 
 tasks:
@@ -42,19 +43,20 @@ tasks:
                 - label
                 - description
                 - worker.env
-                - dependencies
                 - fetches
                 - attributes
                 - run.command
 
-        upstreams-config:
-            upstream-artifacts:
-                - "{dataset_sanitized}.{src_locale}.zst"
-                - "{dataset_sanitized}.{trg_locale}.zst"
-            upstream-task-attributes:
-                cleaning-type:
-                    by-cleaning-type:
-                        bicleaner-ai: bicleaner-ai
+        from-deps:
+            unique-kinds: false
+            kinds:
+                - bicleaner-taskgraph-merge
+            group-by: all
+
+        fetches-from-upstreams:
+            attribute: fetched_artifacts
+            extra:
+                extract: false
 
         worker-type: b-cpu-largedisk
         worker:
@@ -88,6 +90,10 @@ tasks:
                     $VCS_PATH/pipeline/clean/merge-corpus.sh
                     artifacts/{artifact_prefix}
                     $MOZ_FETCHES_DIR/*.zst
+
+        dependencies:
+            toolchain-preprocess: toolchain-preprocess
+
         fetches:
             toolchain:
                 - preprocess

--- a/taskcluster/translations_taskgraph/transforms/dependency_dummies.py
+++ b/taskcluster/translations_taskgraph/transforms/dependency_dummies.py
@@ -11,18 +11,39 @@
 #
 # The jobs yielded are identical to their original, aside from
 # a `-N` being appended to their name, where N is a distinct number.
+#
+# If any `fetches` from upstream tasks are specified in a task using this
+# transform they will be applied to one (and only one) of the generated tasks.
+# This allows artifacts to be forwarded from tasks upstream of a dummy task
+# to tasks downstream of them.
+#
+# Note that the resulting tasks must be using `run-task` to actually
+# process the resulting `MOZ_FETCHES` environment variable that is generated.
+# See the `bicleaner-taskgraph-merge` kind for an example.
 
 import copy
 
 from taskgraph import MAX_DEPENDENCIES
 from taskgraph.transforms.base import TransformSequence
 
+# One less than taskgraph, because some dummy tasks may depend on:
+# - decision task (taskgraph MAX_DEPENDENCIES already accounts for this)
+# - a docker image task (taskgraph MAX_DEPENDENCIES does _not_ account for this)
+# - N other upstream tasks
+OUR_MAX_DEPENDENCIES = MAX_DEPENDENCIES - 1
+
 transforms = TransformSequence()
 
 
-def yield_job(orig_job, deps, count):
+def yield_job(orig_job, deps, fetches, count):
     job = copy.deepcopy(orig_job)
     job["dependencies"] = deps
+    if fetches:
+        job["fetches"] = fetches
+        job["attributes"]["fetched_artifacts"] = []
+        for artifacts in fetches.values():
+            for a in artifacts:
+                job["attributes"]["fetched_artifacts"].append(a["artifact"])
     job["name"] = "{}-{}".format(orig_job["name"], count)
 
     return job
@@ -33,14 +54,18 @@ def add_dependencies(config, jobs):
     for job in jobs:
         count = 1
         deps = {}
+        fetches = {}
 
         for dep_label in sorted(job["dependencies"].keys()):
             deps[dep_label] = dep_label
-            if len(deps) == MAX_DEPENDENCIES:
-                yield yield_job(job, deps, count)
+            if job.get("fetches", {}).get(dep_label):
+                fetches[dep_label] = job["fetches"][dep_label]
+            if len(deps) == OUR_MAX_DEPENDENCIES:
+                yield yield_job(job, deps, fetches, count)
                 deps = {}
+                fetches = {}
                 count += 1
 
         if deps:
-            yield yield_job(job, deps, count)
+            yield yield_job(job, deps, fetches, count)
             count += 1

--- a/taskcluster/translations_taskgraph/transforms/fetches_from_upstream.py
+++ b/taskcluster/translations_taskgraph/transforms/fetches_from_upstream.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This transform creates `fetches` entries out of lists of artifacts located
+# in the attribute specified by `attribute` in each of its upstream tasks.
+# `fetches` entries are created for each upstream task for each `artifact`
+# present in the upstream list as well as any `extra` data specified.
+#
+# For example, an entry like this in a `kind`:
+#   kind-dependencies:
+#     - upstream-a
+#     - upstream-b
+#
+#   task:
+#     fetches-from-upstreams:
+#       attribute: fetched_artifacts
+#       extra:
+#         extract: false
+#
+# ...will result in `fetches` such as:
+#   fetches:
+#     upstream-a:
+#       - artifact: foo
+#         extract: false
+#     upstream-b:
+#       - artifact: bar
+#         extract: false
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import Schema
+from voluptuous import ALLOW_EXTRA, Optional, Required
+
+SCHEMA = Schema(
+    {
+        Required("fetches-from-upstreams"): {
+            Required("attribute"): str,
+            Optional("extra"): dict,
+        },
+    },
+    extra=ALLOW_EXTRA,
+)
+transforms = TransformSequence()
+
+
+@transforms.add
+def fetches_from_upstream(config, jobs):
+    for job in jobs:
+        fetch_config = job.pop("fetches-from-upstreams")
+        attribute = fetch_config["attribute"]
+        extra = fetch_config.get("extra", {})
+
+        artifacts_by_upstream = {}
+
+        for task in sorted(config.kind_dependencies_tasks.values(), key=lambda t: t.label):
+            if attribute not in task.attributes:
+                continue
+
+            artifacts_by_upstream[task.label] = task.attributes.get(attribute, [])
+
+        job.setdefault("fetches", {})
+        for label, artifacts in artifacts_by_upstream.items():
+            label_fetches = []
+            for artifact in artifacts:
+                label_fetches.append(
+                    {
+                        "artifact": artifact,
+                        **extra,
+                    },
+                )
+
+            job["fetches"][label] = label_fetches
+
+        yield job

--- a/taskcluster/translations_taskgraph/transforms/from_datasets.py
+++ b/taskcluster/translations_taskgraph/transforms/from_datasets.py
@@ -118,6 +118,7 @@ def jobs_from_datasets(config, jobs):
             subjob["attributes"]["dataset"] = dataset
             subjob["attributes"]["src_locale"] = src
             subjob["attributes"]["trg_locale"] = trg
+            subjob["attributes"]["dataset_sanitized"] = subs["dataset_sanitized"]
 
             yield subjob
 


### PR DESCRIPTION
The most visible change here is the addition of `post-bicleaner-dummy` tasks that sit between `bicleaner` and `merge-corpus`. These tasks depend on up to 98 bicleaner tasks themselves, and republish the artifacts from each. `merge-corpus` pulls artifacts directly from these dummy tasks.

Ideally we would still pull artifacts from the `bicleaner` tasks, but doing so is not a trivial matter. I did some math on the cost of republishing and my best estimate is in the 3 figures per year if we had 100 full sized training runs - so IMO it's not worth the cost or complexity to take another path.

We can depend on up to 98 `post-bicleaner-dummy` tasks, so we can have 98*98 training datasets now (~9600), which is more than enough for the forseeable future.

There was some necessary refactoring and preamble before fixing this which is described in the individual commits.