### PR TITLE
Use GCP standard instances for alignment tasks

### DIFF
--- a/taskcluster/configs/config.prod.yml
+++ b/taskcluster/configs/config.prod.yml
@@ -259,3 +259,8 @@ taskcluster:
   #   default: gcp-spot
   worker-classes:
     default: gcp-spot
+    # long-running tasks
+    alignments-original: gcp-standard
+    alignments-backtranslated: gcp-standard
+    alignments-student: gcp-standard
+    shortlist: gcp-standard

--- a/taskcluster/configs/config.prod.yml
+++ b/taskcluster/configs/config.prod.yml
@@ -259,7 +259,7 @@ taskcluster:
   #   default: gcp-spot
   worker-classes:
     default: gcp-spot
-    # long-running tasks
+    # long-running tasks that don't support restarts with continuation like training tasks
     alignments-original: gcp-standard
     alignments-backtranslated: gcp-standard
     alignments-student: gcp-standard


### PR DESCRIPTION
[skip ci]