### PR TITLE
Ensure we always export the VCS_PATH into the PYTHONPATH

### DIFF
--- a/taskcluster/kinds/analyze-corpus/kind.yml
+++ b/taskcluster/kinds/analyze-corpus/kind.yml
@@ -62,7 +62,8 @@ tasks:
                 - -c
                 - >-
                     pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/analyze.txt
+                    pip3 install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                    export PYTHONPATH=$PYTHONPATH:$VCS_PATH
                     &&
                     python3 $VCS_PATH/pipeline/data/analyze.py
                     --file_location $MOZ_FETCHES_DIR/{dataset_sanitized}.{src_locale}.zst

--- a/taskcluster/kinds/analyze-mono/kind.yml
+++ b/taskcluster/kinds/analyze-mono/kind.yml
@@ -54,6 +54,7 @@ task-defaults:
             - >-
                 pip3 install --upgrade pip setuptools &&
                 pip3 install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/data/analyze.py
                 --file_location $MOZ_FETCHES_DIR/{dataset_sanitized}.{locale}.zst
                 --output $TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/dataset/kind.yml
+++ b/taskcluster/kinds/dataset/kind.yml
@@ -93,6 +93,7 @@ tasks:
                 - >-
                     pip3 install --upgrade pip setuptools &&
                     pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 -u $VCS_PATH/pipeline/data/dataset_importer.py
                     --type corpus
                     --dataset {dataset}

--- a/taskcluster/kinds/extract-best/kind.yml
+++ b/taskcluster/kinds/extract-best/kind.yml
@@ -81,6 +81,7 @@ tasks:
                 - -c
                 - >-
                     zstd -d --rm $MOZ_FETCHES_DIR/*.zst &&
+                    export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/translate/bestbleu.py
                     -i "$MOZ_FETCHES_DIR/file.{this_chunk}.nbest"
                     -r "$MOZ_FETCHES_DIR/file.{this_chunk}.ref"

--- a/taskcluster/kinds/split-corpus/kind.yml
+++ b/taskcluster/kinds/split-corpus/kind.yml
@@ -64,6 +64,7 @@ tasks:
                 - bash
                 - -c
                 - >-
+                    export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/translate/splitter.py
                     --output_dir=/builds/worker/artifacts
                     --num_parts={split_chunks}

--- a/taskcluster/kinds/split-mono-src/kind.yml
+++ b/taskcluster/kinds/split-mono-src/kind.yml
@@ -63,6 +63,7 @@ task-defaults:
             - bash
             - -c
             - >-
+                export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=/builds/worker/artifacts
                 --num_parts={split_chunks}

--- a/taskcluster/kinds/split-mono-trg/kind.yml
+++ b/taskcluster/kinds/split-mono-trg/kind.yml
@@ -63,6 +63,7 @@ task-defaults:
             - bash
             - -c
             - >-
+                export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=/builds/worker/artifacts
                 --num_parts={split_chunks}


### PR DESCRIPTION
It's easy to miss this when writing new code, so I added it everywhere. This ensures we can always import from the pipeline.