### PR TITLE
Add known bad datasets and failures to the config generator

### DIFF
--- a/utils/config_generator.py
+++ b/utils/config_generator.py
@@ -40,11 +40,18 @@ skip_datasets = [
     "WikiTitles",
     # This mtdata dataset fails in a task, and is a duplicate to OPUS.
     "swedish_work_environment",
+    # Fails to load from mtdata.
+    "lithuanian_legislation_seimas_lithuania",
+    # Fails to load from OPUS.
+    "SPC",
 ]
 
 # Do not include small datasets. This works around #508, and minimizes dataset tasks that
 # won't bring a lot more data.
 minimum_dataset_sentences = 200
+
+# If a task name is too long, it will fail.
+max_dataset_name_size = 80
 
 flores_101_languages = {
     "af", "amh", "ar", "as", "ast", "az", "be", "bn", "bs", "bg", "ca", "ceb", "cs", "ckb", "cy",
@@ -149,6 +156,9 @@ def add_train_data(
                 f"{dataset.corpus_key()} - not enough data  ({sentences:,} sentences)"
             )
             continue
+        if len(dataset.corpus) > max_dataset_name_size:
+            skipped_datasets.append(f"{dataset.corpus_key()} - corpus name is too long for tasks")
+            continue
 
         total_sentences += sentences
         corpus_key = dataset.corpus_key()
@@ -177,6 +187,9 @@ def add_train_data(
 
             if entry.did.name in skip_datasets:
                 skipped_datasets.append(f"{entry.did.name} - ignored datasets")
+                continue
+            if len(entry.did.name) > max_dataset_name_size:
+                skipped_datasets.append(f"{entry.did.name} - corpus name is too long for tasks")
                 continue
 
         if fast:
@@ -277,6 +290,8 @@ def add_test_data(
         if dataset_name in skip_datasets:
             # This could be a dataset with a variant design.
             skipped_datasets.append(f"{dataset_name} - variant dataset")
+        elif len(dataset_name) > max_dataset_name_size:
+            skipped_datasets.append(f"{dataset_name} - corpus name is too long for tasks")
         else:
             dataset_name = dataset_name.replace("sacrebleu_", "")
             if is_test:


### PR DESCRIPTION
I went through the configs that were manually edited for the spring-2024 run and updated the rules to automate the exceptions.