### PR TITLE
Rename all commands to use $TASK_WORKDIR/artifacts rather than an absolute path

### DIFF
--- a/taskcluster/kinds/cefilter/kind.yml
+++ b/taskcluster/kinds/cefilter/kind.yml
@@ -68,7 +68,7 @@ tasks:
                 - >-
                     $VCS_PATH/pipeline/cefilter/ce-filter.sh
                     $MOZ_FETCHES_DIR/corpus
-                    /builds/worker/artifacts/corpus
+                    $TASK_WORKDIR/artifacts/corpus
                     $MOZ_FETCHES_DIR/scores.txt
 
         dependencies:

--- a/taskcluster/kinds/clean-corpus/kind.yml
+++ b/taskcluster/kinds/clean-corpus/kind.yml
@@ -96,7 +96,10 @@ tasks:
                 - >-
                     pip install -r $VCS_PATH/pipeline/clean/requirements/clean.txt &&
                     if [ ${USE_OPUSCLEANER} == "true" ]; then dir="clean/opuscleaner"; else dir="clean"; fi &&
-                    $VCS_PATH/pipeline/${dir}/clean-corpus.sh $MOZ_FETCHES_DIR/{dataset_sanitized} /builds/worker/artifacts/{dataset_sanitized} auto {dataset} ${OPUSCLEANER_MODE} 2>&1
+                    $VCS_PATH/pipeline/${dir}/clean-corpus.sh
+                    $MOZ_FETCHES_DIR/{dataset_sanitized}
+                    $TASK_WORKDIR/artifacts/{dataset_sanitized}
+                    auto {dataset} ${OPUSCLEANER_MODE} 2>&1
         dependencies:
             "{provider}": dataset-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}
         fetches:

--- a/taskcluster/kinds/clean-mono/kind.yml
+++ b/taskcluster/kinds/clean-mono/kind.yml
@@ -77,7 +77,7 @@ task-defaults:
         command:
             - bash
             - -c
-            - $VCS_PATH/pipeline/clean/clean-mono.sh {locale} $MOZ_FETCHES_DIR/{dataset_sanitized} /builds/worker/artifacts/{dataset_sanitized} auto {dataset}
+            - $VCS_PATH/pipeline/clean/clean-mono.sh {locale} $MOZ_FETCHES_DIR/{dataset_sanitized} $TASK_WORKDIR/artifacts/{dataset_sanitized} auto {dataset}
     dependencies:
         "{provider}-{locale}": dataset-{provider}-{dataset_sanitized}-{locale}
     fetches:

--- a/taskcluster/kinds/export/kind.yml
+++ b/taskcluster/kinds/export/kind.yml
@@ -71,7 +71,7 @@ tasks:
                     $MOZ_FETCHES_DIR
                     $MOZ_FETCHES_DIR/lex.s2t.pruned
                     $MOZ_FETCHES_DIR/vocab.spm
-                    /builds/worker/artifacts
+                    $TASK_WORKDIR/artifacts
 
         dependencies:
             train-vocab: train-vocab-{src_locale}-{trg_locale}

--- a/taskcluster/kinds/extract-best/kind.yml
+++ b/taskcluster/kinds/extract-best/kind.yml
@@ -84,7 +84,7 @@ tasks:
                     python3 $VCS_PATH/pipeline/translate/bestbleu.py
                     -i "$MOZ_FETCHES_DIR/file.{this_chunk}.nbest"
                     -r "$MOZ_FETCHES_DIR/file.{this_chunk}.ref"
-                    -o /builds/worker/artifacts/file.{this_chunk}.nbest.out
+                    -o $TASK_WORKDIR/artifacts/file.{this_chunk}.nbest.out
                     -m bleu
 
         dependencies:

--- a/taskcluster/kinds/merge-translated/kind.yml
+++ b/taskcluster/kinds/merge-translated/kind.yml
@@ -70,8 +70,8 @@ task-defaults:
                 $MOZ_FETCHES_DIR/mono.{src_locale}.zst
                 $MOZ_FETCHES_DIR/corpus.{trg_locale}.zst
                 $MOZ_FETCHES_DIR/mono.{trg_locale}.zst
-                /builds/worker/artifacts/corpus.{src_locale}.zst
-                /builds/worker/artifacts/corpus.{trg_locale}.zst
+                $TASK_WORKDIR/artifacts/corpus.{src_locale}.zst
+                $TASK_WORKDIR/artifacts/corpus.{trg_locale}.zst
     fetches:
         toolchain:
             - preprocess

--- a/taskcluster/kinds/quantize/kind.yml
+++ b/taskcluster/kinds/quantize/kind.yml
@@ -81,7 +81,7 @@ tasks:
                     $MOZ_FETCHES_DIR/vocab.spm
                     $MOZ_FETCHES_DIR/lex.s2t.pruned
                     $MOZ_FETCHES_DIR/devset.{src_locale}
-                    /builds/worker/artifacts
+                    $TASK_WORKDIR/artifacts
 
         dependencies:
             merge-devset: merge-devset-{src_locale}-{trg_locale}

--- a/taskcluster/kinds/split-corpus/kind.yml
+++ b/taskcluster/kinds/split-corpus/kind.yml
@@ -65,12 +65,12 @@ tasks:
                 - -c
                 - >-
                     python3 $VCS_PATH/pipeline/translate/splitter.py
-                    --output_dir=/builds/worker/artifacts
+                    --output_dir=$TASK_WORKDIR/artifacts
                     --num_parts={split_chunks}
                     --compression_cmd=zstdmt
                     fetches/corpus.{src_locale}.zst &&
                     python3 $VCS_PATH/pipeline/translate/splitter.py
-                    --output_dir=/builds/worker/artifacts
+                    --output_dir=$TASK_WORKDIR/artifacts
                     --num_parts={split_chunks}
                     --output_suffix=.ref
                     --compression_cmd=zstdmt

--- a/taskcluster/kinds/split-mono-src/kind.yml
+++ b/taskcluster/kinds/split-mono-src/kind.yml
@@ -64,7 +64,7 @@ task-defaults:
             - -c
             - >-
                 python3 $VCS_PATH/pipeline/translate/splitter.py
-                --output_dir=/builds/worker/artifacts
+                --output_dir=$TASK_WORKDIR/artifacts
                 --num_parts={split_chunks}
                 --compression_cmd=zstdmt
                 $MOZ_FETCHES_DIR/mono.$LOCALE.zst

--- a/taskcluster/kinds/split-mono-trg/kind.yml
+++ b/taskcluster/kinds/split-mono-trg/kind.yml
@@ -64,7 +64,7 @@ task-defaults:
             - -c
             - >-
                 python3 $VCS_PATH/pipeline/translate/splitter.py
-                --output_dir=/builds/worker/artifacts
+                --output_dir=$TASK_WORKDIR/artifacts
                 --num_parts={split_chunks}
                 --compression_cmd=zstdmt
                 $MOZ_FETCHES_DIR/mono.$LOCALE.zst

--- a/taskcluster/kinds/tests/kind.yml
+++ b/taskcluster/kinds/tests/kind.yml
@@ -148,4 +148,4 @@ tasks:
       run:
           command: >-
               task taskgraph-diff BASE_REV={base_rev}
-              OUTPUT_FILE=/builds/worker/artifacts/taskgraph.diff
+              OUTPUT_FILE=$TASK_WORKDIR/artifacts/taskgraph.diff


### PR DESCRIPTION
This makes all of the tasks testable, as the `run_task` abstraction can replace the environment variable.