### PR TITLE
add 2tb gpu workers

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -115,6 +115,11 @@ workers:
             implementation: generic-worker
             os: linux
             worker-type: '{alias}'
+        b-linux-v100-gpu-4-2tb:
+            provisioner: '{trust-domain}-{level}'
+            implementation: generic-worker
+            os: linux
+            worker-type: '{alias}'
         b-linux-v100-gpu-4-1tb-standard:
             provisioner: '{trust-domain}-{level}'
             implementation: generic-worker
@@ -196,6 +201,11 @@ worker-configuration:
             WORKSPACE: "12000"
 
     b-linux-v100-gpu-4-1tb:
+        env:
+            GPUS: "0 1 2 3"
+            WORKSPACE: "12000"
+
+    b-linux-v100-gpu-4-2tb:
         env:
             GPUS: "0 1 2 3"
             WORKSPACE: "12000"


### PR DESCRIPTION
We're seeing out of disk issues in https://firefox-ci-tc.services.mozilla.com/tasks/DQeRyr1_TjmXhC0Z-5KWWw/runs/1, which is suspected to be an OpusTrainer bug. In the short term, we're going to workaround this by adding 2tb workers. In the medium term we'll fix the root cause and remove these.