### PR TITLE
Use uv as installer

### DIFF
--- a/pipeline/eval/final_eval.py
+++ b/pipeline/eval/final_eval.py
@@ -4,7 +4,7 @@ Run final evaluation for exported models and compare to other translators
 To run locally:
 
 task inference-build
-pip install -r taskcluster/docker/eval/final_eval.txt
+uv pip install --system -r taskcluster/docker/eval/final_eval.txt
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 export PYTHONPATH=$(pwd)
 python pipeline/eval/final_eval.py

--- a/pipeline/eval/metrics.py
+++ b/pipeline/eval/metrics.py
@@ -102,7 +102,6 @@ class SubprocessMetric(RegularMetric):
 
     def _ensure_venv(self):
         import subprocess
-        import sys
 
         if (self._venv_path / "bin" / "python").exists():
             logging.debug(f"venv already installed in {self._venv_path}, skipping venv setup")
@@ -110,7 +109,15 @@ class SubprocessMetric(RegularMetric):
         logger.info(f"Creating venv at {self._venv_path}...")
         subprocess.run(["uv", "venv", "--system-site-packages", str(self._venv_path)], check=True)
         subprocess.run(
-            [str(self._venv_path / "bin" / "python"), "-m", "uv", "pip", "install", "-r", str(self._requirements_path)],
+            [
+                str(self._venv_path / "bin" / "python"),
+                "-m",
+                "uv",
+                "pip",
+                "install",
+                "-r",
+                str(self._requirements_path),
+            ],
             check=True,
         )
 

--- a/pipeline/eval/metrics.py
+++ b/pipeline/eval/metrics.py
@@ -108,9 +108,9 @@ class SubprocessMetric(RegularMetric):
             logging.debug(f"venv already installed in {self._venv_path}, skipping venv setup")
             return
         logger.info(f"Creating venv at {self._venv_path}...")
-        subprocess.run([sys.executable, "-m", "venv", str(self._venv_path)], check=True)
+        subprocess.run(["uv", "venv", "--system-site-packages", str(self._venv_path)], check=True)
         subprocess.run(
-            [str(self._venv_path / "bin" / "pip"), "install", "-r", str(self._requirements_path)],
+            [str(self._venv_path / "bin" / "python"), "-m", "uv", "pip", "install", "-r", str(self._requirements_path)],
             check=True,
         )
 

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update -qq \
     # Clean up the apt cache to reduce image size.
     && apt-get clean
 
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
 RUN locale-gen "$LANG"
 
 RUN pip install zstandard

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -57,9 +57,11 @@ ENV IS_DOCKER=1
 ENV SHELL=/bin/bash \
     HOME=/builds/worker \
     PATH="/builds/worker/.local/bin:$PATH" \
-    TERM=hterm-256color
+    TERM=hterm-256color \
+    UV_CACHE_DIR=/builds/worker/.task-cache/uv
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv
 
 USER root

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -43,11 +43,16 @@ RUN apt-get update -qq \
     # Clean up the apt cache to reduce image size.
     && apt-get clean
 
-COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
 
 RUN locale-gen "$LANG"
 
-RUN pip install zstandard
+# uv is installed with pip instead of the recommended copy bin
+# from the UV installation with docker page
+# because that way uv is present in the python env as a module
+# and can be run like /path/to/env/bin/python -m uv pip install ...
+RUN pip install "uv==0.10.9"
+RUN ln -s /usr/local/bin/uv /usr/local/bin/uvx /bin/
+RUN uv pip install --system zstandard
 
 # %include-run-task
 

--- a/taskcluster/docker/eval/Dockerfile
+++ b/taskcluster/docker/eval/Dockerfile
@@ -23,3 +23,4 @@ RUN pip3 install -r /tmp/final_eval.txt
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv

--- a/taskcluster/docker/inference/Dockerfile
+++ b/taskcluster/docker/inference/Dockerfile
@@ -69,5 +69,6 @@ ENV SHELL=/bin/bash \
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv
 
 USER root

--- a/taskcluster/docker/test/Dockerfile
+++ b/taskcluster/docker/test/Dockerfile
@@ -29,3 +29,4 @@ RUN curl -sSLf "https://github.com/go-task/task/releases/download/v3.35.1/task_l
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv

--- a/taskcluster/docker/test/Dockerfile
+++ b/taskcluster/docker/test/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qq \
     && apt-get clean
 
 
-RUN pip install poetry==1.8.4
+RUN uv pip install --system "poetry==1.8.4"
 # we do not run poetry install here because the tracking package is installed from code
 
 # Install taskfile - https://taskfile.dev/

