### PR TITLE
feat: allow overwrites in update db task

### DIFF
--- a/taskcluster/kinds/upload-db/kind.yml
+++ b/taskcluster/kinds/upload-db/kind.yml
@@ -46,6 +46,7 @@ tasks:
         worker-type: upload-artifacts
         run-on-tasks-for: []
         worker:
+            allow-overwrites: true
             app-name: translations
             # the `development` bucket pushes to the non-production GCS bucket
             # (moz-fx-translations-data--5f91-stage-translations-data)

--- a/taskcluster/translations_taskgraph/worker_types.py
+++ b/taskcluster/translations_taskgraph/worker_types.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from taskgraph.transforms.task import payload_builder, taskref_or_string
-from voluptuous import Required
+from voluptuous import Required, Optional
 
 from translations_taskgraph.util.dependencies import get_upload_artifacts_upstream_dependency
 
@@ -17,6 +17,7 @@ from translations_taskgraph.util.dependencies import get_upload_artifacts_upstre
         Required("upstream-artifacts"): [str],
         # artifact names or globs / list of destinations
         Required("artifact-map"): {str: [taskref_or_string]},
+        Optional("allow-overwrites"): bool,
     },
 )
 def build_upload_artifacts_payload(_, task, task_def):
@@ -34,6 +35,7 @@ def build_upload_artifacts_payload(_, task, task_def):
     worker = task["worker"]
     task_def["tags"]["worker-implementation"] = "scriptworker"
     task_def["payload"] = {
+        "allow_overwrites": worker.get("allow-overwrites", False),
         "releaseProperties": {"appName": worker["app-name"]},
         "upstreamArtifacts": [
             {


### PR DESCRIPTION
https://github.com/mozilla-releng/scriptworker-scripts/pull/1300 is adding support for the new `allow_overwrites` option in the upload tasks. This change enables it for the `upload-db` task.

Leaving in draft for now, because it depends on https://github.com/mozilla-releng/scriptworker-scripts/pull/1300 being merged and rolled out to production.