### PR TITLE
Fix missing dependency in task train

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -136,7 +136,7 @@ tasks:
   train:
     desc: Start a training run
     summary: Open up the train task from the CLI based on your current branch.
-    deps: [poetry-install-utils]
+    deps: [poetry-install-utils, poetry-install-taskcluster]
     cmds:
       - >-
           poetry run python -W ignore utils/train.py {{.CLI_ARGS}}


### PR DESCRIPTION
There is a taskcluster dependency that is not installed with utils. I missed this on the initial code as it only fails on a clean install.