--- a/taskcluster/docker/toolchain-build/Dockerfile
+++ b/taskcluster/docker/toolchain-build/Dockerfile
@@ -46,5 +46,6 @@ ENV SHELL=/bin/bash \
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv
 
 USER root

--- a/taskcluster/docker/toolchain-build/Dockerfile
+++ b/taskcluster/docker/toolchain-build/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update -qq \
 
 RUN locale-gen "$LANG"
 
-RUN pip install zstandard
+RUN uv pip install --system zstandard
 
 
 # %include-run-task

--- a/taskcluster/docker/train/Dockerfile
+++ b/taskcluster/docker/train/Dockerfile
@@ -19,3 +19,4 @@ RUN apt-get update -qq \
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.task-cache/pip
+VOLUME /builds/worker/.task-cache/uv

--- a/taskcluster/kinds/backtranslations-mono-trg-chunk/kind.yml
+++ b/taskcluster/kinds/backtranslations-mono-trg-chunk/kind.yml
@@ -71,7 +71,7 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip3 install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/backtranslations-mono-trg-chunk/kind.yml
+++ b/taskcluster/kinds/backtranslations-mono-trg-chunk/kind.yml
@@ -71,7 +71,9 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
+++ b/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
@@ -136,8 +136,7 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    pip3 install -U pip==25.0.1 &&
-                    pip3 install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
+++ b/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
@@ -123,7 +123,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -xc

--- a/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
+++ b/taskcluster/kinds/backtranslations-mono-trg-translate/kind.yml
@@ -136,7 +136,9 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
+++ b/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
@@ -116,9 +116,9 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    pip3 install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export MOZ_FETCHES_DIR=$MOZ_FETCHES_DIR &&

--- a/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
+++ b/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
@@ -111,7 +111,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -cx

--- a/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
+++ b/taskcluster/kinds/backtranslations-train-backwards-model/kind.yml
@@ -116,9 +116,11 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export MOZ_FETCHES_DIR=$MOZ_FETCHES_DIR &&

--- a/taskcluster/kinds/build-vocab/kind.yml
+++ b/taskcluster/kinds/build-vocab/kind.yml
@@ -72,7 +72,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -c

--- a/taskcluster/kinds/compile/kind.yml
+++ b/taskcluster/kinds/compile/kind.yml
@@ -74,7 +74,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -c

--- a/taskcluster/kinds/continuation-corpus/kind.yml
+++ b/taskcluster/kinds/continuation-corpus/kind.yml
@@ -68,8 +68,8 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip3 install --upgrade pip setuptools &&
-                pip3 install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                uv pip install --system --upgrade setuptools &&
+                uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/continuation/corpus.py
                 --src_url {src_url}

--- a/taskcluster/kinds/continuation-corpus/kind.yml
+++ b/taskcluster/kinds/continuation-corpus/kind.yml
@@ -68,8 +68,10 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system --upgrade setuptools &&
-                uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install --upgrade setuptools &&
+                uv pip install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/continuation/corpus.py
                 --src_url {src_url}

--- a/taskcluster/kinds/continuation-model/kind.yml
+++ b/taskcluster/kinds/continuation-model/kind.yml
@@ -62,8 +62,8 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip3 install --upgrade pip setuptools &&
-                pip3 install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                uv pip install --system --upgrade setuptools &&
+                uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/continuation/model.py
                 --src_locale {src_locale}

--- a/taskcluster/kinds/continuation-model/kind.yml
+++ b/taskcluster/kinds/continuation-model/kind.yml
@@ -62,8 +62,10 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system --upgrade setuptools &&
-                uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install --upgrade setuptools &&
+                uv pip install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/continuation/model.py
                 --src_locale {src_locale}

--- a/taskcluster/kinds/continuation-vocab/kind.yml
+++ b/taskcluster/kinds/continuation-vocab/kind.yml
@@ -60,8 +60,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/continuation/vocab.py
                     --src_url {src_url}

--- a/taskcluster/kinds/continuation-vocab/kind.yml
+++ b/taskcluster/kinds/continuation-vocab/kind.yml
@@ -60,8 +60,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/continuation/requirements/continuation.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/continuation/vocab.py
                     --src_url {src_url}

