### PR TITLE
Bump disk for cefilter

### DIFF
--- a/taskcluster/kinds/cefilter/kind.yml
+++ b/taskcluster/kinds/cefilter/kind.yml
@@ -40,7 +40,7 @@ tasks:
                 - dependencies
                 - fetches
                 - attributes
-        worker-type: b-cpu-largedisk
+        worker-type: b-cpu-xlargedisk-32-256
         worker:
             docker-image: {"in-tree": "train"}
             # 7 days


### PR DESCRIPTION
It failed for en-ru with out of disk. Corpus size 550M

https://firefox-ci-tc.services.mozilla.com/tasks/cpB6vR2CT9yzmvPiY_tuBw/runs/0/logs/public/logs/live.log