### PR TITLE
Add transform for Python requirements installation

### DIFF
--- a/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
+++ b/taskcluster/kinds/evaluate-teacher-ensemble/kind.yml
@@ -12,6 +12,7 @@ transforms:
     - translations_taskgraph.transforms.worker_selection
     - taskgraph.transforms.from_deps
     - taskgraph.transforms.task_context
+    - translations_taskgraph.transforms.python_requirements
     - taskgraph.transforms.run:transforms
     - translations_taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
@@ -37,6 +38,7 @@ tasks:
                 type: evaluate-teacher-ensemble
                 resources:
                     - pipeline/eval/eval.py
+        python-requirements: $VCS_PATH/pipeline/eval/requirements/eval.txt
         dataset-config:
             category: test
             substitution-fields:
@@ -111,7 +113,6 @@ tasks:
                     export PYTHONPATH=$PYTHONPATH:$VCS_PATH &&
                     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$MOZ_FETCHES_DIR/cuda-toolkit/lib64" &&
                     uv venv --system-site-packages && source .venv/bin/activate &&
-                    uv pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt &&
                     uv pip install $VCS_PATH/tracking &&
                     sed -i -e "s,- .*fetches,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&
                     sed -i -e "s,- .*artifacts,- $MOZ_FETCHES_DIR," $TASK_WORKDIR/fetches/*.yml &&

--- a/taskcluster/test/test_python_requirements.py
+++ b/taskcluster/test/test_python_requirements.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from translations_taskgraph.transforms.python_requirements import (
+    install_python_requirements,
+)
+
+
+class TestPythonRequirements(unittest.TestCase):
+    def test_installs_requirements_after_virtualenv_activation(self):
+        job = {
+            "python-requirements": [
+                "$VCS_PATH/pipeline/eval/requirements/eval.txt",
+                "$VCS_PATH/pipeline/extra/requirements/extra.txt",
+            ],
+            "run": {
+                "command": [
+                    "bash",
+                    "-c",
+                    "uv venv --system-site-packages && "
+                    "source .venv/bin/activate && python script.py",
+                ]
+            },
+        }
+
+        [transformed] = list(install_python_requirements(None, [job]))
+
+        self.assertNotIn("python-requirements", transformed)
+        self.assertEqual(
+            transformed["run"]["command"][2],
+            "uv venv --system-site-packages && source .venv/bin/activate && "
+            "uv pip install -r $VCS_PATH/pipeline/eval/requirements/eval.txt && "
+            "uv pip install -r $VCS_PATH/pipeline/extra/requirements/extra.txt && "
+            "python script.py",
+        )
+
+    def test_requires_virtualenv_activation(self):
+        job = {
+            "python-requirements": "requirements.txt",
+            "run": {"command": ["bash", "-c", "python script.py"]},
+        }
+
+        with self.assertRaisesRegex(Exception, "activate .venv"):
+            list(install_python_requirements(None, [job]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/taskcluster/translations_taskgraph/transforms/python_requirements.py
+++ b/taskcluster/translations_taskgraph/transforms/python_requirements.py
@@ -1,0 +1,59 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import Schema
+from voluptuous import ALLOW_EXTRA, Any, Optional
+
+
+SCHEMA = Schema(
+    {
+        Optional("python-requirements"): Any(str, [str]),
+    },
+    extra=ALLOW_EXTRA,
+)
+
+transforms = TransformSequence()
+transforms.add_validate(SCHEMA)
+
+
+@transforms.add
+def install_python_requirements(config, jobs):
+    for job in jobs:
+        requirements = job.pop("python-requirements", [])
+        if not requirements:
+            yield job
+            continue
+
+        if isinstance(requirements, str):
+            requirements = [requirements]
+
+        command = job.get("run", {}).get("command")
+        if not (
+            isinstance(command, list)
+            and len(command) == 3
+            and command[:2] == ["bash", "-c"]
+            and isinstance(command[2], str)
+        ):
+            raise Exception(
+                "python-requirements requires run.command to use ['bash', '-c', <script>]"
+            )
+
+        activation = "source .venv/bin/activate &&"
+        if activation not in command[2]:
+            raise Exception(
+                "python-requirements requires run.command to activate .venv first"
+            )
+
+        installs = " ".join(
+            f"uv pip install -r {requirements_file} &&"
+            for requirements_file in requirements
+        )
+        command[2] = command[2].replace(
+            activation,
+            f"{activation} {installs}",
+            1,
+        )
+
+        yield job


### PR DESCRIPTION
## Summary

- add a `python-requirements` taskgraph transform for one or more requirements files
- migrate `evaluate-teacher-ensemble` away from an inline requirements install
- validate the generated command and error when the expected virtualenv activation is missing

## Testing

- `python -m unittest taskcluster.test.test_python_requirements -v`
- `taskgraph full --json --parameters taskcluster/test/params/small-ru-en.yml` (153 tasks, 457 dependencies)
- compared the generated graph against `main`; both files have the same SHA-256 hash

Addresses #588.