### PR TITLE
Change base image to trigger toolchain rebuilds

### DIFF
--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 LABEL maintainer="Mozilla Release Engineering <release+docker@mozilla.com>"
 
-# Add worker user with the home directory /builds/worker and bash as the default shell
+# Add worker user with the home directory /builds/worker and bash as the default shell.
 RUN mkdir /builds && \
     useradd -d /builds/worker -s /bin/bash -m worker && \
     chown worker:worker /builds/worker && \


### PR DESCRIPTION
This time from a fork because pushing to working branches on the [mozilla/firefox-translations-training](https://github.com/mozilla/firefox-translations-training ) project rebuilds the toolchains.