### PR TITLE
Delete temporary files after successfully generating alignments

### DIFF
--- a/pipeline/alignments/align.py
+++ b/pipeline/alignments/align.py
@@ -13,6 +13,7 @@ Example:
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from contextlib import ExitStack
@@ -70,6 +71,9 @@ def run(
                 priors_output_path=priors_output_path,
                 stack=stack,
             )
+
+    # Temporary files no longer needed if we completed successfully.
+    shutil.rmtree(tmp_dir)
 
 
 def align(


### PR DESCRIPTION
I noticed we're uploading these as part of alignments tasks, oops. This patch will remove them only when it completes successfully. If there's no value in keeping them even if something fails, I'll update it to always delete them.