### PR TITLE
Fix flores eval for uploaded models

### DIFF
--- a/db/updater.py
+++ b/db/updater.py
@@ -349,7 +349,7 @@ class GCSDataCollector:
                 if not blob.name.endswith(".metrics.json"):
                     continue
 
-                if "-flores-devtest" in blob.name and "-aug-" not in blob.name:
+                if "devtest" in blob.name and "aug-" not in blob.name:
                     return blob
 
         # Check for flores-devtest in dedicated evaluation subdirectories (newer structure)


### PR DESCRIPTION
The naming is slightly different for the uploaded models; this fixes how it searches for evals in names like
```
gs://moz-fx-translations-data--303e-prod-translations-data/models/en-pl/retrain_hr_Go1eMF6eRZuv-lflUT7i_Q/evaluation/student/devtest.metrics.json
```

Updated dashboard has more numbers: https://mozilla.github.io/translations/model-registry/?searchString=&showModels=true&score=vs-google