### PR TITLE
Add --run-as-user flag to docker-run.py

### DIFF
--- a/utils/tasks/docker-run.py
+++ b/utils/tasks/docker-run.py
@@ -16,6 +16,12 @@ def get_args():
         metavar="VOLUME",
     )
 
+    parser.add_argument(
+        "--run-as-user",
+        action="store_true",
+        help="Run the Docker container as the current user's UID and GID.",
+    )
+
     args, other_args = parser.parse_known_args()
     args.other_args = other_args
 
@@ -41,6 +47,12 @@ def main():
     if args.volume:
         for volume in args.volume:
             docker_command.extend(["--volume", volume])
+
+    # Run Docker with the current user's UID and GID if --run-as-user is specified
+    if args.run_as_user:
+        uid = os.getuid()
+        gid = os.getgid()
+        docker_command.extend(["--user", f"{uid}:{gid}"])
 
     # Specify the Docker image
     docker_command.append("translations-local")


### PR DESCRIPTION
For some reason on Linux, when the Gecko Python script pulls a fresh clone of this repository, the Docker container has a permissions issue related to emsdk and `tar`.  

```
tar: bin/npx: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
tar: bin/npm: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
tar: Exiting with failure status due to previous errors
['tar', '-xf', '/builds/worker/checkouts/inference/3rd_party/emsdk/zips/node-v14.18.2-linux-x64.tar.xz', '--strip', '1'] failed with error code 2!
error: installation failed!
```

I've figured out that passing in the same UID/GID on Linux seems to fix this issue so I'm adding that as an option to the script. 

I will then modify the Gecko script to utilize this flag for Linux builds. 

This issue only seems to occur when `task docker-run ...` is invoked from within another Python script. Running `task docker-run ...` directly in the Linux terminal seems to run fine. 