### PR TITLE
Bump memory for shortlist

### DIFF
--- a/taskcluster/kinds/shortlist/kind.yml
+++ b/taskcluster/kinds/shortlist/kind.yml
@@ -43,7 +43,7 @@ tasks:
                 - dependencies
                 - worker.env
                 - attributes
-        worker-type: b-cpu-xlargedisk-32-256
+        worker-type: b-cpu-xlargedisk-64-512
         expires-after: "90 days"
         worker:
             docker-image: {"in-tree": "train"}


### PR DESCRIPTION
It seems there are some OOMs for shortlist and unlike alignments, it's based on a proper sentence piece tokenization. There might be something else in the Python code and I'm investigating it now but in the meantime let's bump memory for it too.