### PR TITLE
fix: invalidate caches when fetch, docker, or toolchain tasks change

### DIFF
--- a/taskcluster/translations_taskgraph/transforms/cached_tasks.py
+++ b/taskcluster/translations_taskgraph/transforms/cached_tasks.py
@@ -6,12 +6,6 @@
 # It exists because there are two features that we need that are missing upstream:
 # - The ability to influence the cache digest from parameters.
 #   (https://github.com/taskcluster/taskgraph/issues/391)
-# - The ability to avoid adding some upstream tasks to the cache digest (which
-#   allows us to avoid rebuilding the world when, eg: we upgrade a Docker base
-#   image version). No upstream issue is filed for this, because for the vast
-#   majority of use cases it is better to take the rebuilds. Our use case is
-#   an exception, because of the truly massive amount of time it takes to
-#   train a model.
 
 
 import itertools
@@ -28,8 +22,6 @@ from translations_taskgraph.util.dict_helpers import deep_get
 
 transforms = TransformSequence()
 
-
-DONT_INVALIDATE_KINDS = ["docker-image", "fetch", "toolchain"]
 
 SCHEMA = Schema(
     {
@@ -122,10 +114,6 @@ def cache_task(config, tasks):
 
         dependency_digests = []
         for p in task.get("dependencies", {}).values():
-            # Here in Translations, we explicit do _not_ invalidate cached
-            # training jobs when non-training jobs are invalidated.
-            if any([kind in p for kind in DONT_INVALIDATE_KINDS]):
-                continue
             if p in digests:
                 dependency_digests.append(digests[p])
             else:


### PR DESCRIPTION
This was an early hack I put in to avoid, eg: retraining entire models because a comment changed in a Dockerfile. We still want to avoid this sort of thing, but these days we do so explicitly with `previous_group_ids` and other techniques in the training config.

Getting rid of this will improve our ability to catch issues in PRs. Eg: https://github.com/mozilla/firefox-translations-training/pull/738 had to be tricked into running things on a second iteration that only changed a Dockerfile.