### PR TITLE
Experiment using translations model for static embeddings

### DIFF
--- a/inference/marian-fork/src/data/sentencepiece_vocab.cpp
+++ b/inference/marian-fork/src/data/sentencepiece_vocab.cpp
@@ -134,6 +134,8 @@ public:
   virtual Word getEosId() const override { return Word::fromWordIndex(spm_->eos_id()); }
   virtual Word getUnkId() const override { return Word::fromWordIndex(spm_->unk_id()); }
 
+  virtual float getScore(Word id) const override { return spm_->GetScore(id.toWordIndex()); }
+
   void create(const std::string& vocabPath,
               const std::vector<std::string>& trainPaths,
               size_t maxSize) override {

--- a/inference/marian-fork/src/data/vocab.cpp
+++ b/inference/marian-fork/src/data/vocab.cpp
@@ -167,6 +167,9 @@ Word Vocab::getEosId() const { return vImpl_->getEosId(); }
 // return UNK symbol id
 Word Vocab::getUnkId() const { return vImpl_->getUnkId(); }
 
+// log-probability (unigram score) of a token, or 0 when the vocab has no scores
+float Vocab::getScore(Word id) const { return vImpl_->getScore(id); }
+
 // for corpus augmentation: convert string to all-caps
 std::string Vocab::toUpper(const std::string& line) const { return vImpl_->toUpper(line); }
 

--- a/inference/marian-fork/src/data/vocab.h
+++ b/inference/marian-fork/src/data/vocab.h
@@ -82,6 +82,9 @@ public:
   // return UNK symbol id
   Word getUnkId() const;
 
+  // log-probability (unigram score) of a token, or 0 when the vocab has no scores
+  float getScore(Word id) const;
+
   // for corpus augmentation: convert string to all-caps
   // @TODO: Consider a different implementation where this does not show on the vocab interface,
   //        but instead as additional options passed to vocab instantiation.

--- a/inference/marian-fork/src/data/vocab_base.h
+++ b/inference/marian-fork/src/data/vocab_base.h
@@ -63,6 +63,10 @@ public:
   virtual Word getEosId() const = 0;
   virtual Word getUnkId() const = 0;
 
+  // Log-probability (unigram score) of a token, where available (e.g. SentencePiece). Returns 0
+  // for vocabularies without per-token scores, which callers can treat as a uniform weight.
+  virtual float getScore(Word /*id*/) const { return 0.f; }
+
   // without specific knowledge of tokenization, these two functions can do nothing
   // Both SentencePieceVocab and FactoredSegmenterVocab
   virtual std::string toUpper(const std::string& line) const { return line; }

--- a/inference/src/translator/translation_model.cpp
+++ b/inference/src/translator/translation_model.cpp
@@ -1,5 +1,7 @@
 #include "translation_model.h"
 
+#include <cmath>
+
 #include "batch.h"
 #include "byte_array_util.h"
 #include "cache.h"
@@ -226,6 +228,79 @@ void TranslationModel::translateBatch(size_t deviceId, Batch &batch) {
   BeamSearch search(options_, backend.scorerEnsemble, vocabs_.target());
   Histories histories = search.search(backend.graph, convertToMarianBatch(batch));
   batch.completeBatch(histories);
+}
+
+std::vector<float> TranslationModel::embed(const std::string &text) {
+  auto &backend = backend_[0];
+
+  if (!backend.initialized) {
+    loadBackend(0);
+    backend.initialized = true;
+  }
+
+  // Tokenize using the source vocabulary. For the tied multilingual models this vocab is shared
+  // across the language pair, so both source- and target-language text map into the same space.
+  Words words = vocabs_.sources().front()->encode(text, /*addEOS=*/false, /*inference=*/true);
+  std::vector<IndexType> indices = toWordIndexVector(words);
+  if (indices.empty()) {
+    return {};
+  }
+
+  auto &graph = backend.graph;
+  graph->clear();
+
+  // Mirror marian's Embedding::applyIndices: gather the embedding rows for the token ids, then
+  // mean-pool across the tokens. The embedding parameter is named "Wemb" when embeddings are
+  // tied (the case for these models) and "encoder_Wemb" otherwise.
+  Expr wemb = graph->get("Wemb");
+  if (!wemb) {
+    wemb = graph->get("encoder_Wemb");
+  }
+  ABORT_IF(!wemb, "Could not find the word-embedding parameter (Wemb/encoder_Wemb) in the model.");
+
+  Expr embeddings = rows(wemb, indices);  // [numTokens x dimEmb]
+  graph->forward();
+
+  // Read the per-token embedding rows out of the graph (float, dequantized by `rows`).
+  std::vector<float> rowsData;
+  embeddings->val()->get(rowsData);
+  const size_t numTokens = indices.size();
+  const size_t dimEmb = rowsData.size() / numTokens;
+
+  // SIF (smooth inverse frequency) weighting: down-weight frequent subwords using the vocab's
+  // unigram log-probabilities. A token's weight is a / (a + p), where p = exp(score). When the
+  // vocabulary has no scores (getScore returns 0 -> p = 1), all weights are equal and this
+  // reduces to plain mean-pooling.
+  const float a = 1e-3f;
+  const auto &vocab = vocabs_.sources().front();
+  std::vector<float> result(dimEmb, 0.f);
+  double weightSum = 0.0;
+  for (size_t i = 0; i < numTokens; ++i) {
+    const float p = std::exp(vocab->getScore(words[i]));
+    const float weight = a / (a + p);
+    weightSum += weight;
+    for (size_t d = 0; d < dimEmb; ++d) {
+      result[d] += weight * rowsData[i * dimEmb + d];
+    }
+  }
+  if (weightSum > 0.0) {
+    for (float &value : result) {
+      value /= static_cast<float>(weightSum);
+    }
+  }
+
+  float norm = 0.f;
+  for (float value : result) {
+    norm += value * value;
+  }
+  norm = std::sqrt(norm);
+  if (norm > 0.f) {
+    for (float &value : result) {
+      value /= norm;
+    }
+  }
+
+  return result;
 }
 
 }  // namespace bergamot