--- a/taskcluster/kinds/corpus-align-backtranslations/kind.yml
+++ b/taskcluster/kinds/corpus-align-backtranslations/kind.yml
@@ -83,8 +83,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-align-backtranslations/kind.yml
+++ b/taskcluster/kinds/corpus-align-backtranslations/kind.yml
@@ -83,8 +83,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-align-distillation/kind.yml
+++ b/taskcluster/kinds/corpus-align-distillation/kind.yml
@@ -80,8 +80,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-align-distillation/kind.yml
+++ b/taskcluster/kinds/corpus-align-distillation/kind.yml
@@ -80,8 +80,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-align-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-align-parallel/kind.yml
@@ -82,8 +82,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-align-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-align-parallel/kind.yml
@@ -82,8 +82,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/corpus-analyze-mono/kind.yml
+++ b/taskcluster/kinds/corpus-analyze-mono/kind.yml
@@ -56,8 +56,8 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip3 install --upgrade pip setuptools &&
-                pip3 install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                uv pip install --system --upgrade setuptools &&
+                uv pip install --system -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/data/analyze.py
                 --file_location $MOZ_FETCHES_DIR/{dataset_sanitized}.{locale}.zst

--- a/taskcluster/kinds/corpus-analyze-mono/kind.yml
+++ b/taskcluster/kinds/corpus-analyze-mono/kind.yml
@@ -56,8 +56,10 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system --upgrade setuptools &&
-                uv pip install --system -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install --upgrade setuptools &&
+                uv pip install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/data/analyze.py
                 --file_location $MOZ_FETCHES_DIR/{dataset_sanitized}.{locale}.zst

--- a/taskcluster/kinds/corpus-analyze-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-analyze-parallel/kind.yml
@@ -66,8 +66,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH
                     &&
                     python3 $VCS_PATH/pipeline/data/analyze.py

--- a/taskcluster/kinds/corpus-analyze-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-analyze-parallel/kind.yml
@@ -66,8 +66,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/analyze.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH
                     &&
                     python3 $VCS_PATH/pipeline/data/analyze.py

