### PR TITLE
Adjust data cleaning for CJK

### DIFF
--- a/pipeline/clean/opuscleaner/configs/en-ja/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/en-ja/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.4,
+        "TRGWORDRAT": 0.0,
+        "SRCALPHARAT": 0.5,
+        "TRGALPHARAT": 0.0,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/configs/en-ko/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/en-ko/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.4,
+        "TRGWORDRAT": 0.0,
+        "SRCALPHARAT": 0.5,
+        "TRGALPHARAT": 0.0,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/configs/en-zh/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/en-zh/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<src>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.4,
+        "TRGWORDRAT": 0.0,
+        "SRCALPHARAT": 0.5,
+        "TRGALPHARAT": 0.0,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/configs/ja-en/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/ja-en/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.0,
+        "TRGWORDRAT": 0.4,
+        "SRCALPHARAT": 0.0,
+        "TRGALPHARAT": 0.5,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/configs/ko-en/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/ko-en/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.0,
+        "TRGWORDRAT": 0.4,
+        "SRCALPHARAT": 0.0,
+        "TRGALPHARAT": 0.5,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/configs/zh-en/default.filters.json
+++ b/pipeline/clean/opuscleaner/configs/zh-en/default.filters.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "files": [
+  ],
+  "filters": [
+    {
+      "filter": "remove_empty_lines",
+      "parameters": {},
+      "language": null
+    },
+    {
+      "filter": "normalize_whitespace",
+      "parameters": {
+        "COLLAPSE": true
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "deescape-special-chars",
+      "parameters": {
+        "LANG1": "other"
+      },
+      "language": "<trg>"
+    },
+    {
+      "filter": "max_length",
+      "parameters": {
+        "MAXLENGTH": 150,
+        "MINLENGTH": 1
+      },
+      "language": null
+    },
+    {
+      "filter": "fix_wiki",
+      "parameters": {
+        "ALWAYS": false,
+        "FOOTNOTES": true,
+        "URLS": true,
+        "WIKILINKS": true,
+        "CODE": true,
+        "HEADINGS": true,
+        "REMOVEEMPTYLINES": true
+      },
+      "language": null
+    },
+    {
+      "filter": "alpha_ratio",
+      "parameters": {
+        "LANG1": "<src>",
+        "LANG2": "<trg>",
+        "SRCWORDRAT": 0.0,
+        "TRGWORDRAT": 0.4,
+        "SRCALPHARAT": 0.0,
+        "TRGALPHARAT": 0.5,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "num_mismatch",
+      "parameters": {
+        "RATIO": 1,
+        "DEBUG": false
+      },
+      "language": null
+    },
+    {
+      "filter": "fasttext_filter",
+      "parameters": {
+        "FASTTEXT_MODEL_TYPE": "large",
+        "LANG1": "<src>",
+        "LANG2": "<trg>"
+      },
+      "language": null
+    }
+  ]
+}

--- a/pipeline/clean/opuscleaner/generate_filters.py
+++ b/pipeline/clean/opuscleaner/generate_filters.py
@@ -33,8 +33,7 @@ def find_custom_filter(src: str, trg: str, dataset: str) -> Optional[str]:
     paths = [
         f"{CURRENT_FOLDER}/configs/{src}-{trg}/{dataset}.filters.json",
         f"{CURRENT_FOLDER}/configs/{src}-{trg}/{dataset_opus}.filters.json",
-        f"{CURRENT_FOLDER}/configs/{trg}-{src}/{dataset}.filters.json",
-        f"{CURRENT_FOLDER}/configs/{trg}-{src}/{dataset_opus}.filters.json",
+        f"{CURRENT_FOLDER}/configs/{src}-{trg}/default.filters.json",
         f"{CURRENT_FOLDER}/configs/{dataset}.filters.json",
         f"{CURRENT_FOLDER}/configs/{dataset_opus}.filters.json",
     ]

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -11,6 +11,88 @@ SRC = "ru"
 TRG = "en"
 CURRENT_FOLDER = os.path.dirname(os.path.abspath(__file__))
 
+hplt_translations = {
+    "en": [
+        "If you are having problems with your HP Computer, the article below will help determine if the problem is with your HP Drivers. Downloading the latest Driver releases helps resolve Driver conflicts and improve your computer's stability and performance. Updates are recommended for all Windows 10, 8, Windows 7, XP and Vista users.\n",
+        "This webpage shows information on what a issue is and the various issues that may occurs when no permission to write document. Several issue are easy to fix, but others are not, so you need to read our article to find proper methods, so, our article is very necessary for you to read.\n",
+        "0x8004D00D XACT_E_NOTCURRENT The transaction failed to commit due to the failure of optimistic concurrency control in at least one of the resource managers.\n",
+        "5. Download the driver which you want. There may be numerous variations shown. Pick the latest one. If these doesn't work, the easiest way you can see.\n",
+        '3. Depending on your view options either click on "uninstall a program" or "program and features". 4. When the programs and features window opens select the program your want to uninstall from the list and click on the "Uninstall" button. 5. Confirm that you want to uninstall a program by clicking on the "Yes" button.\n',
+        "2.Follow the instructions in the preceding procedure to update drivers. 3.Click Search automatically for updated driver software. 4. If below message popped up, your driver is already the latest driver and there is no need to update. 5. If a new driver is found, please follow the instruction to install it and restart your computer. Description Compatibility\n",
+        "Show the most common Drivers below\n",
+        "HP Drivers Download Utility was created to save your time resolving driver problems by providing you with a single, automatic tool.\n",
+        "All your drivers just in a minute!\n",
+        "Have you encountered and don't know how to resolve issue? This guide show information on most usual lead to for problem, we hope your PC can in order after reading this.\n",
+    ],
+    "ru": [
+        "Мы прошли проверку временем, и стали одним из ведущих операторов на рынке России в поставках металла как со склада, так и напрямую с металлургических комбинатов на объекты наших клиентов. Мы предлагаем оптимальные варианты поставок металла вашему предприятию в нужные сроки, в требуемом объеме, с необходимым качеством.\n",
+        "Именно так мы видим нашу историю, – 17 лет ежедневного упорного труда «вопреки, а не благодаря», - формируя рынок и меняя компанию. Это история, которую мы пишем и сегодня, - принимая решения и воплощая их в жизнь. Это история про отношения и про внутренние рекорды. История о том, как складывать пазл внутри компании, достигать, и кропотливо создавать следующий пазл. История о том, как этические ценности становятся генетическим кодом компании. История строительства умного бизнеса. История создания своей бизнес-модели, во главу которой поставлен клиент и его потребности. Мы не останавливаемся, мы уже работаем в будущем.\n",
+        "«быть конкурентоспособней» – мы становимся полностью независимым металлотрейдером, это решение во многом предопределило наше острое восприятие рынка и потребностей наших клиентов.\n",
+        "«быть лучше» – мы значительно улучшили предлагаемый клиентам ассортимент, - мы начинаем работать со всеми ведущими металлургическим комбинатами России и зарубежья.\n",
+        "«быть в гармонии» – сетевое развитие становится стратегической целью компании, в её рамках клиентская перспектива становится ключевым компонентом.\n",
+        "Поэтому никакой критической ситуации сейчас нет, как и необходимости вводить какие-либо ограничения на федеральном уровне. Но рекомендуется следовать стандартным мерам предосторожности — носить маски в общественных местах, соблюдать гигиену рук. Это крайне важно для уязвимых категорий граждан. Также следует вакцинироваться, если подошло время.\n",
+        "Отмечу, что сегодняшний рост в большей степени связан со сменой циркулирующих субвариантов вируса, а не с сезоном летних отпусков. Ведь летом люди проводят больше времени на открытом воздухе, где риски инфицирования не столь высоки. Хотя в некоторых случаях повышенная мобильность, смена климата и часовых поясов всё же могут приводить к ослаблению иммунитета и способствовать развитию инфекции. Это многие ощущали на себе в период после летних отпусков.\n",
+        "— Итальянские исследователи пришли к выводу, что к каждому 20-му, кто переболел коронавирусом, возможно, никогда больше не вернутся обоняние и вкус. О подобных осложнениях также говорят российские специалисты. Вызывает ли постковид новые, более лёгкие варианты коронавируса? — Постковидный синдром продолжает регистрироваться у людей по всему миру. Считается, что он встречается у одного из восьми взрослых. В отдельных случаях при постковидном синдроме наблюдаются признаки поражения сердечно-сосудистой системы, почек, метаболические нарушения. У некоторых пациентов стойкая потеря вкуса и запаха отмечается уже на протяжении двух лет.\n",
+        "Главным фактором прекращения пандемии COVID-19 станет коллективный иммунитет, его можно достичь за счёт вакцинации. Об этом в интервью...\n",
+        "Сложно сказать, восстановится ли окончательно вкус или обоняние у тех, кто испытывает проблемы с ними после перенесённого COVID-19. Ещё в доковидную эпоху было показано, что 1,5% населения имеют проблемы с обонянием. После 50 лет их ощущают более 50% населения, а после 80 лет — более 80%. Поэтому если предрасположенность к этим нарушениям у человека была и до COVID-19, то такие нарушения после перенесённой инфекции могут продолжаться неопределённо долго.\n",
+    ],
+}
+
+hplt_stats = {
+    "en": {
+        "shards": {
+            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
+            "filtered": 1,
+            "kept": 1,
+            "visited": 2,
+        },
+        "visited_lines": {
+            "description": "How many lines were visited and kept from the HPLT documents.",
+            "filtered": 1517,
+            "kept": 208,
+            "visited": 1725,
+        },
+        "document_count": {
+            "description": "How many documents were visited. This can help represent data diversity.",
+            "value": 15,
+        },
+        "duplicate_lines": {
+            "description": "Of the collected lines, this counts how many were duplicates and discarded.",
+            "value": 27,
+        },
+        "final_lines": {
+            "description": "How many lines were actually written. Smaller lines will be combined together.",
+            "value": 100,
+        },
+    },
+    "ru": {
+        "shards": {
+            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
+            "filtered": 1,
+            "kept": 1,
+            "visited": 2,
+        },
+        "visited_lines": {
+            "description": "How many lines were visited and kept from the HPLT documents.",
+            "filtered": 2192,
+            "kept": 164,
+            "visited": 2356,
+        },
+        "document_count": {
+            "description": "How many documents were visited. This can help represent data diversity.",
+            "value": 22,
+        },
+        "duplicate_lines": {
+            "description": "Of the collected lines, this counts how many were duplicates and discarded.",
+            "value": 33,
+        },
+        "final_lines": {
+            "description": "How many lines were actually written. Smaller lines will be combined together.",
+            "value": 100,
+        },
+    },
+}
+
 
 def add_fake_alignments(corpus):
     corpus_and_aln = []
@@ -111,10 +193,10 @@ def test_basic_corpus_import(importer, dataset, data_dir):
 
 
 mono_params = [
-    ("news-crawl", "en", "news_2021",                    [0, 1, 4, 6, 3, 7, 5, 2]),
-    ("news-crawl", "ru", "news_2021",                    [0, 1, 4, 6, 3, 7, 5, 2]),
-    ("url",        "en", "gcp_pytest-dataset_en_cdd0d7", [2, 1, 5, 4, 0, 7, 6, 3]),
-    ("url",        "ru", "gcp_pytest-dataset_ru_be3263", [5, 4, 2, 0, 7, 1, 3, 6]),
+    ("news-crawl", "en", "news_2021", [0, 1, 4, 6, 3, 7, 5, 2]),
+    ("news-crawl", "ru", "news_2021", [0, 1, 4, 6, 3, 7, 5, 2]),
+    ("url", "en", "gcp_pytest-dataset_en_cdd0d7", [2, 1, 5, 4, 0, 7, 6, 3]),
+    ("url", "ru", "gcp_pytest-dataset_ru_be3263", [5, 4, 2, 0, 7, 1, 3, 6]),
 ]  # fmt: skip
 
 
@@ -149,89 +231,6 @@ def test_mono_source_import(importer, language, dataset, sort_order, data_dir):
     assert [
         source_lines.index(line) for line in sample_lines
     ] == sort_order, "The data is shuffled."
-
-
-hplt_translations = {
-    "en": [
-        "If you are having problems with your HP Computer, the article below will help determine if the problem is with your HP Drivers. Downloading the latest Driver releases helps resolve Driver conflicts and improve your computer's stability and performance. Updates are recommended for all Windows 10, 8, Windows 7, XP and Vista users.\n",
-        "This webpage shows information on what a issue is and the various issues that may occurs when no permission to write document. Several issue are easy to fix, but others are not, so you need to read our article to find proper methods, so, our article is very necessary for you to read.\n",
-        "0x8004D00D XACT_E_NOTCURRENT The transaction failed to commit due to the failure of optimistic concurrency control in at least one of the resource managers.\n",
-        "5. Download the driver which you want. There may be numerous variations shown. Pick the latest one. If these doesn't work, the easiest way you can see.\n",
-        '3. Depending on your view options either click on "uninstall a program" or "program and features". 4. When the programs and features window opens select the program your want to uninstall from the list and click on the "Uninstall" button. 5. Confirm that you want to uninstall a program by clicking on the "Yes" button.\n',
-        "2.Follow the instructions in the preceding procedure to update drivers. 3.Click Search automatically for updated driver software. 4. If below message popped up, your driver is already the latest driver and there is no need to update. 5. If a new driver is found, please follow the instruction to install it and restart your computer. Description Compatibility\n",
-        "Show the most common Drivers below\n",
-        "HP Drivers Download Utility was created to save your time resolving driver problems by providing you with a single, automatic tool.\n",
-        "All your drivers just in a minute!\n",
-        "Have you encountered and don't know how to resolve issue? This guide show information on most usual lead to for problem, we hope your PC can in order after reading this.\n",
-    ],
-    "ru": [
-        "Мы прошли проверку временем, и стали одним из ведущих операторов на рынке России в поставках металла как со склада, так и напрямую с металлургических комбинатов на объекты наших клиентов. Мы предлагаем оптимальные варианты поставок металла вашему предприятию в нужные сроки, в требуемом объеме, с необходимым качеством.\n",
-        "Именно так мы видим нашу историю, – 17 лет ежедневного упорного труда «вопреки, а не благодаря», - формируя рынок и меняя компанию. Это история, которую мы пишем и сегодня, - принимая решения и воплощая их в жизнь. Это история про отношения и про внутренние рекорды. История о том, как складывать пазл внутри компании, достигать, и кропотливо создавать следующий пазл. История о том, как этические ценности становятся генетическим кодом компании. История строительства умного бизнеса. История создания своей бизнес-модели, во главу которой поставлен клиент и его потребности. Мы не останавливаемся, мы уже работаем в будущем.\n",
-        "«быть конкурентоспособней» – мы становимся полностью независимым металлотрейдером, это решение во многом предопределило наше острое восприятие рынка и потребностей наших клиентов.\n",
-        "«быть лучше» – мы значительно улучшили предлагаемый клиентам ассортимент, - мы начинаем работать со всеми ведущими металлургическим комбинатами России и зарубежья.\n",
-        "«быть в гармонии» – сетевое развитие становится стратегической целью компании, в её рамках клиентская перспектива становится ключевым компонентом.\n",
-        "Поэтому никакой критической ситуации сейчас нет, как и необходимости вводить какие-либо ограничения на федеральном уровне. Но рекомендуется следовать стандартным мерам предосторожности — носить маски в общественных местах, соблюдать гигиену рук. Это крайне важно для уязвимых категорий граждан. Также следует вакцинироваться, если подошло время.\n",
-        "Отмечу, что сегодняшний рост в большей степени связан со сменой циркулирующих субвариантов вируса, а не с сезоном летних отпусков. Ведь летом люди проводят больше времени на открытом воздухе, где риски инфицирования не столь высоки. Хотя в некоторых случаях повышенная мобильность, смена климата и часовых поясов всё же могут приводить к ослаблению иммунитета и способствовать развитию инфекции. Это многие ощущали на себе в период после летних отпусков.\n",
-        "— Итальянские исследователи пришли к выводу, что к каждому 20-му, кто переболел коронавирусом, возможно, никогда больше не вернутся обоняние и вкус. О подобных осложнениях также говорят российские специалисты. Вызывает ли постковид новые, более лёгкие варианты коронавируса? — Постковидный синдром продолжает регистрироваться у людей по всему миру. Считается, что он встречается у одного из восьми взрослых. В отдельных случаях при постковидном синдроме наблюдаются признаки поражения сердечно-сосудистой системы, почек, метаболические нарушения. У некоторых пациентов стойкая потеря вкуса и запаха отмечается уже на протяжении двух лет.\n",
-        "Главным фактором прекращения пандемии COVID-19 станет коллективный иммунитет, его можно достичь за счёт вакцинации. Об этом в интервью...\n",
-        "Сложно сказать, восстановится ли окончательно вкус или обоняние у тех, кто испытывает проблемы с ними после перенесённого COVID-19. Ещё в доковидную эпоху было показано, что 1,5% населения имеют проблемы с обонянием. После 50 лет их ощущают более 50% населения, а после 80 лет — более 80%. Поэтому если предрасположенность к этим нарушениям у человека была и до COVID-19, то такие нарушения после перенесённой инфекции могут продолжаться неопределённо долго.\n",
-    ],
-}
-
-hplt_stats = {
-    "en": {
-        "shards": {
-            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
-            "filtered": 1,
-            "kept": 1,
-            "visited": 2,
-        },
-        "visited_lines": {
-            "description": "How many lines were visited and kept from the HPLT documents.",
-            "filtered": 1517,
-            "kept": 208,
-            "visited": 1725,
-        },
-        "document_count": {
-            "description": "How many documents were visited. This can help represent data diversity.",
-            "value": 15,
-        },
-        "duplicate_lines": {
-            "description": "Of the collected lines, this counts how many were duplicates and discarded.",
-            "value": 27,
-        },
-        "final_lines": {
-            "description": "How many lines were actually written. Smaller lines will be combined together.",
-            "value": 100,
-        },
-    },
-    "ru": {
-        "shards": {
-            "description": "How many shards were sampled from. Each shard contains a subset of the total datasets available.",
-            "filtered": 1,
-            "kept": 1,
-            "visited": 2,
-        },
-        "visited_lines": {
-            "description": "How many lines were visited and kept from the HPLT documents.",
-            "filtered": 2192,
-            "kept": 164,
-            "visited": 2356,
-        },
-        "document_count": {
-            "description": "How many documents were visited. This can help represent data diversity.",
-            "value": 22,
-        },
-        "duplicate_lines": {
-            "description": "Of the collected lines, this counts how many were duplicates and discarded.",
-            "value": 33,
-        },
-        "final_lines": {
-            "description": "How many lines were actually written. Smaller lines will be combined together.",
-            "value": 100,
-        },
-    },
-}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use custom OpusCleaner configs with disabled word-based filters.

The filters are copied from https://github.com/hplt-project/HPLT-MT-Models/blob/main/v1.0/data/en-zh_hant/raw/v2/HPLT-v1.1.en-zh_hant.filters.json. 

I don't think it's feasible to do the src-trg-ratio that requires tokenization now. We would have to move tokenization to a separate step for that and somehow adjust the cleaning step to work with that instead of the original text. I filed https://github.com/mozilla/firefox-translations-training/issues/899

closes #742 