--- a/inference/src/translator/translation_model.h
+++ b/inference/src/translator/translation_model.h
@@ -97,6 +97,15 @@ class TranslationModel {
   /// Returns a unique-identifier for the model.
   size_t modelId() const { return modelId_; }
 
+  /// Computes a static sentence embedding for a single piece of text by gathering the rows of
+  /// the tied word-embedding matrix (Wemb) for the text's subword tokens and mean-pooling them.
+  /// The returned vector has length dim-emb and is L2-normalized. Returns an empty vector when
+  /// the text yields no tokens.
+  ///
+  /// @param [in] text: Source text to embed. Tokenized with the source vocabulary, which for the
+  /// tied multilingual models is shared across the language pair.
+  std::vector<float> embed(const std::string& text);
+
 #if defined(WASM)
  private:
   /// The target language to be translated into.

--- a/inference/wasm/bindings/bergamot-translator.d.ts
+++ b/inference/wasm/bindings/bergamot-translator.d.ts
@@ -14,6 +14,7 @@ export namespace Bergamot {
     AlignedMemory: typeof AlignedMemory;
     VectorResponseOptions: typeof VectorResponseOptions;
     VectorString: typeof VectorString;
+    VectorFloat: typeof VectorFloat;
   }
 
   /**
@@ -29,6 +30,7 @@ export namespace Bergamot {
   export class VectorString extends Vector<string> {}
   export class VectorResponseOptions extends Vector<ResponseOptions> {}
   export class AlignedMemoryList extends Vector<AlignedMemory> {}
+  export class VectorFloat extends Vector<number> {}
 
   /**
    * A blocking (e.g. non-threaded) translation service, via Bergamot.
@@ -61,7 +63,14 @@ export namespace Bergamot {
   /**
    * The actual translation model, which is passed into the `BlockingService` methods.
    */
-  export class TranslationModel {}
+  export class TranslationModel {
+    /**
+     * Computes an L2-normalized, mean-pooled static sentence embedding for the given text by
+     * gathering rows of the tied word-embedding matrix. The returned vector has length dim-emb,
+     * or is empty when the text yields no tokens.
+     */
+    embed(text: string): VectorFloat;
+  }
 
   /**
    * The models need to be placed in the wasm memory space. This object represents

--- a/inference/wasm/bindings/service_bindings.cpp
+++ b/inference/wasm/bindings/service_bindings.cpp
@@ -81,7 +81,10 @@ std::shared_ptr<TranslationModel> TranslationModelFactory(
 
 EMSCRIPTEN_BINDINGS(translation_model) {
   class_<TranslationModel>("TranslationModel")
-      .smart_ptr_constructor("TranslationModel", &TranslationModelFactory, allow_raw_pointers());
+      .smart_ptr_constructor("TranslationModel", &TranslationModelFactory, allow_raw_pointers())
+      .function("embed", &TranslationModel::embed);
+
+  register_vector<float>("VectorFloat");
 }
 
 EMSCRIPTEN_BINDINGS(blocking_service_config) {


### PR DESCRIPTION
This is just a draft PR to show an example of the code.  No review is required at this time.

Some Claude generated notes are below.

# Generating Translations embeddings from the command line

This describes how to build the experimental "static embedding" capability of the Firefox
Translations engine and use it to embed an arbitrary text dataset (e.g. from Hugging Face) into
float32 vectors you can load in Python/NumPy.

The embedding is the translation model's tied word-embedding matrix (`Wemb`), pooled across a
sentence's SentencePiece tokens with SIF (smooth-inverse-frequency) weighting and L2-normalized.

> **How it runs.** The embedding model is an Emscripten/embind WASM module, so it cannot be
> driven directly from Python. Instead a small xpcshell harness (shipped in the Firefox patch
> stack) loads the WASM + model and writes raw float32 vectors. Python is used to (a) export the
> dataset to JSONL and (b) read the resulting `.bin` vectors. The one command that produces
> embeddings is `./mach test …` (below).

There are **two pieces**:

| Piece | Where | What it provides |
|---|---|---|
| C++ engine + WASM | `rolf-moz/translations` branch `embedding_experiment` | the `embed()` implementation + WASM build |
| Firefox wiring + CLI harness | Phabricator stack **D304488** (applies to mozilla-central) | `embed()` JS API + `test_embedding_eval.js` |

---

## 1. Build the embedding WASM (translations fork)

```bash
git clone https://github.com/rolf-moz/translations.git
cd translations
git checkout embedding_experiment

# Builds emsdk 3.1.8 + all submodules on first run, then the WASM.
#  - ALLOW_RUN_ON_HOST=1 builds on the host instead of Docker.
#  - CMAKE_POLICY_VERSION_MINIMUM=3.5 is only needed if your host CMake is >= 4
#    (an old vendored dep declares cmake_minimum_required < 3.5).
ALLOW_RUN_ON_HOST=1 CMAKE_POLICY_VERSION_MINIMUM=3.5 ./inference/scripts/build-wasm.py
```

Artifacts land in `inference/build-wasm/`:

- `bergamot-translator.wasm`  ← the engine (with `embed()` compiled in)
- `bergamot-translator.js`    ← Emscripten glue

Note the absolute path to `bergamot-translator.wasm`; you pass it to the harness below.
(For *embedding* the glue/wasm pairing is not strict — `embed()` uses no `EM_ASM`. Only translation
needs the matching glue.)

---

## 2. Get a Firefox build with the embedding harness (D304488)

In a [mozilla-central](https://firefox-source-docs.mozilla.org/setup/) checkout:

```bash
# Apply the patch stack (requires moz-phab: https://moz-conduit.readthedocs.io/en/latest/mozphab-intro.html)
moz-phab patch D304488

# Artifact build is enough — no C++/Rust compilation needed for the harness.
cat > mozconfig <<'EOF'
ac_add_options --enable-artifact-builds
EOF
./mach build
```

This packages the harness at
`toolkit/components/translations/tests/unit/test_embedding_eval.js`, which is what generates the
embeddings. (The stack also includes the in-tree glue; if you rebuilt the WASM in step 1 and want
them perfectly paired, copy `inference/build-wasm/bergamot-translator.js` over
`toolkit/components/translations/bergamot-translator/bergamot-translator.js`, re-apply
`bergamot-translator/patches/patch1.diff`, and `./mach build faster`. Not required for embedding.)

---

## 3. Get a model + vocabulary

Any tied/shared-vocab model works. The example uses **fr-en** (its native source language is
French, so it embeds French well; English is in the shared vocab too). Download from the
Translations Remote Settings CDN and decompress the zstd:

```bash
# fr-en model (v3.0) + shared SentencePiece vocab
curl -L -o model.zst "https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/translations-models-v2/3a84a714-bfc7-4e52-81a1-b08d5d9421d2.zst"
zstd -d model.zst -o model.fren.intgemm.alphas.bin

curl -L -o vocab.zst "https://firefox-settings-attachments.cdn.mozilla.net/main-workspace/translations-models-v2/671f09a0-12a2-436e-94d8-2575a4594c2a.zst"
zstd -d vocab.zst -o vocab.fren.spm
```

To find other language pairs, list the collection and filter on `sourceLanguage`/`targetLanguage`/`fileType`:

```bash
curl -s "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/translations-models-v2/records" \
 | python3 -c 'import sys,json; [print(r["fileType"], r["name"], r["attachment"]["location"]) for r in json.load(sys.stdin)["data"] if r.get("sourceLanguage")=="fr" and r.get("targetLanguage")=="en"]'
```

> The harness is wired for **fr-en** (it labels the payload `model.fren.intgemm.alphas.bin` /
> `vocab.fren.spm` and uses language pair `fr→en`). To use a different pair, change the record
> names and `sourceLanguage`/`targetLanguage` near the top of `test_embedding_eval.js`.

---

## 4. Export a Hugging Face dataset to JSONL

The harness reads two JSONL files of `{"id", "text"}` — a *docs* file and a *queries* file — and
writes a vector file for each. To embed a single dataset, put your texts in the docs file; the
queries file can be a single placeholder line (its vectors are ignored).

```python
# export_hf.py  — pip install datasets
import json
from datasets import load_dataset

ds = load_dataset("mteb/SyntecRetrieval", "corpus", split="test")  # example
TEXT_COL = "text"  # the column to embed

with open("docs.jsonl", "w") as f:
    for i, row in enumerate(ds):
        f.write(json.dumps({"id": str(row.get("_id", i)), "text": row[TEXT_COL]}) + "\n")

# Placeholder queries file (only docs vectors are needed here).
with open("queries.jsonl", "w") as f:
    f.write(json.dumps({"id": "0", "text": "placeholder"}) + "\n")

print("wrote docs.jsonl + queries.jsonl")
```

```bash
python3 export_hf.py
```

---

## 5. Generate the embeddings

From the mozilla-central checkout, point the harness at the WASM (step 1), the model/vocab
(step 3), and your JSONL (step 4):

```bash
MOZ_EMBED_WASM=/abs/path/translations/inference/build-wasm/bergamot-translator.wasm \
MOZ_EMBED_MODEL=/abs/path/model.fren.intgemm.alphas.bin \
MOZ_EMBED_VOCAB=/abs/path/vocab.fren.spm \
MOZ_EMBED_DOCS=/abs/path/docs.jsonl \
MOZ_EMBED_QUERIES=/abs/path/queries.jsonl \
MOZ_EMBED_OUT=/abs/path/vecs \
./mach test toolkit/components/translations/tests/unit/test_embedding_eval.js --headless
```

This writes:

- `vecs.docvecs.bin`  — `N_docs × dim` float32, row-major, in `docs.jsonl` order
- `vecs.qvecs.bin`    — `N_queries × dim` float32 (ignore if you used a placeholder)
- `vecs.index.json`   — `{ "dim": 384, "docIds": [...], "queryIds": [...] }`

Embedding is fast (tens of thousands of texts in seconds); the harness embeds in batches via the
engine's `embedBatch`.

---

## 6. Load the embeddings in Python

```python
import json, numpy as np

idx = json.load(open("vecs.index.json"))
dim = idx["dim"]                       # 384 for fr-en
doc_ids = idx["docIds"]               # aligns row-for-row with docs.jsonl

embeddings = np.fromfile("vecs.docvecs.bin", dtype=np.float32).reshape(-1, dim)
# Vectors are already L2-normalized, so cosine similarity == dot product:
sims = embeddings @ embeddings.T
```

That's it — `embeddings[i]` is the vector for `doc_ids[i]`.

---

## Notes / gotchas

- **Dim is model-specific.** fr-en here is `dim-emb = 384`; other pairs may differ (some use 256).
  Always read `dim` from `vecs.index.json`.
- **Never compare vectors across different models** — each model is trained from scratch, so their
  spaces are unrelated. A single tied/shared-vocab model (like fr-en) does place multiple
  languages in one comparable space.
- **Pure-Python alternative?** Not supported. The model is embind WASM; driving it outside a JS
  host (xpcshell here) would require re-implementing tokenization + the `Wemb` gather/SIF pooling
  against a raw WASM runtime.
- This is the *embedding-generation* path only. The intent-classifier / about:inference demo is a
  separate use case and not covered here.
