### PR TITLE
Update the Statistics class to use data attributes and use it in merge-mono.py

### DIFF
--- a/pipeline/data/importers/mono/hplt.py
+++ b/pipeline/data/importers/mono/hplt.py
@@ -47,40 +47,28 @@ class HPLTDocument:
         self.lines = self.text.split("\n")
 
 
-@dataclass
 class FilteringStatistics(Statistics):
     """
     Gather statistics about the filtering process.
     """
 
-    shards: FilteringStep
-    visited_lines: FilteringStep
-    document_count: CountingStep
-    duplicate_lines: CountingStep
-    final_lines: CountingStep
-
     def __init__(self, dataset_path: Path) -> None:
         super().__init__(dataset_path)
         self.shards = FilteringStep(
-            dataset_path,
             "How many shards were sampled from. Each shard contains a subset of the "
             "total datasets available.",
         )
         self.visited_lines = FilteringStep(
-            dataset_path,
             "How many lines were visited and kept from the HPLT documents.",
         )
         self.document_count = CountingStep(
-            dataset_path,
             "How many documents were visited. This can help represent data diversity.",
         )
-        self.final_lines = CountingStep(
-            dataset_path,
-            "How many lines were actually written. Smaller lines will be combined together.",
-        )
         self.duplicate_lines = CountingStep(
-            dataset_path,
             "Of the collected lines, this counts how many were duplicates and discarded.",
+        )
+        self.final_lines = CountingStep(
+            "How many lines were actually written. Smaller lines will be combined together.",
         )
 
     def count_shards_visited(self):

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -185,50 +185,54 @@ hplt_translations = {
 hplt_stats = {
     "en": {
         "shards": {
+            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
             "filtered": 1,
             "kept": 1,
-            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
+            "visited": 2,
         },
         "visited_lines": {
+            "description": "How many lines were visited and kept from the HPLT documents.",
             "filtered": 1517,
             "kept": 208,
-            "description": "How many lines were visited and kept from the HPLT documents.",
+            "visited": 1725,
         },
         "document_count": {
-            "value": 15,
             "description": "How many documents were visited. This can help represent data diversity.",
+            "value": 15,
         },
         "duplicate_lines": {
-            "value": 27,
             "description": "Of the collected lines, this counts how many were duplicates and discarded.",
+            "value": 27,
         },
         "final_lines": {
-            "value": 100,
             "description": "How many lines were actually written. Smaller lines will be combined together.",
+            "value": 100,
         },
     },
     "ru": {
         "shards": {
+            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
             "filtered": 1,
             "kept": 1,
-            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
+            "visited": 2,
         },
         "visited_lines": {
+            "description": "How many lines were visited and kept from the HPLT documents.",
             "filtered": 2192,
             "kept": 164,
-            "description": "How many lines were visited and kept from the HPLT documents.",
+            "visited": 2356,
         },
         "document_count": {
-            "value": 22,
             "description": "How many documents were visited. This can help represent data diversity.",
+            "value": 22,
         },
         "duplicate_lines": {
-            "value": 33,
             "description": "Of the collected lines, this counts how many were duplicates and discarded.",
+            "value": 33,
         },
         "final_lines": {
-            "value": 100,
             "description": "How many lines were actually written. Smaller lines will be combined together.",
+            "value": 100,
         },
     },
 }

--- a/tests/test_merge_mono.py
+++ b/tests/test_merge_mono.py
@@ -51,13 +51,36 @@ def test_merge_mono(task: str):
     data_dir.print_tree()
 
     assert json.loads(data_dir.load(f"artifacts/mono.{locale}.stats.json")) == {
-        "duplicates_of_monolingual_corpus": 2,
-        "duplicates_of_parallel_corpus": 2,
-        "parallel_corpus_lines": 7,
-        "original_monolingual_lines": 14,
-        "deduplicated_monolingual_lines": 10,
-        "final_truncated_monolingual_lines": 10,
-        "final_truncated_monolingual_codepoints": 104,
+        "final_truncated_monolingual_lines": {
+            "description": "After truncation via the config's `experiment.mono-max-sentences-src.total`, how many lines are left.",
+            "value": 10,
+        },
+        "final_truncated_monolingual_codepoints": {
+            "description": "The amount of codepoints in the final monolingual corpus.",
+            "value": 104,
+        },
+        "parallel_corpus_lines": {
+            "description": "The size of the merged parallel corpus before truncation.",
+            "value": 7,
+        },
+        "duplicates_of_parallel_corpus": {
+            "description": "How much of the monolingual data was duplicated in the merged parallel corpus.",
+            "value": 2,
+        },
+        "duplicates_of_monolingual_corpus": {
+            "description": "How much of the monolingual data was duplicated across the monolingual datasets.",
+            "value": 2,
+        },
+        "deduplicated_size": {
+            "description": "What was the size of the monolingual data and how much was deduplicated. This doesn't count the truncation of datasets at the datasets gathering time.",
+            "filtered": 4,
+            "kept": 10,
+            "visited": 14,
+        },
+        "deduplicated_monolingual_lines": {
+            "description": "After deduplication, how much monolingual data is left.",
+            "value": 10,
+        },
     }
 
     with read_lines(data_dir.join(f"artifacts/mono.{locale}.zst")) as lines_iter:


### PR DESCRIPTION
I spent some time on how attributes work in Python, as I was struggling to understand why things were behaving the way they were with the Statistics class. This PR updates the class to only use data attributes (so they can be enumerated by the `__dict__` attribute). I reworked how the JSON is generated so it properly recurses into the structure. Finally, I updated `FilteringStatistics` to use `Statistics` which was the entire point of this to begin with.