### PR TITLE
Faster Bicleaner AI

### DIFF
--- a/pipeline/bicleaner/bicleaner.sh
+++ b/pipeline/bicleaner/bicleaner.sh
@@ -15,7 +15,6 @@ python3 -c "from pipeline.common.marian import assert_gpus_available; assert_gpu
 
 test -v SRC
 test -v TRG
-test -v CUDA_DIR
 
 corpus_prefix=$1
 output_prefix=$2
@@ -89,7 +88,7 @@ else
    paste <(zstdmt -dc "${corpus_prefix}.${SRC}.zst") <(zstdmt -dc "${corpus_prefix}.${TRG}.zst") |
      bicleaner-ai-classify --disable_hardrules \
        --fp16 --batch_size 512 --block_size 50000 \
-       --scol ${scol} --tcol ${tcol} "${threads}"  - - "${pack_dir}"/*.yaml \
+       --scol ${scol} --tcol ${tcol} - - "${pack_dir}"/*.yaml \
     | zstdmt >"${output_prefix}.scored.zst"
   fi
 

--- a/pipeline/bicleaner/requirements/bicleaner-ai.in
+++ b/pipeline/bicleaner/requirements/bicleaner-ai.in
@@ -1,3 +1,3 @@
-bicleaner-ai==3.6.0
+bicleaner-ai[and-cuda,transliterate]==3.6.0
 tensorflow==2.20.*
 PyICU==2.15.2

--- a/pipeline/bicleaner/requirements/bicleaner-ai.txt
+++ b/pipeline/bicleaner/requirements/bicleaner-ai.txt
@@ -15,7 +15,7 @@ astunparse==1.6.3 \
     --hash=sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872 \
     --hash=sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
     # via tensorflow
-bicleaner-ai==3.6 \
+bicleaner-ai[and-cuda,transliterate]==3.6 \
     --hash=sha256:aee587cb64105ff21d1c3eccc2289b441a31626b7173add8dd42ae06649dfd8d \
     --hash=sha256:bc136d8c72779b793790419154273b1ecb93d100f94dc336ebf20463f30b4a2e
     # via -r pipeline/bicleaner/requirements/bicleaner-ai.in
@@ -124,6 +124,9 @@ charset-normalizer==3.3.2 \
     --hash=sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519 \
     --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561
     # via requests
+cyrtranslit==1.1 \
+    --hash=sha256:8f4fa3f4e70b534640288c83917cdae1a32906a4fd054b92900cd71beead3eb0
+    # via bicleaner-ai
 exceptiongroup==1.2.1 \
     --hash=sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad \
     --hash=sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16
@@ -455,6 +458,74 @@ numpy==1.26.4 \
     #   tensorboard
     #   tensorflow
     #   transformers
+nvidia-cublas-cu12==12.9.1.4 \
+    --hash=sha256:1e5fee10662e6e52bd71dec533fbbd4971bb70a5f24f3bc3793e5c2e9dc640bf \
+    --hash=sha256:453611eb21a7c1f2c2156ed9f3a45b691deda0440ec550860290dc901af5b4c2 \
+    --hash=sha256:7a950dae01add3b415a5a5cdc4ec818fb5858263e9cca59004bb99fdbbd3a5d6
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   tensorflow
+nvidia-cuda-cupti-cu12==12.9.79 \
+    --hash=sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f \
+    --hash=sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8 \
+    --hash=sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe
+    # via tensorflow
+nvidia-cuda-nvcc-cu12==12.9.86 \
+    --hash=sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b \
+    --hash=sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0 \
+    --hash=sha256:8ed7f0b17dea662755395be029376db3b94fed5cbb17c2d35cc866c5b1b84099
+    # via tensorflow
+nvidia-cuda-nvrtc-cu12==12.9.86 \
+    --hash=sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead \
+    --hash=sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4 \
+    --hash=sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349
+    # via tensorflow
+nvidia-cuda-runtime-cu12==12.9.79 \
+    --hash=sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3 \
+    --hash=sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4 \
+    --hash=sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891
+    # via tensorflow
+nvidia-cudnn-cu12==9.19.0.56 \
+    --hash=sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e \
+    --hash=sha256:ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625 \
+    --hash=sha256:cec70596b9ce878fab83810c3f5a2e606d35f510e5fee579759e4cbc68a23750
+    # via tensorflow
+nvidia-cufft-cu12==11.4.1.4 \
+    --hash=sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf \
+    --hash=sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80 \
+    --hash=sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28
+    # via tensorflow
+nvidia-curand-cu12==10.3.10.19 \
+    --hash=sha256:49b274db4780d421bd2ccd362e1415c13887c53c214f0d4b761752b8f9f6aa1e \
+    --hash=sha256:de663377feb1697e1d30ed587b07d5721fdd6d2015c738d7528a6002a6134d37 \
+    --hash=sha256:e8129e6ac40dc123bd948e33d3e11b4aa617d87a583fa2f21b3210e90c743cde
+    # via tensorflow
+nvidia-cusolver-cu12==11.7.5.82 \
+    --hash=sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88 \
+    --hash=sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2 \
+    --hash=sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd
+    # via tensorflow
+nvidia-cusparse-cu12==12.5.10.65 \
+    --hash=sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83 \
+    --hash=sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78 \
+    --hash=sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c
+    # via
+    #   nvidia-cusolver-cu12
+    #   tensorflow
+nvidia-nccl-cu12==2.29.7 \
+    --hash=sha256:0cf032ee22b560447daf0456108a75e32bd74a4de6c6b64725637a359fa48cd8 \
+    --hash=sha256:ecd0a012051abc20c1aa87328841efa8cade3ced65803046e38c2f03c0891fea
+    # via tensorflow
+nvidia-nvjitlink-cu12==12.9.86 \
+    --hash=sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca \
+    --hash=sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db \
+    --hash=sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9
+    # via
+    #   nvidia-cufft-cu12
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+    #   tensorflow
 opt-einsum==3.3.0 \
     --hash=sha256:2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147 \
     --hash=sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549
@@ -1064,7 +1135,7 @@ tensorboard-data-server==0.7.2 \
     --hash=sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60 \
     --hash=sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530
     # via tensorboard
-tensorflow==2.20.0 \
+tensorflow[and-cuda]==2.20.0 \
     --hash=sha256:02a0293d94f5c8b7125b66abf622cc4854a33ae9d618a0d41309f95e091bbaea \
     --hash=sha256:0deb5c583dfc53b54fd158a194ce0087b406bb6518af400ca3809735e4548ec3 \
     --hash=sha256:1590cbf87b6bcbd34d8e9ad70d0c696135e0aa71be31803b27358cf7ed63f8fc \

--- a/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
@@ -107,10 +107,7 @@ tasks:
                 - >-
                     pip install -r {bicleaner_reqs} &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    export CUDA_DIR="$MOZ_FETCHES_DIR/cuda-toolkit" &&
-                    export PATH="$PATH:~/.local/bin:$CUDA_DIR/bin" &&
-                    export XLA_FLAGS="--xla_gpu_cuda_data_dir=$CUDA_DIR" &&
-                    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64:$MOZ_FETCHES_DIR/cudnn/lib" &&
+                    export PATH="$PATH:~/.local/bin" &&
                     $VCS_PATH/pipeline/bicleaner/bicleaner.sh
                     $MOZ_FETCHES_DIR/{dataset_sanitized}
                     $TASK_WORKDIR/artifacts/{dataset_sanitized}
@@ -121,10 +118,6 @@ tasks:
             "{provider}": corpus-clean-parallel-{provider}-{dataset_sanitized}-{src_locale}-{trg_locale}
             corpus-clean-parallel-fetch-bicleaner-model: corpus-clean-parallel-fetch-bicleaner-model-{src_locale}-{trg_locale}
         fetches:
-            fetch:
-                - cudnn
-            toolchain:
-                - cuda-toolkit
             "{provider}":
                 - artifact: "{dataset_sanitized}.{src_locale}.zst"
                   extract: false


### PR DESCRIPTION
Benchmarks with one GPU on a interactive task (en-bs model and en-xx-large model)
| configuration | speed (rows/s) |
| -- | -- |
| base fp32 batch32 block10k (previous config) | 273 |
| base fp32 batch128 block10k | 320 |
| base fp16 batch128 block10k | 729 |
| base fp16 batch512 block10k | 746 |
| base fp16 batch512 block50k | 768 |
| large fp32 batch32 block10k (previous config) | 126 |
| large fp16 batch512 block50k | 276 |

We can squeeze a bit more speed with bigger batches but I guess we prefer to be on the safer side regarding possible OOM issues. I tested 1024 and 2048 batch sizes and does not crash, so 512 should be pretty safe.