### PR TITLE
Do not use aggressive dash splitting in tokenization

### DIFF
--- a/pipeline/alignments/tokenizer.py
+++ b/pipeline/alignments/tokenizer.py
@@ -36,13 +36,12 @@ def _tokenize_lines(params) -> List[str]:
     from mosestokenizer import MosesTokenizer
 
     try:
-        # Use aggressive dash splitting to reduce vocabulary size
-        tokenizer = MosesTokenizer(lang, aggressive_dash_splits=True)
+        tokenizer = MosesTokenizer(lang)
     except RuntimeError as err:
         msg = str(err)
         if "No known abbreviations for language" in msg:
             # Fall-back to English if the language is not found
-            tokenizer = MosesTokenizer("en", aggressive_dash_splits=True)
+            tokenizer = MosesTokenizer("en")
         else:
             raise err
 

--- a/tests/test_aln_mapping.py
+++ b/tests/test_aln_mapping.py
@@ -12,8 +12,9 @@ tokenizer = MosesTokenizer("en")
         ("Hi", {0: 0}),
         ("Hello, world!", {0: 0, 1: 0, 2: 1, 3: 1}),
         ("Hello,  world!", {0: 0, 1: 0, 2: 1, 3: 1}),
-        ("Hello,  half-world!", {0: 0, 1: 0, 2: 1, 3: 1}),
+        ("Hello,  half-world and welcome!", {0: 0, 1: 0, 2: 1, 3: 2, 4: 3, 5: 3}),
         ("Hello - world!", {0: 0, 1: 1, 2: 2, 3: 2}),
+        ("Hello,- world!", {0: 0, 1: 0, 2: 0, 3: 1, 4: 1}),
         (
             "“I will not,” retorted the Witch, “for it is now my shoe, and not yours.”",
             {
@@ -50,6 +51,7 @@ def test_remap_indices(orig, expected_idx_map):
     """
     tokenized = tokenizer.tokenize(orig)
     tokenized_str = " ".join(tokenized)
+    print(tokenized_str)
 
     idx_map = map_indices(tokenized_str, orig)
 

--- a/tests/test_aln_mapping.py
+++ b/tests/test_aln_mapping.py
@@ -13,6 +13,7 @@ tokenizer = MosesTokenizer("en")
         ("Hello, world!", {0: 0, 1: 0, 2: 1, 3: 1}),
         ("Hello,  world!", {0: 0, 1: 0, 2: 1, 3: 1}),
         ("Hello,  half-world!", {0: 0, 1: 0, 2: 1, 3: 1}),
+        ("Hello - world!", {0: 0, 1: 1, 2: 2, 3: 2}),
         (
             "“I will not,” retorted the Witch, “for it is now my shoe, and not yours.”",
             {

--- a/tests/test_aln_mapping.py
+++ b/tests/test_aln_mapping.py
@@ -12,6 +12,7 @@ tokenizer = MosesTokenizer("en")
         ("Hi", {0: 0}),
         ("Hello, world!", {0: 0, 1: 0, 2: 1, 3: 1}),
         ("Hello,  world!", {0: 0, 1: 0, 2: 1, 3: 1}),
+        ("Hello,  half-world!", {0: 0, 1: 0, 2: 1, 3: 1}),
         (
             "“I will not,” retorted the Witch, “for it is now my shoe, and not yours.”",
             {


### PR DESCRIPTION
I did not realize Moses tokenizer can modify text. Using aggressive dash splitting leads to dashes represented as `@-@` in the tokenized text. The tests didn't catch this because I tokenize text differently there with a Python Moses tokenizer `sacremoses` and without aggressive dash splitting which is another problem. The C++ based `opus-fast-mosestokenizer` that we use in prod didn't install on MacOS for me and I wanted this quick test to run without Docker. 

The implication is some of the remapped alignments might've been incorrect, but I assume most of the sentences don't include dashes, so it's not critical. It only happens for the words where the dash is a part of the word, for example: `semi-colon`. I tested it with the bug and it leads to merging all words after the dash into "one word" in their alignments.

I think implications for the teacher training are minor: there's some probability of inserting inline noise in the wrong position in the sentences with dashed words.
As for the student, I think it's more important to land the fix there because we use alignments not only for data augmentation but also pass them to marian as `guided-alignments`. In this case, we should restart all the tasks starting from `alignments-student` and `shortlist` stage.