### PR TITLE
Add a test-fast command for faster local testing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,6 +128,19 @@ tasks:
       - poetry install --only tests --only utils --no-root
       - PYTHONPATH="$(pwd):$(pwd)/taskcluster/scripts/pipeline" poetry run pytest -vv {{.CLI_ARGS}}
 
+  test-fast:
+    desc: Re-run tests in a faster configuration.
+    summary: |
+      This command skips taskgraph generation and skips the poetry install in order to
+      re-run tests quickly. If the taskgraph or dependencies are out of date, then tests
+      may incorrectly fail. It also outputs the captured stdout.
+
+        task test-fast -- tests/test_alignments.py
+    cmds:
+      - >-
+        SKIP_TASKGRAPH=1 PYTHONPATH="$(pwd):$(pwd)/taskcluster/scripts/pipeline"
+        poetry run pytest -vv -s {{.CLI_ARGS}}
+
   test-docker:
     desc: Run the unit tests in the docker image. Some tests require the pre-built Linux executables.
     cmds:


### PR DESCRIPTION
I'm frequently invoking this command locally when working on tests, it would be nice to encode it as an official command. I'm using it when re-running tests when developing locally. It skips Taskgraph generation, which can take awhile. Generally you only need to run the Taskgraph generation once, and then a test will work.