### PR TITLE
Add environment variables to all artifacts and fetches

### DIFF
--- a/taskcluster/kinds/bicleaner-model/kind.yml
+++ b/taskcluster/kinds/bicleaner-model/kind.yml
@@ -68,7 +68,7 @@ tasks:
                     python3 $VCS_PATH/pipeline/bicleaner/download_pack.py
                     --src={src_locale}
                     --trg={trg_locale}
-                    artifacts/bicleaner-ai-{src_locale}-{trg_locale}.tar.zst
+                    $TASK_WORKDIR/artifacts/bicleaner-ai-{src_locale}-{trg_locale}.tar.zst
 
         fetches:
             toolchain:

--- a/taskcluster/kinds/bicleaner/kind.yml
+++ b/taskcluster/kinds/bicleaner/kind.yml
@@ -105,7 +105,7 @@ tasks:
                     export PATH=$PATH:~/.local/bin &&
                     $VCS_PATH/pipeline/bicleaner/bicleaner.sh
                     $MOZ_FETCHES_DIR/{dataset_sanitized}
-                    artifacts/{dataset_sanitized}
+                    $TASK_WORKDIR/artifacts/{dataset_sanitized}
                     {bicleaner_threshold}
                     {bicleaner_threads}
                     $MOZ_FETCHES_DIR/bicleaner-ai-{src_locale}-{trg_locale}

--- a/taskcluster/kinds/collect-corpus/kind.yml
+++ b/taskcluster/kinds/collect-corpus/kind.yml
@@ -78,7 +78,7 @@ tasks:
                 - >-
                     $VCS_PATH/pipeline/translate/collect.sh
                     fetches
-                    artifacts/corpus.{trg_locale}.zst
+                    $TASK_WORKDIR/artifacts/corpus.{trg_locale}.zst
                     $MOZ_FETCHES_DIR/corpus.{trg_locale}.zst
 
         # Don't run unless explicitly scheduled

--- a/taskcluster/kinds/collect-mono-src/kind.yml
+++ b/taskcluster/kinds/collect-mono-src/kind.yml
@@ -63,7 +63,7 @@ task-defaults:
                 zstd -d --rm $MOZ_FETCHES_DIR/file* &&
                 $VCS_PATH/pipeline/translate/collect.sh
                 fetches
-                artifacts/mono.{trg_locale}.zst
+                $TASK_WORKDIR/artifacts/mono.{trg_locale}.zst
                 $MOZ_FETCHES_DIR/mono.{src_locale}.zst
 
 tasks:

--- a/taskcluster/kinds/collect-mono-trg/kind.yml
+++ b/taskcluster/kinds/collect-mono-trg/kind.yml
@@ -63,7 +63,7 @@ task-defaults:
                 zstd -d --rm $MOZ_FETCHES_DIR/file* &&
                 $VCS_PATH/pipeline/translate/collect.sh
                 fetches
-                artifacts/mono.{src_locale}.zst
+                $TASK_WORKDIR/artifacts/mono.{src_locale}.zst
                 $MOZ_FETCHES_DIR/mono.{trg_locale}.zst
 
 tasks:

--- a/taskcluster/kinds/merge-corpus/kind.yml
+++ b/taskcluster/kinds/merge-corpus/kind.yml
@@ -69,7 +69,7 @@ task-defaults:
             - >-
                 export BIN=$MOZ_FETCHES_DIR &&
                 $VCS_PATH/pipeline/clean/merge-corpus.sh
-                artifacts/{artifact_prefix}
+                $TASK_WORKDIR/artifacts/{artifact_prefix}
                 $MOZ_FETCHES_DIR/*.zst
     fetches:
         toolchain:

--- a/taskcluster/kinds/merge-devset/kind.yml
+++ b/taskcluster/kinds/merge-devset/kind.yml
@@ -69,7 +69,7 @@ task-defaults:
             - >-
                 export BIN=$MOZ_FETCHES_DIR &&
                 $VCS_PATH/pipeline/clean/merge-corpus.sh
-                artifacts/{artifact_prefix}
+                $TASK_WORKDIR/artifacts/{artifact_prefix}
                 $MOZ_FETCHES_DIR/*.zst
     fetches:
         toolchain:

--- a/taskcluster/kinds/score/kind.yml
+++ b/taskcluster/kinds/score/kind.yml
@@ -76,10 +76,10 @@ tasks:
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     find fetches &&
                     $VCS_PATH/pipeline/cefilter/score.sh
-                    fetches/final.model.npz.best-{best_model}.npz
-                    fetches/vocab.spm
-                    fetches/corpus
-                    artifacts/scores.txt
+                    $TASK_WORKDIR/fetches/final.model.npz.best-{best_model}.npz
+                    $TASK_WORKDIR/fetches/vocab.spm
+                    $TASK_WORKDIR/fetches/corpus
+                    $TASK_WORKDIR/artifacts/scores.txt
 
         dependencies:
             train-backwards: train-backwards-{src_locale}-{trg_locale}

--- a/taskcluster/kinds/train-vocab/kind.yml
+++ b/taskcluster/kinds/train-vocab/kind.yml
@@ -73,9 +73,9 @@ tasks:
                 - >-
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     $VCS_PATH/pipeline/train/spm-vocab.sh
-                    fetches/corpus.{src_locale}.zst
-                    fetches/corpus.{trg_locale}.zst
-                    artifacts/vocab.spm
+                    $TASK_WORKDIR/fetches/corpus.{src_locale}.zst
+                    $TASK_WORKDIR/fetches/corpus.{trg_locale}.zst
+                    $TASK_WORKDIR/vocab.spm
                     {spm_sample_size}
                     auto
                     {spm_vocab_size}

--- a/taskcluster/kinds/train-vocab/kind.yml
+++ b/taskcluster/kinds/train-vocab/kind.yml
@@ -75,7 +75,7 @@ tasks:
                     $VCS_PATH/pipeline/train/spm-vocab.sh
                     $TASK_WORKDIR/fetches/corpus.{src_locale}.zst
                     $TASK_WORKDIR/fetches/corpus.{trg_locale}.zst
-                    $TASK_WORKDIR/vocab.spm
+                    $TASK_WORKDIR/artifacts/vocab.spm
                     {spm_sample_size}
                     auto
                     {spm_vocab_size}


### PR DESCRIPTION
I keep on adding these when adding a new `run_task` test, so it would be nice to just have this corrected everywhere.