--- a/taskcluster/kinds/corpus-clean-mono/kind.yml
+++ b/taskcluster/kinds/corpus-clean-mono/kind.yml
@@ -90,10 +90,10 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip install $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
-                pip install $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
-                pip install monocleaner==1.7.0 &&
-                pip install -r $VCS_PATH/pipeline/clean/requirements/clean-mono.txt &&
+                uv pip install --system $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
+                uv pip install --system $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
+                uv pip install --system monocleaner==1.7.0 &&
+                uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/clean-mono.txt &&
                 export PATH=$PATH:~/.local/bin &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 cp $MOZ_FETCHES_DIR/*.bin $VCS_PATH/pipeline/clean/tools/ &&

--- a/taskcluster/kinds/corpus-clean-mono/kind.yml
+++ b/taskcluster/kinds/corpus-clean-mono/kind.yml
@@ -90,10 +90,12 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
-                uv pip install --system $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
-                uv pip install --system monocleaner==1.7.0 &&
-                uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/clean-mono.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install $MOZ_FETCHES_DIR/cyhunspell-2.0.3-cp310-cp310-linux_x86_64.whl &&
+                uv pip install $MOZ_FETCHES_DIR/kenlm-0.0.0-cp310-cp310-linux_x86_64.whl &&
+                uv pip install monocleaner==1.7.0 &&
+                uv pip install -r $VCS_PATH/pipeline/clean/requirements/clean-mono.txt &&
                 export PATH=$PATH:~/.local/bin &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 cp $MOZ_FETCHES_DIR/*.bin $VCS_PATH/pipeline/clean/tools/ &&

--- a/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
@@ -105,7 +105,7 @@ tasks:
                 # 4) number of threads to use - auto means nproc
                 # 5) "pack dir" - which needs to be where the `bicleaner-src-trg` fetch was unpacked to
                 - >-
-                    pip install -r {bicleaner_reqs} &&
+                    uv pip install --system -r {bicleaner_reqs} &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export PATH="$PATH:~/.local/bin" &&
                     $VCS_PATH/pipeline/bicleaner/bicleaner.sh

--- a/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
@@ -94,7 +94,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -c

--- a/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-bicleaner-ai/kind.yml
@@ -105,7 +105,9 @@ tasks:
                 # 4) number of threads to use - auto means nproc
                 # 5) "pack dir" - which needs to be where the `bicleaner-src-trg` fetch was unpacked to
                 - >-
-                    uv pip install --system -r {bicleaner_reqs} &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r {bicleaner_reqs} &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export PATH="$PATH:~/.local/bin" &&
                     $VCS_PATH/pipeline/bicleaner/bicleaner.sh

--- a/taskcluster/kinds/corpus-clean-parallel-fetch-bicleaner-model/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-fetch-bicleaner-model/kind.yml
@@ -64,7 +64,7 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip install -r $VCS_PATH/pipeline/bicleaner/requirements/bicleaner-ai.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/bicleaner/requirements/bicleaner-ai.txt &&
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/bicleaner/download_pack.py

--- a/taskcluster/kinds/corpus-clean-parallel-fetch-bicleaner-model/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel-fetch-bicleaner-model/kind.yml
@@ -64,7 +64,9 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/bicleaner/requirements/bicleaner-ai.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/bicleaner/requirements/bicleaner-ai.txt &&
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/bicleaner/download_pack.py

--- a/taskcluster/kinds/corpus-clean-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel/kind.yml
@@ -112,7 +112,7 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip install -r $VCS_PATH/pipeline/clean/requirements/clean-parallel.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/clean-parallel.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     cp $MOZ_FETCHES_DIR/*.bin /builds/worker/.local/lib/python3.10/site-packages/opuscleaner/filters/ &&
                     $VCS_PATH/pipeline/clean/opuscleaner/clean-parallel.sh

--- a/taskcluster/kinds/corpus-clean-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel/kind.yml
@@ -116,7 +116,7 @@ tasks:
                     source .venv/bin/activate &&
                     uv pip install -r $VCS_PATH/pipeline/clean/requirements/clean-parallel.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    cp $MOZ_FETCHES_DIR/*.bin /builds/worker/.local/lib/python3.10/site-packages/opuscleaner/filters/ &&
+                    cp $MOZ_FETCHES_DIR/*.bin $VIRTUAL_ENV/lib/python3.10/site-packages/opuscleaner/filters/ &&
                     $VCS_PATH/pipeline/clean/opuscleaner/clean-parallel.sh
                     $MOZ_FETCHES_DIR/{dataset_sanitized}
                     $TASK_WORKDIR/artifacts/{dataset_sanitized}

--- a/taskcluster/kinds/corpus-clean-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-clean-parallel/kind.yml
@@ -112,7 +112,9 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/clean-parallel.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/clean/requirements/clean-parallel.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     cp $MOZ_FETCHES_DIR/*.bin /builds/worker/.local/lib/python3.10/site-packages/opuscleaner/filters/ &&
                     $VCS_PATH/pipeline/clean/opuscleaner/clean-parallel.sh

--- a/taskcluster/kinds/corpus-merge-devset/kind.yml
+++ b/taskcluster/kinds/corpus-merge-devset/kind.yml
@@ -89,7 +89,7 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/clean/merge-parallel.py
                     --src           {src_locale}

--- a/taskcluster/kinds/corpus-merge-devset/kind.yml
+++ b/taskcluster/kinds/corpus-merge-devset/kind.yml
@@ -89,7 +89,9 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/clean/merge-parallel.py
                     --src           {src_locale}

--- a/taskcluster/kinds/corpus-merge-mono/kind.yml
+++ b/taskcluster/kinds/corpus-merge-mono/kind.yml
@@ -81,7 +81,7 @@ task-defaults:
             # 2) max_sentences
             # 3) datasets
             - >-
-                pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/clean/merge-mono.py
                 --parallel_corpus $MOZ_FETCHES_DIR/corpus/corpus.{locale}.zst

--- a/taskcluster/kinds/corpus-merge-mono/kind.yml
+++ b/taskcluster/kinds/corpus-merge-mono/kind.yml
@@ -81,7 +81,9 @@ task-defaults:
             # 2) max_sentences
             # 3) datasets
             - >-
-                uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/clean/merge-mono.py
                 --parallel_corpus $MOZ_FETCHES_DIR/corpus/corpus.{locale}.zst

--- a/taskcluster/kinds/corpus-merge-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-merge-parallel/kind.yml
@@ -92,7 +92,7 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/clean/merge-parallel.py
                     --src           {src_locale}

--- a/taskcluster/kinds/corpus-merge-parallel/kind.yml
+++ b/taskcluster/kinds/corpus-merge-parallel/kind.yml
@@ -92,7 +92,9 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/clean/requirements/merge.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/clean/merge-parallel.py
                     --src           {src_locale}

--- a/taskcluster/kinds/dataset/kind.yml
+++ b/taskcluster/kinds/dataset/kind.yml
@@ -71,8 +71,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -101,8 +101,8 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 -u $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -132,8 +132,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -163,8 +163,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -193,8 +193,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -231,8 +231,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -271,8 +271,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -311,8 +311,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -351,8 +351,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -395,8 +395,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -441,8 +441,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -474,8 +474,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -512,8 +512,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -552,8 +552,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}

--- a/taskcluster/kinds/dataset/kind.yml
+++ b/taskcluster/kinds/dataset/kind.yml
@@ -71,8 +71,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -101,8 +103,10 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 -u $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -132,8 +136,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -163,8 +169,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -193,8 +201,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -231,8 +241,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -271,8 +283,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -311,8 +325,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -351,8 +367,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -395,8 +413,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -441,8 +461,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -474,8 +496,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/parallel_importer.py
                     --dataset {dataset}
@@ -512,8 +536,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}
@@ -552,8 +578,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/data/requirements/data.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/data/requirements/data.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/data/mono_importer.py
                     --dataset {dataset}

--- a/taskcluster/kinds/distillation-corpus-build-shortlist/kind.yml
+++ b/taskcluster/kinds/distillation-corpus-build-shortlist/kind.yml
@@ -81,8 +81,8 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&

--- a/taskcluster/kinds/distillation-corpus-build-shortlist/kind.yml
+++ b/taskcluster/kinds/distillation-corpus-build-shortlist/kind.yml
@@ -81,8 +81,10 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/alignments/requirements/alignments.txt &&
                     export BIN=$MOZ_FETCHES_DIR &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PATH=$PATH:$MOZ_FETCHES_DIR &&

--- a/taskcluster/kinds/distillation-mono-src-chunk/kind.yml
+++ b/taskcluster/kinds/distillation-mono-src-chunk/kind.yml
@@ -71,7 +71,7 @@ task-defaults:
             - bash
             - -c
             - >-
-                pip3 install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/distillation-mono-src-chunk/kind.yml
+++ b/taskcluster/kinds/distillation-mono-src-chunk/kind.yml
@@ -71,7 +71,9 @@ task-defaults:
             - bash
             - -c
             - >-
-                uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                uv venv --system-site-packages &&
+                source .venv/bin/activate &&
+                uv pip install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 python3 $VCS_PATH/pipeline/translate/splitter.py
                 --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/distillation-mono-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-mono-src-translate/kind.yml
@@ -137,8 +137,7 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    pip3 install -U pip==25.0.1 &&
-                    pip3 install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/distillation-mono-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-mono-src-translate/kind.yml
@@ -137,7 +137,9 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/distillation-mono-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-mono-src-translate/kind.yml
@@ -126,7 +126,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -xc

--- a/taskcluster/kinds/distillation-parallel-src-chunk/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-chunk/kind.yml
@@ -71,7 +71,7 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    pip3 install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/translate/splitter.py
                     --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/distillation-parallel-src-chunk/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-chunk/kind.yml
@@ -71,7 +71,9 @@ tasks:
                 - bash
                 - -c
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/translate/requirements/splitter.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     python3 $VCS_PATH/pipeline/translate/splitter.py
                     --output_dir=$TASK_WORKDIR/artifacts

--- a/taskcluster/kinds/distillation-parallel-src-extract-best/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-extract-best/kind.yml
@@ -94,8 +94,8 @@ tasks:
                 - >-
                     zstd -d --rm $MOZ_FETCHES_DIR/*.zst &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    pip install --upgrade pip &&
-                    pip install -r $VCS_PATH/pipeline/translate/requirements/extract_best.txt &&
+                    uv pip install --system --upgrade pip &&
+                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/extract_best.txt &&
                     python3 $VCS_PATH/pipeline/translate/extract_best.py
                     --nbest "$MOZ_FETCHES_DIR/file.{this_chunk}.nbest"
                     --references "$MOZ_FETCHES_DIR/file.{this_chunk}.ref"

--- a/taskcluster/kinds/distillation-parallel-src-extract-best/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-extract-best/kind.yml
@@ -93,9 +93,9 @@ tasks:
                 - -c
                 - >-
                     zstd -d --rm $MOZ_FETCHES_DIR/*.zst &&
+                    uv venv --system-site-packages && source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/translate/requirements/extract_best.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    uv pip install --system --upgrade pip &&
-                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/extract_best.txt &&
                     python3 $VCS_PATH/pipeline/translate/extract_best.py
                     --nbest "$MOZ_FETCHES_DIR/file.{this_chunk}.nbest"
                     --references "$MOZ_FETCHES_DIR/file.{this_chunk}.ref"

--- a/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
@@ -134,8 +134,7 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    pip3 install -U pip==25.0.1 &&
-                    pip3 install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
@@ -134,7 +134,9 @@ tasks:
                 # (this is done here to avoid rebuilding worker images for what
                 # is hopefully a short term issue.)
                 - >-
-                    uv pip install --system -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/translate/requirements/translate-ctranslate2.txt &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     python3 $VCS_PATH/pipeline/translate/translate.py

--- a/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-translate/kind.yml
@@ -121,7 +121,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -xc

--- a/taskcluster/kinds/distillation-parallel-src-translations-score/kind.yml
+++ b/taskcluster/kinds/distillation-parallel-src-translations-score/kind.yml
@@ -80,7 +80,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -c

--- a/taskcluster/kinds/distillation-student-model-finetune/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-finetune/kind.yml
@@ -105,9 +105,9 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    pip3 install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/distillation-student-model-finetune/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-finetune/kind.yml
@@ -100,7 +100,7 @@ tasks:
             from-parameters: training_config.marian-args.training-student-finetuned
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -cx

--- a/taskcluster/kinds/distillation-student-model-finetune/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-finetune/kind.yml
@@ -105,9 +105,11 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/distillation-student-model-quantize/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-quantize/kind.yml
@@ -81,7 +81,7 @@ tasks:
                     export BIN=$MOZ_FETCHES_DIR &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     zstd --rm -d $MOZ_FETCHES_DIR/*.zst &&
-                    pip install -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
+                    uv pip install --system -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
                     mkdir -p scripts/alphas &&
                     $VCS_PATH/pipeline/quantize/quantize.sh
                     $MOZ_FETCHES_DIR/final.model.npz.best-{best_model}.npz

--- a/taskcluster/kinds/distillation-student-model-quantize/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-quantize/kind.yml
@@ -81,7 +81,8 @@ tasks:
                     export BIN=$MOZ_FETCHES_DIR &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     zstd --rm -d $MOZ_FETCHES_DIR/*.zst &&
-                    uv pip install --system -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
+                    uv venv --system-site-packages && source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
                     mkdir -p scripts/alphas &&
                     $VCS_PATH/pipeline/quantize/quantize.sh
                     $MOZ_FETCHES_DIR/final.model.npz.best-{best_model}.npz

--- a/taskcluster/kinds/distillation-student-model-train/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-train/kind.yml
@@ -113,9 +113,9 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    pip3 install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/distillation-student-model-train/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-train/kind.yml
@@ -108,7 +108,7 @@ tasks:
             from-parameters: training_config.marian-args.training-student
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -cx

--- a/taskcluster/kinds/distillation-student-model-train/kind.yml
+++ b/taskcluster/kinds/distillation-student-model-train/kind.yml
@@ -113,9 +113,11 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/evaluate-quantized/kind.yml
+++ b/taskcluster/kinds/evaluate-quantized/kind.yml
@@ -102,9 +102,9 @@ tasks:
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                    pip install --upgrade pip &&
-                    pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                    pip install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade pip &&
+                    uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     zstd --rm -d $MOZ_FETCHES_DIR/lex.s2t.pruned.zst &&
                     $VCS_PATH/pipeline/eval/eval.py
                     --src               {src_locale}

--- a/taskcluster/kinds/evaluate-quantized/kind.yml
+++ b/taskcluster/kinds/evaluate-quantized/kind.yml
@@ -102,9 +102,9 @@ tasks:
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                    uv pip install --system --upgrade pip &&
-                    uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages && source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     zstd --rm -d $MOZ_FETCHES_DIR/lex.s2t.pruned.zst &&
                     $VCS_PATH/pipeline/eval/eval.py
                     --src               {src_locale}

--- a/taskcluster/kinds/evaluate-quantized/kind.yml
+++ b/taskcluster/kinds/evaluate-quantized/kind.yml
@@ -94,7 +94,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             command:
                 - bash
                 - -c

--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -110,9 +110,9 @@ tasks:
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                    pip install --upgrade pip &&
-                    pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                    pip install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade pip &&
+                    uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     $VCS_PATH/pipeline/eval/eval.py

--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -96,7 +96,7 @@ tasks:
 
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             # The two sed commands here are the unfortunate result of us consuming
             # a marian config that was produced by an earlier step. These configs
             # have hardcoded absolute paths to the models they were trained on,

--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -110,9 +110,9 @@ tasks:
                     export PATH=$PATH:~/.local/bin &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                    uv pip install --system --upgrade pip &&
-                    uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages && source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     $VCS_PATH/pipeline/eval/eval.py

--- a/taskcluster/kinds/evaluate/kind.yml
+++ b/taskcluster/kinds/evaluate/kind.yml
@@ -103,9 +103,9 @@ task-defaults:
                 export PATH=$PATH:~/.local/bin &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                pip install --upgrade pip &&
-                pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                pip install $VCS_PATH/tracking &&
+                uv pip install --system --upgrade pip &&
+                uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                uv pip install --system $VCS_PATH/tracking &&
                 sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                 sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                 $VCS_PATH/pipeline/eval/eval.py

--- a/taskcluster/kinds/evaluate/kind.yml
+++ b/taskcluster/kinds/evaluate/kind.yml
@@ -89,7 +89,7 @@ task-defaults:
 
     run:
         using: run-task
-        use-caches: [checkout, pip]
+        use-caches: [checkout, uv]
         # The two sed commands here are the unfortunate result of us consuming
         # a marian config that was produced by an earlier step. These configs
         # have hardcoded absolute paths to the models they were trained on,

--- a/taskcluster/kinds/evaluate/kind.yml
+++ b/taskcluster/kinds/evaluate/kind.yml
@@ -103,9 +103,9 @@ task-defaults:
                 export PATH=$PATH:~/.local/bin &&
                 export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
-                uv pip install --system --upgrade pip &&
-                uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
-                uv pip install --system $VCS_PATH/tracking &&
+                uv venv --system-site-packages && source .venv/bin/activate &&
+                uv pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
+                uv pip install $VCS_PATH/tracking &&
                 sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                 sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                 $VCS_PATH/pipeline/eval/eval.py

--- a/taskcluster/kinds/export/kind.yml
+++ b/taskcluster/kinds/export/kind.yml
@@ -83,8 +83,8 @@ tasks:
                     export BMT_MARIAN=$MOZ_FETCHES_DIR &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    pip install --upgrade pip &&
-                    pip install -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
+                    uv pip install --system --upgrade pip &&
+                    uv pip install --system -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
                     zstd --rm -d $MOZ_FETCHES_DIR/*.zst &&
                     $VCS_PATH/pipeline/quantize/export.sh
                     $MOZ_FETCHES_DIR

--- a/taskcluster/kinds/export/kind.yml
+++ b/taskcluster/kinds/export/kind.yml
@@ -83,7 +83,7 @@ tasks:
                     export BMT_MARIAN=$MOZ_FETCHES_DIR &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    uv venv && source .venv/bin/activate &&
+                    uv venv --system-site-packages && source .venv/bin/activate &&
                     uv pip install -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
                     zstd --rm -d $MOZ_FETCHES_DIR/*.zst &&
                     $VCS_PATH/pipeline/quantize/export.sh

--- a/taskcluster/kinds/export/kind.yml
+++ b/taskcluster/kinds/export/kind.yml
@@ -83,8 +83,8 @@ tasks:
                     export BMT_MARIAN=$MOZ_FETCHES_DIR &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
-                    uv pip install --system --upgrade pip &&
-                    uv pip install --system -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
+                    uv venv && source .venv/bin/activate &&
+                    uv pip install -r $VCS_PATH/pipeline/quantize/requirements/quantize.txt &&
                     zstd --rm -d $MOZ_FETCHES_DIR/*.zst &&
                     $VCS_PATH/pipeline/quantize/export.sh
                     $MOZ_FETCHES_DIR

--- a/taskcluster/kinds/final-eval-lang/kind.yml
+++ b/taskcluster/kinds/final-eval-lang/kind.yml
@@ -82,7 +82,7 @@ tasks:
 
     run:
       using: run-task
-      use-caches: [checkout, pip]
+      use-caches: [checkout, uv]
       # We use CI config that overrides the defaults to limit the translators and metrics to a minimal set in CI
       command:
         - bash

--- a/taskcluster/kinds/final-eval/kind.yml
+++ b/taskcluster/kinds/final-eval/kind.yml
@@ -56,7 +56,7 @@ tasks:
 
     run:
       using: run-task
-      use-caches: [checkout, pip]
+      use-caches: [checkout, uv]
       command:
         - bash
         - -c

--- a/taskcluster/kinds/train-teacher-model/kind.yml
+++ b/taskcluster/kinds/train-teacher-model/kind.yml
@@ -133,9 +133,9 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    pip3 install --upgrade pip setuptools &&
-                    pip3 install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    pip3 install $VCS_PATH/tracking &&
+                    uv pip install --system --upgrade setuptools &&
+                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install --system $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/train-teacher-model/kind.yml
+++ b/taskcluster/kinds/train-teacher-model/kind.yml
@@ -133,9 +133,11 @@ tasks:
                 - bash
                 - -cx
                 - >-
-                    uv pip install --system --upgrade setuptools &&
-                    uv pip install --system -r $VCS_PATH/pipeline/train/requirements/train.txt &&
-                    uv pip install --system $VCS_PATH/tracking &&
+                    uv venv --system-site-packages &&
+                    source .venv/bin/activate &&
+                    uv pip install --upgrade setuptools &&
+                    uv pip install -r $VCS_PATH/pipeline/train/requirements/train.txt &&
+                    uv pip install $VCS_PATH/tracking &&
                     export PATH="$HOME/.local/bin:$PATH" &&
                     export MARIAN=$MOZ_FETCHES_DIR &&
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&

--- a/taskcluster/kinds/train-teacher-model/kind.yml
+++ b/taskcluster/kinds/train-teacher-model/kind.yml
@@ -127,7 +127,7 @@ tasks:
             from-parameters: training_config.marian-args.training-teacher
         run:
             using: run-task
-            use-caches: [checkout, pip]
+            use-caches: [checkout, uv]
             # order of comma separated datasets is important
             command:
                 - bash

--- a/taskcluster/kinds/update-db/kind.yml
+++ b/taskcluster/kinds/update-db/kind.yml
@@ -46,6 +46,6 @@ tasks:
         - bash
         - -c
         - >-
-          pip3 install -r $VCS_PATH/db/requirements/requirements.txt &&
+          uv pip install --system -r $VCS_PATH/db/requirements/requirements.txt &&
           export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
           python3 $VCS_PATH/db/updater.py --db-path $TASK_WORKDIR/artifacts/db.sqlite

--- a/taskcluster/kinds/update-db/kind.yml
+++ b/taskcluster/kinds/update-db/kind.yml
@@ -46,6 +46,8 @@ tasks:
         - bash
         - -c
         - >-
-          uv pip install --system -r $VCS_PATH/db/requirements/requirements.txt &&
+          uv venv --system-site-packages &&
+          source .venv/bin/activate &&
+          uv pip install -r $VCS_PATH/db/requirements/requirements.txt &&
           export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
           python3 $VCS_PATH/db/updater.py --db-path $TASK_WORKDIR/artifacts/db.sqlite

--- a/taskcluster/kinds/update-db/kind.yml
+++ b/taskcluster/kinds/update-db/kind.yml
@@ -41,7 +41,7 @@ tasks:
 
     run:
       using: run-task
-      use-caches: [checkout, pip]
+      use-caches: [checkout, uv]
       command:
         - bash
         - -c

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -261,6 +261,7 @@ class DataDir:
                     final_env = {
                         **final_env,
                         "PATH": f'{python_bin_dir}:{os.environ.get("PATH", "")}',
+                        "VIRTUAL_ENV": venv_dir,
                     }
                     if command_parts_split[0].endswith(".py"):
                         # This script is relying on a shebang, add the python3 from the executable instead.
@@ -544,9 +545,11 @@ def find_requirements(commands: Commands) -> Optional[str]:
     # Match the following:
     # pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt && ...
     #                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # or
+    # uv pip install --system -r $VCS_PATH/pipeline/eval/requirements/eval.txt && ...
     match = re.search(
         r"""
-        pip3?\ install\ -r\ \$VCS_PATH\/  # Find the pip install.
+        (uv\ )?pip3?\ install(\ --system)?\ -r\ \$VCS_PATH\/  # Find the pip install.
         (?P<requirements>                 # Capture as "requirements"
             [\w\/\-\.]+                   # Match the path
         )
@@ -696,17 +699,17 @@ def get_python_dirs(requirements: str) -> Tuple[str, str]:
             subprocess.check_call(
                 # Give the virtual environment access to the system site packages, as these
                 # are installed via docker.
-                ["python", "-m", "venv", "--system-site-packages", venv_dir],
+                ["uv", "venv", "--system-site-packages", venv_dir],
             )
 
             print("Installing setuptools", requirements)
             subprocess.check_call(
-                [python_bin, "-m", "pip", "install", "--upgrade", "setuptools", "pip"],
+                [python_bin, "-m", "uv", "pip", "install", "--upgrade", "setuptools"],
             )
 
             print("Installing", requirements)
             subprocess.check_call(
-                [python_bin, "-m", "pip", "install", "-r", requirements],
+                [python_bin, "-m", "uv", "pip", "install", "-r", requirements],
             )
         except Exception as exception:
             print("Removing the venv due to an error in its creation.")


### PR DESCRIPTION
Replacing pip by uv as installer for the tasks. These are the wall clock times for some of the tasks that i found significant gains:

| task | pip | uv |
| ------ | --- | --- |
| corpus-clean-parallel-bicleaner-ai-opus-ELRC-3075-wikipedia_health_v1-ru-en | 5m 44s | 3m 59s |
| corpus-clean-parallel-opus-ELRC-3075-wikipedia_health_v1-ru-en | 3m 42s | 2m 39s |
| corpus-clean-mono-news-crawl-en-news_2007-mono-trg | 3m 51s | 2m 30s |
| dataset-opus-ELRC-3075-wikipedia_health_v1-ru-en | 8m 9s | 4m 41s |
| evaluate-teacher-ensemble-flores-devtest-ru-en | 20m 22s | 9m 8s |
| evaluate-teacher-flores-devtest-ru-en-1 | 14m | 10m 51s |
| test-lint-black | 1m9s | 35s |
| backtranslations-train-backwards-model | 7m 36s | 6m 13s |

for the rest of the task kinds there are not much gains, but it is quite noticeable on `corpus-clean-*`, `dataset-*` and `evaluate-*` which we have many, so I guess it's worth the change. I will squash it before merging so we can easily revert it if something goes wrong.