### PR TITLE
Fix task expiration issue

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -1,8 +1,8 @@
 ---
 trust-domain: "translations"
 task-priority: low
-task-deadline-after: 60 days
-task-expires-after: 90 days
+task-deadline-after: 20 days
+task-expires-after: 360 days
 treeherder:
     group-names:
         "I": "Docker images"


### PR DESCRIPTION
I don't expect the training tasks to run longer than 20 days. 

Is it ok to just bump the expiration? We might need to use some tasks as pre-trained models for the training in the opposite direction.

fixes #691 